### PR TITLE
LPS-184385 reset the default value of virtual.hosts.valid.hosts

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -9024,8 +9024,12 @@
     #
     # Env: LIFERAY_VIRTUAL_PERIOD_HOSTS_PERIOD_VALID_PERIOD_HOSTS
     #
-    virtual.hosts.valid.hosts=*
-    #virtual.hosts.valid.hosts=localhost,127.0.0.1,[::1],[0:0:0:0:0:0:0:1]
+    #virtual.hosts.valid.hosts=*
+    virtual.hosts.valid.hosts=\
+        localhost,\
+        127.0.0.1,\
+        [::1],\
+        [0:0:0:0:0:0:0:1]
 
 ##
 ## Work Directory

--- a/portal-impl/test/unit/com/liferay/portal/util/PortalImplEscapeRedirectTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/util/PortalImplEscapeRedirectTest.java
@@ -16,10 +16,12 @@ package com.liferay.portal.util;
 
 import com.liferay.portal.kernel.redirect.RedirectURLSettings;
 import com.liferay.portal.kernel.redirect.RedirectURLSettingsUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.PropsTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
@@ -32,6 +34,9 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 /**
  * @author Tomas Polesovsky
@@ -59,6 +64,14 @@ public class PortalImplEscapeRedirectTest {
 		_originalRedirectURLSettings = ReflectionTestUtil.getAndSetFieldValue(
 			RedirectURLSettingsUtil.class, "_redirectURLSettings",
 			_redirectURLSettingsImpl);
+
+		_prefsPropsUtilMockedStatic.when(
+			() -> PrefsPropsUtil.getString(
+				CompanyThreadLocal.getCompanyId(), PropsKeys.CDN_HOST_HTTPS,
+				PropsValues.CDN_HOST_HTTPS)
+		).thenReturn(
+			PropsValues.CDN_HOST_HTTPS
+		);
 	}
 
 	@After
@@ -66,6 +79,7 @@ public class PortalImplEscapeRedirectTest {
 		ReflectionTestUtil.setFieldValue(
 			RedirectURLSettingsUtil.class, "_redirectURLSettings",
 			_originalRedirectURLSettings);
+		_prefsPropsUtilMockedStatic.close();
 	}
 
 	@Test
@@ -285,6 +299,8 @@ public class PortalImplEscapeRedirectTest {
 
 	private RedirectURLSettings _originalRedirectURLSettings;
 	private final PortalImpl _portalImpl = new PortalImpl();
+	private final MockedStatic<PrefsPropsUtil> _prefsPropsUtilMockedStatic =
+		Mockito.mockStatic(PrefsPropsUtil.class);
 	private final RedirectURLSettingsImpl _redirectURLSettingsImpl =
 		new RedirectURLSettingsImpl();
 

--- a/portal-impl/test/unit/com/liferay/portal/util/PortalImplUnitTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/util/PortalImplUnitTest.java
@@ -140,38 +140,18 @@ public class PortalImplUnitTest {
 	}
 
 	@Test
-	public void testGetForwardedHostWithCustomXForwardedHostEnabled()
+	public void testGetForwardedHostWithCustomXForwardedHostEnabledAndNotValidHost()
 		throws Exception {
 
-		boolean webServerForwardedHostEnabled =
-			PropsValues.WEB_SERVER_FORWARDED_HOST_ENABLED;
-		String webServerForwardedHostHeader =
-			PropsValues.WEB_SERVER_FORWARDED_HOST_HEADER;
+		_testGetForwardedHostWithoutValidHost("X-Forwarded-Custom-Host");
+	}
 
-		try {
-			setPropsValuesValue("WEB_SERVER_FORWARDED_HOST_ENABLED", true);
-			setPropsValuesValue(
-				"WEB_SERVER_FORWARDED_HOST_HEADER", "X-Forwarded-Custom-Host");
+	@Test
+	public void testGetForwardedHostWithCustomXForwardedHostEnabledAndValidHost()
+		throws Exception {
 
-			MockHttpServletRequest mockHttpServletRequest =
-				new MockHttpServletRequest();
-
-			mockHttpServletRequest.addHeader(
-				"X-Forwarded-Custom-Host", "forwardedServer");
-			mockHttpServletRequest.setServerName("serverName");
-
-			Assert.assertEquals(
-				"forwardedServer",
-				_portalImpl.getForwardedHost(mockHttpServletRequest));
-		}
-		finally {
-			setPropsValuesValue(
-				"WEB_SERVER_FORWARDED_HOST_ENABLED",
-				webServerForwardedHostEnabled);
-			setPropsValuesValue(
-				"WEB_SERVER_FORWARDED_HOST_HEADER",
-				webServerForwardedHostHeader);
-		}
+		_testGetForwardedHostWithValidHost(
+			"X-Forwarded-Custom-Host", "forwardedServer");
 	}
 
 	@Test
@@ -203,31 +183,18 @@ public class PortalImplUnitTest {
 	}
 
 	@Test
-	public void testGetForwardedHostWithXForwardedHostEnabled()
+	public void testGetForwardedHostWithXForwardedHostEnabledAndNotValidHost()
 		throws Exception {
 
-		boolean webServerForwardedHostEnabled =
-			PropsValues.WEB_SERVER_FORWARDED_HOST_ENABLED;
+		_testGetForwardedHostWithoutValidHost("X-Forwarded-Host");
+	}
 
-		try {
-			setPropsValuesValue("WEB_SERVER_FORWARDED_HOST_ENABLED", true);
+	@Test
+	public void testGetForwardedHostWithXForwardedHostEnabledAndValidHost()
+		throws Exception {
 
-			MockHttpServletRequest mockHttpServletRequest =
-				new MockHttpServletRequest();
-
-			mockHttpServletRequest.addHeader(
-				"X-Forwarded-Host", "forwardedServer");
-			mockHttpServletRequest.setServerName("serverName");
-
-			Assert.assertEquals(
-				"forwardedServer",
-				_portalImpl.getForwardedHost(mockHttpServletRequest));
-		}
-		finally {
-			setPropsValuesValue(
-				"WEB_SERVER_FORWARDED_HOST_ENABLED",
-				webServerForwardedHostEnabled);
-		}
+		_testGetForwardedHostWithValidHost(
+			"X-Forwarded-Host", "forwardedServer");
 	}
 
 	@Test
@@ -870,6 +837,82 @@ public class PortalImplUnitTest {
 		return ActionResponseFactory.create(
 			_createActionRequest(portletMode), new DummyHttpServletResponse(),
 			new UserImpl(), new LayoutImpl());
+	}
+
+	private void _testGetForwardedHostWithoutValidHost(
+		String forwaredHostHeader) {
+
+		boolean webServerForwardedHostEnabled =
+			PropsValues.WEB_SERVER_FORWARDED_HOST_ENABLED;
+
+		String webServerForwardedHostHeader =
+			PropsValues.WEB_SERVER_FORWARDED_HOST_HEADER;
+
+		try {
+			setPropsValuesValue("WEB_SERVER_FORWARDED_HOST_ENABLED", true);
+			setPropsValuesValue(
+				"WEB_SERVER_FORWARDED_HOST_HEADER", forwaredHostHeader);
+
+			MockHttpServletRequest mockHttpServletRequest =
+				new MockHttpServletRequest();
+
+			mockHttpServletRequest.addHeader(
+				forwaredHostHeader, "forwardedServer");
+			mockHttpServletRequest.setServerName("serverName");
+		}
+		catch (Exception exception) {
+			Assert.assertTrue(exception instanceof NullPointerException);
+		}
+		finally {
+			setPropsValuesValue(
+				"WEB_SERVER_FORWARDED_HOST_ENABLED",
+				webServerForwardedHostEnabled);
+			setPropsValuesValue(
+				"WEB_SERVER_FORWARDED_HOST_HEADER",
+				webServerForwardedHostHeader);
+		}
+	}
+
+	private void _testGetForwardedHostWithValidHost(
+		String forwaredHostHeader, String forwaredServer) {
+
+		boolean webServerForwardedHostEnabled =
+			PropsValues.WEB_SERVER_FORWARDED_HOST_ENABLED;
+
+		String webServerForwardedHostHeader =
+			PropsValues.WEB_SERVER_FORWARDED_HOST_HEADER;
+
+		String[] virtualHostsValidHosts = PropsValues.VIRTUAL_HOSTS_VALID_HOSTS;
+
+		try {
+			setPropsValuesValue("WEB_SERVER_FORWARDED_HOST_ENABLED", true);
+			setPropsValuesValue(
+				"WEB_SERVER_FORWARDED_HOST_HEADER", forwaredHostHeader);
+
+			setPropsValuesValue(
+				"VIRTUAL_HOSTS_VALID_HOSTS", new String[] {forwaredServer});
+
+			MockHttpServletRequest mockHttpServletRequest =
+				new MockHttpServletRequest();
+
+			mockHttpServletRequest.addHeader(
+				forwaredHostHeader, "forwardedServer");
+			mockHttpServletRequest.setServerName("serverName");
+
+			Assert.assertEquals(
+				"forwardedServer",
+				_portalImpl.getForwardedHost(mockHttpServletRequest));
+		}
+		finally {
+			setPropsValuesValue(
+				"WEB_SERVER_FORWARDED_HOST_ENABLED",
+				webServerForwardedHostEnabled);
+			setPropsValuesValue(
+				"WEB_SERVER_FORWARDED_HOST_HEADER",
+				webServerForwardedHostHeader);
+			setPropsValuesValue(
+				"VIRTUAL_HOSTS_VALID_HOSTS", virtualHostsValidHosts);
+		}
 	}
 
 	private final PortalImpl _portalImpl = new PortalImpl();

--- a/readme/BREAKING_CHANGES.markdown
+++ b/readme/BREAKING_CHANGES.markdown
@@ -1404,3 +1404,26 @@ Remove `cacheDirCleanUpExpunge` and `cacheDirCleanUpFrequency` from `com.liferay
 ### Why was this change made?
 
 `S3FileCache` has various design flaws, and all other cloud-based store implementations in Liferay do not provide any caching mechanism.
+
+---------------------------------------
+
+## Changed default value of virtual.hosts.valid.hosts from '*' to 'localhost,127.0.0.1,[::1],[0:0:0:0:0:0:0:1]'
+
+- **Date:** 2023-June-2
+- **JIRA Ticket:** [LPS-184385](https://issues.liferay.com/browse/LPS-184385)
+
+### What changed?
+
+Default value of virtual.hosts.valid.hosts is no longer '*'
+
+### Who is affected?
+
+Anyone setting virtual.hosts.valid.hosts besides localhost, 127.0.0.1, [::1], [0:0:0:0:0:0:0:1]
+
+### How should I update my code?
+
+Upgrade the default value of virtual.hosts.valid.hosts in portal-impl/src/portal.properties to match the value being used in your current configuration
+
+### Why was this change made?
+
+This change was made to address security vulnerabilities.


### PR DESCRIPTION
Hi Tina,

Reset the default value of "virtual.hosts.valid.hosts", and fix the unit test.
Decided to use two private methods in this case, because the logic will be more complicated if we use one private method. Please see https://github.com/jeffwu0724/liferay-portal/pull/332/commits/2d04e4b2f8345b0e7e37fac2617c7c1eb387586c
Thanks for checking