### PR TITLE
LPS-190839 fix "kotlin.jvm.internal.Intrinsics cannot be found"

### DIFF
--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -4578,6 +4578,18 @@
 				</licenses>
 			</library>
 			<library>
+				<file-name>com.liferay.push.notifications.sender.firebase.jar!kotlin-stdlib.jar</file-name>
+				<version>1.8.0</version>
+				<project-name>Kotlin Stdlib</project-name>
+				<project-url>https://kotlinlang.org/</project-url>
+				<licenses>
+					<license>
+						<license-name>The Apache License, Version 2.0</license-name>
+						<license-url>http://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
+					</license>
+				</licenses>
+			</library>
+			<library>
 				<file-name>com.liferay.push.notifications.sender.firebase.jar!okhttp.jar</file-name>
 				<version>3.5.0</version>
 				<project-name>OkHttp</project-name>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -2384,6 +2384,12 @@
 </tr>
 			
 <tr>
+<td nowrap="nowrap">com.liferay.push.notifications.sender.firebase.jar!kotlin-stdlib.jar</td><td nowrap="nowrap">1.8.0</td><td nowrap="nowrap"><a href="https://kotlinlang.org/">Kotlin Stdlib</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache License, Version 2.0</a>
+<br>
+</td><td></td>
+</tr>
+			
+<tr>
 <td nowrap="nowrap">com.liferay.push.notifications.sender.firebase.jar!okhttp.jar</td><td nowrap="nowrap">3.5.0</td><td nowrap="nowrap">OkHttp</td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache 2.0</a>
 <br>
 </td><td></td>

--- a/modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-firebase/bnd.bnd
+++ b/modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-firebase/bnd.bnd
@@ -7,3 +7,4 @@ Import-Package:\
 	!io.reactivex.*,\
 	\
 	*
+-fixupmessages: "^Classes found in the wrong directory: \\\\{META-INF/versions/9/";is:=warning

--- a/modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-firebase/bnd.bnd
+++ b/modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-firebase/bnd.bnd
@@ -6,6 +6,4 @@ Import-Package:\
 	\
 	!io.reactivex.*,\
 	\
-	!kotlin.*,\
-	\
 	*

--- a/modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-firebase/build.gradle
+++ b/modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-firebase/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	compileInclude group: "com.liferay.mobile", name: "fcm-client", version: "0.3.0"
 	compileInclude group: "com.squareup.okhttp3", name: "okhttp", version: "3.5.0"
 	compileInclude group: "com.squareup.okio", name: "okio", version: "3.4.0"
+	compileInclude group: "org.jetbrains.kotlin", name: "kotlin-stdlib", version: "1.8.0"
 
 	compileOnly group: "com.google.code.gson", name: "gson", version: "2.9.0"
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/bnd.bnd
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/bnd.bnd
@@ -61,3 +61,4 @@ Import-Package:\
 	*
 Web-ContextPath: /document-library-opener-one-drive-web
 -dsannotations-options: inherit
+-fixupmessages: "^Classes found in the wrong directory: \\\\{META-INF/versions/9/";is:=warning

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/bnd.bnd
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/bnd.bnd
@@ -23,8 +23,6 @@ Import-Package:\
 	\
 	!junit.framework,\
 	\
-	!kotlin.*,\
-	\
 	!net.sf.saxon.*,\
 	\
 	!org.apache.batik.anim.dom.*,\

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/build.gradle
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	compileInclude group: "com.squareup.okhttp3", name: "okhttp", version: "3.12.1"
 	compileInclude group: "com.squareup.okio", name: "okio", version: "3.4.0"
 	compileInclude group: "org.apache.xmlbeans", name: "xmlbeans", version: "3.1.0"
+	compileInclude group: "org.jetbrains.kotlin", name: "kotlin-stdlib", version: "1.8.0"
 
 	compileOnly group: "com.google.code.gson", name: "gson", version: "2.9.0"
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"


### PR DESCRIPTION
Hi Tina, 

I found there is a bug in upstream (not reported yet by others yet) when we try to add a word file with one drive ,it should be caused by https://github.com/liferay-core-infra/liferay-portal/pull/5048
```
Exception in thread "liferay/background_task-5" java.lang.NoClassDefFoundError: kotlin/jvm/internal/Intrinsics 
       at okio.Buffer.write(Buffer.kt) 
       at okhttp3.ResponseBody.create(ResponseBody.java:210) 
       at okhttp3.internal.Util.<clinit>(Util.java:62) 
       at okhttp3.OkHttpClient.<clinit>(OkHttpClient.java:127) 
       at okhttp3.OkHttpClient$Builder.<init>(OkHttpClient.java:475) 
       at com.microsoft.graph.httpcore.HttpClients.custom(HttpClients.java:22) 
       at com.microsoft.graph.httpcore.HttpClients.createDefault(HttpClients.java:37) 
       at com.microsoft.graph.http.CoreHttpProvider.sendRequestInternal(CoreHttpProvider.java:245) 
       at com.microsoft.graph.http.CoreHttpProvider.send(CoreHttpProvider.java:204) 
       at com.microsoft.graph.http.CoreHttpProvider.send(CoreHttpProvider.java:184) 
       at com.microsoft.graph.http.BaseRequest.send(BaseRequest.java:306) 
       at com.microsoft.graph.http.CustomRequest.post(CustomRequest.java:106) 
       at com.liferay.document.library.opener.onedrive.web.internal.background.task.UploadOneDriveDocumentBackgroundTaskExecutor._uploadFile(UploadOneDrive
DocumentBackgroundTaskExecutor.java:227) 
       at com.liferay.document.library.opener.onedrive.web.internal.background.task.UploadOneDriveDocumentBackgroundTaskExecutor.execute(UploadOneDriveDocu
mentBackgroundTaskExecutor.java:97) 
       at com.liferay.portal.background.task.internal.SerialBackgroundTaskExecutor.execute(SerialBackgroundTaskExecutor.java:54) 
       at com.liferay.portal.kernel.backgroundtask.DelegatingBackgroundTaskExecutor.execute(DelegatingBackgroundTaskExecutor.java:32) 
       at com.liferay.portal.background.task.internal.ThreadLocalAwareBackgroundTaskExecutor.execute(ThreadLocalAwareBackgroundTaskExecutor.java:63) 
       at com.liferay.portal.background.task.internal.messaging.BackgroundTaskMessageListener.doReceive(BackgroundTaskMessageListener.java:115) 
       at com.liferay.portal.kernel.messaging.BaseMessageListener.doReceive(BaseMessageListener.java:39) 
       at com.liferay.portal.kernel.messaging.BaseMessageListener.receive(BaseMessageListener.java:25) 
       at com.liferay.portal.kernel.messaging.InvokerMessageListener.receive(InvokerMessageListener.java:65) 
       at com.liferay.portal.messaging.internal.ParallelDestination$1.run(ParallelDestination.java:47) 
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) 
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) 
       at java.lang.Thread.run(Thread.java:750) 
Caused by: java.lang.ClassNotFoundException: kotlin.jvm.internal.Intrinsics cannot be found by com.liferay.document.library.opener.onedrive.web_3.0.45 
       at org.eclipse.osgi.internal.loader.BundleLoader.findClassInternal(BundleLoader.java:518) 
       at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:429) 
       at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:421) 
       at org.eclipse.osgi.internal.loader.ModuleClassLoader.loadClass(ModuleClassLoader.java:151) 
       at java.lang.ClassLoader.loadClass(ClassLoader.java:351) 
       ... 25 more
```