### PR TITLE
[Remove Stream/Optional usage] LPS-178006 remove_stream_and_optional_in_search-experiences-web

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/configuration/admin/display/SemanticSearchConfigurationFormRenderer.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/configuration/admin/display/SemanticSearchConfigurationFormRenderer.java
@@ -44,10 +44,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
@@ -249,17 +246,17 @@ public class SemanticSearchConfigurationFormRenderer
 	}
 
 	private Map<String, String> _sortByValue(Map<String, String> map) {
-		Set<Map.Entry<String, String>> entrySet = map.entrySet();
+		Map<String, String> sortedValues = new LinkedHashMap<>();
 
-		Stream<Map.Entry<String, String>> stream = entrySet.stream();
+		for (Map.Entry<String, String> entry :
+				ListUtil.sort(
+					new ArrayList<>(map.entrySet()),
+					Map.Entry.comparingByValue())) {
 
-		return stream.sorted(
-			Map.Entry.comparingByValue()
-		).collect(
-			Collectors.toMap(
-				entry -> entry.getKey(), entry -> entry.getValue(),
-				(entry1, entry2) -> entry2, LinkedHashMap::new)
-		);
+			sortedValues.put(entry.getKey(), entry.getValue());
+		}
+
+		return sortedValues;
 	}
 
 	@Reference


### PR DESCRIPTION
Hi Tina, Dante,

Resent: https://github.com/liferay-core-infra/liferay-portal/pull/3793
This is for ticket https://issues.liferay.com/browse/LPS-178006.
There is still one optional usage in SXPBlueprintOptionsPortletPreferencesUtil, and it will be removed when the PR for portal-search-test-util is merged.
Thanks for checking!