### PR TITLE
[Remove Stream/Optional usage] LPS-175324 Remove_Stream_usages_for_module_layout_item_selector_web

### DIFF
--- a/modules/apps/layout/layout-item-selector-web/src/main/java/com/liferay/layout/item/selector/web/internal/display/context/LayoutItemSelectorViewDisplayContext.java
+++ b/modules/apps/layout/layout-item-selector-web/src/main/java/com/liferay/layout/item/selector/web/internal/display/context/LayoutItemSelectorViewDisplayContext.java
@@ -33,7 +33,6 @@ import com.liferay.portal.kernel.util.WebKeys;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Stream;
 
 import javax.portlet.PortletException;
 import javax.portlet.PortletURL;
@@ -74,21 +73,21 @@ public class LayoutItemSelectorViewDisplayContext {
 		List<ItemSelectorReturnType> desiredItemSelectorReturnTypes =
 			_layoutItemSelectorCriterion.getDesiredItemSelectorReturnTypes();
 
-		Stream<ItemSelectorReturnType> desiredItemSelectorReturnTypesStream =
-			desiredItemSelectorReturnTypes.stream();
+		for (ItemSelectorReturnType itemSelectorReturnType :
+				desiredItemSelectorReturnTypes) {
 
-		_itemSelectedReturnType = desiredItemSelectorReturnTypesStream.map(
-			itemSelectorReturnType -> {
-				Class<?> clazz = itemSelectorReturnType.getClass();
+			Class<?> clazz = itemSelectorReturnType.getClass();
 
-				return clazz.getName();
+			if (_supportedItemSelectorReturnTypesClassNames.contains(
+					clazz.getName())) {
+
+				_itemSelectedReturnType = clazz.getName();
+
+				return _itemSelectedReturnType;
 			}
-		).filter(
-			_supportedItemSelectorReturnTypesClassNames::contains
-		).findFirst(
-		).orElse(
-			URLItemSelectorReturnType.class.getName()
-		);
+		}
+
+		_itemSelectedReturnType = URLItemSelectorReturnType.class.getName();
 
 		return _itemSelectedReturnType;
 	}


### PR DESCRIPTION
Hi Tina, Dante,

I tried to assign the value to _itemSelectedReturnType instead of returning the value directly is because in the very beginning, we will check if _itemSelectedReturnType is null or not. If we assign the value to _itemSelectedReturnType in advance, then we will just return it instead of going into the loop again.
This is for ticket https://issues.liferay.com/browse/LPS-175324
Thanks for checking.