### PR TITLE
[Urgent][TS] LPS-187302 Async Antivirus scheduled message data get lost due to improper enum serialization 

### DIFF
--- a/portal-impl/test/unit/com/liferay/portal/json/FooBean7.java
+++ b/portal-impl/test/unit/com/liferay/portal/json/FooBean7.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.json;
+
+/**
+ * @author Olivér Kecskeméty
+ */
+public enum FooBean7 {
+
+	TEST_1, TEST_2, TEST_3
+
+}

--- a/portal-impl/test/unit/com/liferay/portal/json/JSONFactoryTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/json/JSONFactoryTest.java
@@ -20,6 +20,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.json.jabsorb.serializer.LiferayJSONDeserializationWhitelist;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONSerializer;
+import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -28,6 +29,7 @@ import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -63,7 +65,7 @@ public class JSONFactoryTest {
 			FooBean.class.getName(), FooBean1.class.getName(),
 			FooBean2.class.getName(), FooBean3.class.getName(),
 			FooBean4.class.getName(), FooBean5.class.getName(),
-			FooBean6.class.getName());
+			FooBean6.class.getName(), FooBean7.class.getName());
 
 		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
 
@@ -246,6 +248,40 @@ public class JSONFactoryTest {
 		Assert.assertNotNull(map);
 		Assert.assertEquals(map.toString(), 1, map.size());
 		Assert.assertEquals(JSONFactoryImpl.class.getName(), map.get("class"));
+	}
+
+	@Test
+	public void testSerializeDeserializeEnum() {
+		String json = JSONFactoryUtil.serialize(
+			HashMapBuilder.put(
+				"enum", FooBean7.TEST_1
+			).build());
+
+		Object object = JSONFactoryUtil.deserialize(json);
+
+		Assert.assertTrue(object instanceof HashMap);
+
+		Assert.assertTrue(
+			((HashMap<?, ?>)object).get("enum") instanceof FooBean7);
+
+		Assert.assertSame(((HashMap<?, ?>)object).get("enum"), FooBean7.TEST_1);
+	}
+
+	@Test
+	public void testSerializeDeserializeEnumInsideMessage() {
+		Message message = new Message();
+
+		message.put("enum", FooBean7.TEST_1);
+
+		String json = JSONFactoryUtil.serialize(message);
+
+		Object object = JSONFactoryUtil.deserialize(json);
+
+		Assert.assertTrue(object instanceof Message);
+
+		Assert.assertTrue(((Message)object).get("enum") instanceof FooBean7);
+
+		Assert.assertSame(((Message)object).get("enum"), FooBean7.TEST_1);
 	}
 
 	@Test


### PR DESCRIPTION
Hi everyone,

[LPS-187302](https://issues.liferay.com/browse/LPS-187302). As [discussed on Slack](https://liferay.slack.com/archives/C01FP01V5L0/p1686226016669079) I opened a ticket for the enum serialization issue and here I provide two tests for reproduction.

As you will see `testSerializeDeserializeEnum` will throw an exception but `testSerializeDeserializeEnumInsideMessage` which is the same as the messages from `QuartzSchedulerEngine` will silently fail and on deserialization you can see that all values disappeared.

Can you please look into that? It would be urgent as it is related to an escalated bug [LPS-176414](https://issues.liferay.com/browse/LPS-176414).

Thank you!