### PR TITLE
LPS-145904

### DIFF
--- a/portal-impl/src/com/liferay/portal/verify/VerifyProperties.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyProperties.java
@@ -1607,6 +1607,7 @@ public class VerifyProperties extends VerifyProcess {
 		"captcha.engine.simplecaptcha.text.producers",
 		"captcha.engine.simplecaptcha.word.renderers", "cas.validate.url",
 		"cluster.executor.heartbeat.interval",
+		"cluster.link.node.bootup.response.timeout",
 		"com.liferay.filters.doubleclick.DoubleClickFilter",
 		"com.liferay.portal.servlet.filters.audit.AuditFilter",
 		"com.liferay.portal.servlet.filters.doubleclick.DoubleClickFilter",

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -6299,13 +6299,6 @@
 ##
 
     #
-    # Set the cluster node bootup response timeout in milliseconds.
-    #
-    # Env: LIFERAY_CLUSTER_PERIOD_LINK_PERIOD_NODE_PERIOD_BOOTUP_PERIOD_RESPONSE_PERIOD_TIMEOUT
-    #
-    cluster.link.node.bootup.response.timeout=10000
-
-    #
     # Set this to true to enable the cluster link. This is required if you want
     # to cluster indexing and other features that depend on the cluster link.
     #

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -480,9 +480,6 @@ public interface PropsKeys {
 
 	public static final String CLUSTER_LINK_ENABLED = "cluster.link.enabled";
 
-	public static final String CLUSTER_LINK_NODE_BOOTUP_RESPONSE_TIMEOUT =
-		"cluster.link.node.bootup.response.timeout";
-
 	public static final String CLUSTERABLE_ADVICE_CALL_MASTER_TIMEOUT =
 		"clusterable.advice.call.master.timeout";
 


### PR DESCRIPTION
Hi @tinatian, @shuyangzhou ,

I have removed unused properties "Cluster.link.node.bootup.response.timeout", and updated to propskeys.java and verifyproperties.java.

"CLUSTER_LINK_NODE_BOOTUP_RESPONSE_TIMEOUT" was added in commit 7c45ef6853a25a3b4b5658409c114c0275adfce4, see LPS-35561, and it was used in "EhcacheStreamBootstrapHelpUtil.java".

then, it was renamed to portal-impl/src/com/liferay/portal/cache/ehcache/StreamBootstrapHelpUtil.java, based on commit 738aa763e4be218d31b68355aaa67ec09405a8e7, see LPS-49136.

then, it renamed to portal-impl/src/com/liferay/portal/cache/ehcache/StreamBootstrapHelpUtil.java, based on commit 5321311fd508cee45cad6fb87368caba6cf94241, see LPS-49136.

then, it moved to portal-impl/src/com/liferay/portal/cache/bootstrap/ClusterLinkBootstrapLoaderHelperUtil.java, based on commit 23b1ccbc2c7fc69c4a336b679d7d474ff8eabb4a, see LPS-49135.

then, it was moved to rename to portal-service/src/com/liferay/portal/kernel/cache/bootstrap/ClusterLinkBootstrapLoaderHelperUtil.java, based on 9352e3923b1aff7578380a847b05734595eda040, see LPS-55479.

It was rename to modules/portal-cache/portal-cache-cluster/src/com/liferay/portal/cache/cluster/internal/bootstrap/ClusterLinkBootstrapLoaderHelperUtil.java, based on commit d89c9eb46b34ed44df301a53a1752bb703117d22, see LPS-57770.

It was finally removed based on commit c0986d124ef82aa598fb9dac6b3647ae0c51770a, see LPS-57770.
Thanks for checking.

Best,
Jeff