### PR TITLE
LPS-51404 bump bnd version as preparation for backport

### DIFF
--- a/modules/apps/cookies/cookies-impl/bnd.bnd
+++ b/modules/apps/cookies/cookies-impl/bnd.bnd
@@ -1,3 +1,3 @@
 Bundle-Name: Liferay Cookies Implementation
 Bundle-SymbolicName: com.liferay.cookies.impl
-Bundle-Version: 1.0.12
+Bundle-Version: 6.0.0


### PR DESCRIPTION
Based on the comment https://github.com/liferay/liferay-portal-ee/pull/31195#issuecomment-1837750482, 
>The modification of the [bnd.bnd](https://github.com/liferay/liferay-portal-ee/pull/31195/files#diff-1dc56bb8ba9230e66d3b17e8401650873cc2cdd6b4e92071bfeab5e014ae0900) file does not conform to the [rules](https://liferay.atlassian.net/wiki/spaces/QA/pages/2074607646/Backporting+new+modules). If a new module is added, the version numbers are in order from the low branch to the high branch such as:
7.0.x ------ 1.0.0
7.1.x ------ 2.0.0
7.2.x ------ 3.0.0
7.3.x ------ 4.0.0
master ------ 5.0.0

To backport a new module `cookies-impl`, I will need to bump the version.
FYI, https://liferay.atlassian.net/wiki/spaces/QA/pages/2074607646/Backporting+new+modules
Thanks for checking.