### PR TITLE
LPS-145571

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1211,9 +1211,6 @@ public class PropsValues {
 			PropsUtil.get(
 				PropsKeys.INDEX_SEARCH_QUERY_SUGGESTION_SCORES_THRESHOLD));
 
-	public static final boolean INDEX_WITH_THREAD = GetterUtil.getBoolean(
-		PropsUtil.get(PropsKeys.INDEX_WITH_THREAD));
-
 	public static final boolean JAVASCRIPT_BAREBONE_ENABLED =
 		GetterUtil.getBoolean(
 			PropsUtil.get(PropsKeys.JAVASCRIPT_BAREBONE_ENABLED));

--- a/portal-impl/src/com/liferay/portal/verify/VerifyProperties.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyProperties.java
@@ -1702,7 +1702,7 @@ public class VerifyProperties extends VerifyProcess {
 		"hibernate.cache.use_structured_entries", "icq.jar", "icq.login",
 		"icq.password", "index.filter.search.limit", "index.on.upgrade",
 		"index.portal.field.analyzer.enabled", "index.search.highlight.enabled",
-		"index.read.only", "intraband.impl",
+		"index.read.only", "index.with.thread", "intraband.impl",
 		"intraband.mailbox.reaper.thread.enabled",
 		"intraband.mailbox.storage.life", "intraband.proxy.dump.classes.dir",
 		"intraband.proxy.dump.classes.enabled", "intraband.timeout.default",

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -5834,14 +5834,6 @@
     index.on.startup.delay=60
 
     #
-    # Set this to true if you want the indexing on startup to be executed on a
-    # separate thread to speed up execution.
-    #
-    # Env: LIFERAY_INDEX_PERIOD_WITH_PERIOD_THREAD
-    #
-    index.with.thread=true
-
-    #
     # Set the date format used for storing dates as text in the index.
     #
     # Env: LIFERAY_INDEX_PERIOD_DATE_PERIOD_FORMAT_PERIOD_PATTERN

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1408,8 +1408,6 @@ public interface PropsKeys {
 	public static final String INDEX_SORTABLE_TEXT_FIELDS_TRUNCATED_LENGTH =
 		"index.sortable.text.fields.truncated.length";
 
-	public static final String INDEX_WITH_THREAD = "index.with.thread";
-
 	public static final String INDEXER_ENABLED = "indexer.enabled";
 
 	public static final String INVOKER_FILTER_CHAIN_ENABLED =


### PR DESCRIPTION
Hi @tinatian, @shuyangzhou ,

Resend, resolve the conflicts with Brian's master. See (https://github.com/liferay-core-infra/liferay-portal/pull/210).
I have removed unused properties "Index.with.thread", and updated to propskeys.java, propsvalues.java and verifyproperties.java.

"INDEX_WITH_THREAD" was added in commit 8f6217e, see LPS-16139, and it was used in "LuceneHelperImpl.java".
It was moved to "modules/portal/portal-search-lucene/src/com/liferay/portal/search/lucene/internal/LuceneIndexSearcher.java" in commit 60db4fa, see LPS-54860.
It was finally moved the usage in commit f125dd5, see LPS-56180.
Thanks for checking.

Best,
Jeff