### PR TITLE
LPS-149266

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/FileImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/FileImpl.java
@@ -778,6 +778,22 @@ public class FileImpl implements com.liferay.portal.kernel.util.File {
 			while ((entry = zipInputStream.getNextEntry()) != null) {
 				File destinationFile = new File(destination, entry.getName());
 
+				String destinationFileCanonicalPath =
+					destinationFile.getCanonicalPath();
+
+				if (!destinationFileCanonicalPath.startsWith(
+						destination.getCanonicalPath() + File.separator)) {
+
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							StringBundler.concat(
+								"Entry Name: ", entry.getName(),
+								" is not valid"));
+					}
+
+					continue;
+				}
+
 				if (entry.isDirectory()) {
 					destinationFile.mkdirs();
 				}


### PR DESCRIPTION
Hi Tina, Shuyang,

Fixed naming issue
Fixed some naming issues as well as changed to use only one destination dir in unit test based on discussion in https://github.com/liferay-core-infra/liferay-portal/pull/1023.
Fixed the rebase error in https://github.com/liferay-core-infra/liferay-portal/pull/920. Changed to use getCanonicalPath() instead of path.normalize() because we are getting rid of java.nio.file.Path.
After discussion, Dante helps me to modify the unit test, please see https://github.com/jeffwu0724/liferay-portal/pull/90. cc: @dantewang
This PR is to fix https://issues.liferay.com/browse/LPS-149266.
Thanks for checking.