### PR TITLE
LPS-167051 fix cannot auto generate versions.html by running "ant build-lib-versions"

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/XSLTBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/XSLTBuilder.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.xml.SecureXMLFactoryProviderUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.security.xml.SecureXMLFactoryProviderImpl;
 import com.liferay.portal.xml.SAXReaderFactory;
 
 import java.io.BufferedReader;
@@ -97,6 +98,12 @@ public class XSLTBuilder {
 					Paths.get(completeXml),
 					completeContent.getBytes(StandardCharsets.UTF_8));
 			}
+
+			SecureXMLFactoryProviderUtil secureXMLFactoryProviderUtil =
+				new SecureXMLFactoryProviderUtil();
+
+			secureXMLFactoryProviderUtil.setSecureXMLFactoryProvider(
+				new SecureXMLFactoryProviderImpl());
 
 			TransformerFactory transformerFactory =
 				SecureXMLFactoryProviderUtil.newTransformerFactory();


### PR DESCRIPTION
Hi Tina, shuyang,

This PR is to fix the bug that when we run "ant build-lib-versions", versions.html cannot be generated probably.
When we run
`TransformerFactory transformerFactory = SecureXMLFactoryProviderUtil.newTransformerFactory();`
it will throw NPE because we didn't call setSecureXMLFactoryProvider in ahead.
It is caused by https://issues.liferay.com/browse/LPS-167051
Thanks for checking!