### PR TITLE
LPS-131933 remove the use of jackson.databind 2.10.3.LIFERAY-PATCHED-1

### DIFF
--- a/modules/apps/segments/segments-web/build.gradle
+++ b/modules/apps/segments/segments-web/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
+	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.13.4.2"
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"
-	compileOnly group: "com.liferay", name: "com.fasterxml.jackson.databind", version: "2.10.3.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"


### PR DESCRIPTION
Hi Tina, Shuyang,

This is for ticket https://issues.liferay.com/browse/LPS-131933.
We are still using
`compileOnly group: "com.liferay", name: "com.fasterxml.jackson.databind", version: "2.10.3.LIFERAY-PATCHED-1"`
in our code base, even though this patch has been removed. I changed to use
`compileOnly group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.13.4.2"` instead.
Thanks for checking.