### PR TITLE
LPS-147678

### DIFF
--- a/modules/apps/portal-store/portal-store-azure/bnd.bnd
+++ b/modules/apps/portal-store/portal-store-azure/bnd.bnd
@@ -116,4 +116,4 @@ Import-Package:\
 	!sun.security.x509,\
 	\
 	*
--fixupmessages: "^Classes found in the wrong directory: \\\\{META-INF/versions/9/";is:=warning
+-fixupmessages: "^Classes found in the wrong directory: *";is:=ignore

--- a/modules/apps/portal-store/portal-store-azure/bnd.bnd
+++ b/modules/apps/portal-store/portal-store-azure/bnd.bnd
@@ -2,9 +2,15 @@ Bundle-Name: Liferay Portal Store Azure
 Bundle-SymbolicName: com.liferay.portal.store.azure
 Bundle-Version: 5.0.2
 Import-Package:\
+	!com.aayushatharva.brotli4j,\
+	!com.aayushatharva.brotli4j.decoder,\
+	!com.aayushatharva.brotli4j.encoder,\
+	\
 	!com.conversantmedia.util.concurrent,\
 	\
 	!com.fasterxml.jackson.dataformat.yaml,\
+	\
+	!com.github.luben.zstd,\
 	\
 	!com.google.crypto.tink.subtle,\
 	!com.google.protobuf,\
@@ -30,6 +36,7 @@ Import-Package:\
 	!io.micrometer.core.instrument.search,\
 	\
 	!io.netty.handler.codec.haproxy,\
+	!io.netty.incubator.channel.uring,\
 	\
 	!javax.annotation.meta,\
 	\
@@ -72,6 +79,7 @@ Import-Package:\
 	!org.bouncycastle.crypto.engines,\
 	!org.bouncycastle.crypto.modes,\
 	!org.bouncycastle.crypto.params,\
+	!org.bouncycastle.jcajce.provider,\
 	!org.bouncycastle.jce.provider,\
 	!org.bouncycastle.openssl,\
 	!org.bouncycastle.openssl.jcajce,\

--- a/modules/apps/portal-store/portal-store-azure/build.gradle
+++ b/modules/apps/portal-store/portal-store-azure/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 	compileIncludePlatform group: "com.azure", name: "azure-identity"
 	compileIncludePlatform group: "com.azure", name: "azure-storage-blob"
 	compileIncludePlatform group: "com.azure", name: "azure-storage-blob-batch"
-	compileIncludePlatform platform("com.azure:azure-sdk-bom:1.0.2")
+	compileIncludePlatform platform("com.azure:azure-sdk-bom:1.2.0")
 
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"


### PR DESCRIPTION
Hi Tina, Shuyang,

This is for https://issues.liferay.com/browse/LPS-147678
I have update update com.azure:azure-sdk-bom version to 1.2.0, which will use azure-identity 1.4.6, which will include json-smart 4.5.7.
The bugs Victor found in https://github.com/liferay-core-infra/liferay-portal/pull/589 has been fixed.
Also see https://github.com/jeffwu0724/liferay-portal/pull/56, Koor has helped me to double checked the PR, and he said "The bug is no longer reproducible. I have tested on both jdk8 and jdk11 and I was not able to reproduce, following the steps victor has provided."
Thanks for checking.

Note: The error Victor mentioned in master upstream (as shown below) is not fixed yet, and I will create a new ticket and work on it later.

```
ERROR [http-nio-8080-exec-6][ImageImpl:87] Unable to read image 40441
com.liferay.document.library.kernel.exception.NoSuchFileException: {companyId=0, repositoryId=0, fileName=40441.png}
        at com.liferay.portal.store.azure.AzureStore._getFirstFileVersion(AzureStore.java:436) ~[?:?]
```