### PR TITLE
LPS-158865

### DIFF
--- a/modules/apps/archived/web-proxy-web/bnd.bnd
+++ b/modules/apps/archived/web-proxy-web/bnd.bnd
@@ -1,4 +1,9 @@
 Bundle-Name: Liferay Web Proxy Web
 Bundle-SymbolicName: com.liferay.web.proxy.web
 Bundle-Version: 5.0.16
+Import-Package:\
+	!org.apache.commons.httpclient.*,\
+	!org.apache.http.*,\
+	\
+	*
 Web-ContextPath: /web-proxy-web


### PR DESCRIPTION
Hi Tina, Shuyang,

This is to fix the error caused by changes made in web.proxy.web in  [LPS-154824](https://github.com/liferay-core-infra/liferay-portal/pull/997/commits/bbb19fda01f389e94eb05206c6ad43d56e1fae51).

```
[exec] > Task :apps:archived:portal-security-wedeploy-auth-test:testIntegrationClasses
     [exec] 2022-07-12 08:20:24.003 ERROR [fileinstall-directory-watcher][DirectoryWatcher:1173] Unable to start bundle: file:/opt/dev/projects/github/liferay-portal/bundles/osgi/modules/com.liferay.web.proxy.web.jar
     [exec] org.osgi.framework.BundleException: Could not resolve module: com.liferay.web.proxy.web [966]
     [exec]   Unresolved requirement: Import-Package: org.apache.commons.httpclient
     [exec] 
     [exec] 	at org.eclipse.osgi.container.Module.start(Module.java:444) ~[org.eclipse.osgi.jar:?]
     [exec] 	at org.eclipse.osgi.internal.framework.EquinoxBundle.start(EquinoxBundle.java:428) ~[org.eclipse.osgi.jar:?]
     [exec] 	at com.liferay.portal.file.install.internal.DirectoryWatcher._startBundle(DirectoryWatcher.java:1156) [bundleFile:?]
     [exec] 	at com.liferay.portal.file.install.internal.DirectoryWatcher._startBundles(DirectoryWatcher.java:1189) [bundleFile:?]
     [exec] 	at com.liferay.portal.file.install.internal.DirectoryWatcher._startAllBundles(DirectoryWatcher.java:1130) [bundleFile:?]
     [exec] 	at com.liferay.portal.file.install.internal.DirectoryWatcher._process(DirectoryWatcher.java:1041) [bundleFile:?]
     [exec] 	at com.liferay.portal.file.install.internal.DirectoryWatcher.run(DirectoryWatcher.java:221) [bundleFile:?]
```
Thanks for checking!
For more info, please see https://issues.liferay.com/browse/LPS-158865.

cc:@kyle-miho