### PR TITLE
LPS-188134 bump bnd version as preparation for backport 

### DIFF
--- a/modules/apps/shared-dependencies/shared-dependencies-guava/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-guava/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Shared Dependencies Guava
 Bundle-SymbolicName: com.liferay.shared.dependencies.guava
-Bundle-Version: 1.0.3
+Bundle-Version: 5.0.0
 -exportcontents: com.google.common.*


### PR DESCRIPTION
Hi Shuyang,

Based on the comment [here](https://github.com/liferay/liferay-portal-ee/pull/30765#issuecomment-1717041772), in order to backport a new module "shared-dependencies-guava", I will need to bump the version.
FYI, https://liferay.atlassian.net/wiki/spaces/QA/pages/2074607646/Backporting+new+modules
Thanks for checking. 