### PR TITLE
LPS-156153 Output all files with missing entries in unit test LibraryReferenceTest.testIntelliJLibPreModules

### DIFF
--- a/portal-kernel/test/unit/com/liferay/portal/library/LibraryReferenceTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/library/LibraryReferenceTest.java
@@ -103,10 +103,11 @@ public class LibraryReferenceTest {
 
 	@Test
 	public void testIntelliJLibPreModules() {
+		StringBundler sb = new StringBundler();
+
 		for (Map.Entry<String, List<String>> entry :
 				_intelliJModuleSourceModules.entrySet()) {
 
-			String intelliJFileName = entry.getKey();
 			List<String> modules = entry.getValue();
 
 			List<String> missingModules = new ArrayList<>();
@@ -123,12 +124,17 @@ public class LibraryReferenceTest {
 				}
 			}
 
-			Assert.assertTrue(
-				intelliJFileName +
-					" is missing orderEntry elements for modules " +
-						missingModules,
-				missingModules.isEmpty());
+			if (!missingModules.isEmpty()) {
+				sb.append(entry.getKey());
+				sb.append(" is missing orderEntry elements for modules: ");
+				sb.append(missingModules);
+				sb.append(StringPool.NEW_LINE);
+			}
 		}
+
+		String errorMessage = sb.toString();
+
+		Assert.assertEquals(errorMessage, StringPool.BLANK, errorMessage);
 	}
 
 	@Test


### PR DESCRIPTION
@tinatian
Hi Tina,
[LPS-156153](https://issues.liferay.com/browse/LPS-156153)

Resubmitted from https://github.com/liferay-core-infra/liferay-portal/pull/974

Issue was found in https://github.com/julschong/liferay-portal/pull/334#issuecomment-1155484998

Currently,

LibraryReferenceTest.testIntelliJLibPreModules unit test will only output the first file with missing entries encountered.

Then, it stops checking the rest.

Example output below:

> [junit] Testcase: testIntelliJLibPreModules(com.liferay.portal.library.LibraryReferenceTest): FAILED
> [junit] util-slf4j/util-slf4j.iml is missing orderEntry elements for modules [portal-log4j]
> [junit] junit.framework.AssertionFailedError: util-slf4j/util-slf4j.iml is missing orderEntry elements for modules [portal-log4j]
> [junit] at com.liferay.portal.library.LibraryReferenceTest.testIntelliJLibPreModules(LibraryReferenceTest.java:126)

However, test actually fails with multiple files with missing entries.

It would be better to finish checking all files and output all files with missing entries like below:

> [junit] Testcase: testIntelliJLibPreModules(com.liferay.portal.library.LibraryReferenceTest): FAILED
> [junit] portal-test/portal-test.iml is missing orderEntry elements for modules [portal-log4j]
> [junit] util-java/util-java.iml is missing orderEntry elements for modules [portal-log4j]
> [junit] portal-web/portal-web.iml is missing orderEntry elements for modules [portal-log4j]
> [junit] util-taglib/util-taglib.iml is missing orderEntry elements for modules [portal-log4j]
> [junit]
> [junit] junit.framework.AssertionFailedError: portal-test/portal-test.iml is missing orderEntry elements for modules [portal-log4j]
> [junit] util-java/util-java.iml is missing orderEntry elements for modules [portal-log4j]
> [junit] portal-web/portal-web.iml is missing orderEntry elements for modules [portal-log4j]
> [junit] util-taglib/util-taglib.iml is missing orderEntry elements for modules [portal-log4j]
> [junit]
> [junit] at com.liferay.portal.library.LibraryReferenceTest.testIntelliJLibPreModules(LibraryReferenceTest.java:146)

CC. @kyle-miho