### PR TITLE
LPS-200603 Move GroupModelListener and RoleModelListener to modules

### DIFF
--- a/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/model/listener/GroupModelListener.java
+++ b/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/model/listener/GroupModelListener.java
@@ -3,33 +3,38 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.portlet.announcements.model;
+package com.liferay.announcements.web.internal.model.listener;
 
-import com.liferay.announcements.kernel.service.AnnouncementsEntryLocalServiceUtil;
+import com.liferay.announcements.kernel.service.AnnouncementsEntryLocalService;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
+import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Christopher Kian
  */
+@Component(service = ModelListener.class)
 public class GroupModelListener extends BaseModelListener<Group> {
 
 	@Override
 	public void onBeforeRemove(Group group) throws ModelListenerException {
 		try {
 			if (group.isSite()) {
-				AnnouncementsEntryLocalServiceUtil.deleteEntries(
+				_announcementsEntryLocalService.deleteEntries(
 					group.getClassNameId(), group.getGroupId());
 			}
 			else {
-				AnnouncementsEntryLocalServiceUtil.deleteEntries(
+				_announcementsEntryLocalService.deleteEntries(
 					group.getClassNameId(), group.getClassPK());
 
 				if (group.isOrganization()) {
-					AnnouncementsEntryLocalServiceUtil.deleteEntries(
-						ClassNameLocalServiceUtil.getClassNameId(Group.class),
+					_announcementsEntryLocalService.deleteEntries(
+						_classNameLocalService.getClassNameId(Group.class),
 						group.getGroupId());
 				}
 			}
@@ -38,5 +43,11 @@ public class GroupModelListener extends BaseModelListener<Group> {
 			throw new ModelListenerException(exception);
 		}
 	}
+
+	@Reference
+	private AnnouncementsEntryLocalService _announcementsEntryLocalService;
+
+	@Reference
+	private ClassNameLocalService _classNameLocalService;
 
 }

--- a/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/model/listener/RoleModelListener.java
+++ b/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/model/listener/RoleModelListener.java
@@ -3,27 +3,35 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.portlet.announcements.model;
+package com.liferay.announcements.web.internal.model.listener;
 
-import com.liferay.announcements.kernel.service.AnnouncementsEntryLocalServiceUtil;
+import com.liferay.announcements.kernel.service.AnnouncementsEntryLocalService;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.Role;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Christopher Kian
  */
+@Component(service = ModelListener.class)
 public class RoleModelListener extends BaseModelListener<Role> {
 
 	@Override
 	public void onBeforeRemove(Role role) throws ModelListenerException {
 		try {
-			AnnouncementsEntryLocalServiceUtil.deleteEntries(
+			_announcementsEntryLocalService.deleteEntries(
 				role.getClassNameId(), role.getRoleId());
 		}
 		catch (Exception exception) {
 			throw new ModelListenerException(exception);
 		}
 	}
+
+	@Reference
+	private AnnouncementsEntryLocalService _announcementsEntryLocalService;
 
 }

--- a/portal-impl/src/META-INF/model-listener-spring.xml
+++ b/portal-impl/src/META-INF/model-listener-spring.xml
@@ -18,6 +18,4 @@
 	<bean class="com.liferay.portal.security.permission.UserModelListener" id="com.liferay.portal.security.permission.UserModelListener" />
 	<bean class="com.liferay.portal.service.impl.LayoutSetPrototypeLayoutModelListener" id="com.liferay.portal.service.impl.LayoutSetPrototypeLayoutModelListener" />
 	<bean class="com.liferay.portal.service.impl.LayoutSetPrototypeLayoutSetModelListener" id="com.liferay.portal.service.impl.LayoutSetPrototypeLayoutSetModelListener" />
-	<bean class="com.liferay.portlet.announcements.model.GroupModelListener" id="com.liferay.portlet.announcements.model.GroupModelListener" />
-	<bean class="com.liferay.portlet.announcements.model.RoleModelListener" id="com.liferay.portlet.announcements.model.RoleModelListener" />
 </beans>


### PR DESCRIPTION
Hi Tina, Shuyang,

This ticket is for https://liferay.atlassian.net/browse/LPS-200603.
In this PR, I ove GroupModelListener and RoleModelListener to modules so that we can get rid of the spring-bean
Thanks for checking!