### PR TITLE
LPS-157718 add checking for driverClassName in SetupWizardUtil._testConnection

### DIFF
--- a/portal-impl/src/com/liferay/portal/setup/SetupWizardUtil.java
+++ b/portal-impl/src/com/liferay/portal/setup/SetupWizardUtil.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PropertiesParamUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.kernel.util.UnicodeProperties;
@@ -49,6 +50,7 @@ import java.sql.Connection;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -292,6 +294,11 @@ public class SetupWizardUtil {
 		throws Exception {
 
 		if (Validator.isNull(jndiName)) {
+			if (!_driverClassNameWhiteList.contains(driverClassName)) {
+				throw new Exception(
+					driverClassName + " is not a valid driver class name!");
+			}
+
 			Class.forName(driverClassName);
 		}
 
@@ -510,5 +517,18 @@ public class SetupWizardUtil {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		SetupWizardUtil.class);
+
+	private static final Set<String> _driverClassNameWhiteList =
+		SetUtil.fromArray(
+			new String[] {
+				PropsKeys.SETUP_DATABASE_DRIVER_CLASS_NAME_DB2,
+				PropsKeys.SETUP_DATABASE_DRIVER_CLASS_NAME_HYPERSONIC,
+				PropsKeys.SETUP_DATABASE_DRIVER_CLASS_NAME_MARIADB,
+				PropsKeys.SETUP_DATABASE_DRIVER_CLASS_NAME_MYSQL,
+				PropsKeys.SETUP_DATABASE_DRIVER_CLASS_NAME_ORACLE,
+				PropsKeys.SETUP_DATABASE_DRIVER_CLASS_NAME_POSTGRESQL,
+				PropsKeys.SETUP_DATABASE_DRIVER_CLASS_NAME_SQLSERVER,
+				PropsKeys.SETUP_DATABASE_DRIVER_CLASS_NAME_SYBASE
+			});
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2484,6 +2484,30 @@ public interface PropsKeys {
 	public static final String SETUP_DATABASE_DRIVER_CLASS_NAME =
 		"setup.database.driverClassName";
 
+	public static final String SETUP_DATABASE_DRIVER_CLASS_NAME_DB2 =
+		"com.ibm.db2.jcc.DB2Driver";
+
+	public static final String SETUP_DATABASE_DRIVER_CLASS_NAME_HYPERSONIC =
+		"org.hsqldb.jdbc.JDBCDriver";
+
+	public static final String SETUP_DATABASE_DRIVER_CLASS_NAME_MARIADB =
+		"org.mariadb.jdbc.Driver";
+
+	public static final String SETUP_DATABASE_DRIVER_CLASS_NAME_MYSQL =
+		"com.mysql.cj.jdbc.Driver";
+
+	public static final String SETUP_DATABASE_DRIVER_CLASS_NAME_ORACLE =
+		"oracle.jdbc.OracleDriver";
+
+	public static final String SETUP_DATABASE_DRIVER_CLASS_NAME_POSTGRESQL =
+		"org.postgresql.Driver";
+
+	public static final String SETUP_DATABASE_DRIVER_CLASS_NAME_SQLSERVER =
+		"com.microsoft.sqlserver.jdbc.SQLServerDriver";
+
+	public static final String SETUP_DATABASE_DRIVER_CLASS_NAME_SYBASE =
+		"com.sybase.jdbc4.jdbc.SybDriver";
+
 	public static final String SETUP_DATABASE_JAR_NAME =
 		"setup.database.jar.name";
 


### PR DESCRIPTION
Hi Tina, Shuyang,

After talking with Samuel, I decided to use the whitelist for checking because of safety reason.
I also use PropsKey to refer to the value in portal.properties in this fix. 
This is for ticket https://issues.liferay.com/browse/LPS-157718.
Thanks for checking.