### PR TITLE
[Blocker]LPS-201589 add constant to allow redirecting if it is authorized

### DIFF
--- a/modules/apps/marketplace/marketplace-store-web/src/main/java/com/liferay/marketplace/store/web/internal/portlet/MarketplaceStorePortlet.java
+++ b/modules/apps/marketplace/marketplace-store-web/src/main/java/com/liferay/marketplace/store/web/internal/portlet/MarketplaceStorePortlet.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.patcher.PatcherValues;
+import com.liferay.portal.kernel.portlet.LiferayActionResponse;
 import com.liferay.portal.kernel.portlet.PortletResponseUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
@@ -134,6 +135,11 @@ public class MarketplaceStorePortlet extends MVCPortlet {
 			redirect, OAuthConstants.CALLBACK, callbackURL);
 
 		actionResponse.sendRedirect(redirect);
+
+		LiferayActionResponse liferayActionResponse =
+			(LiferayActionResponse)actionResponse;
+
+		liferayActionResponse.setAuthExternalSite(true);
 	}
 
 	public void deauthorize(

--- a/portal-impl/src/com/liferay/portlet/internal/ActionResponseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/ActionResponseImpl.java
@@ -30,6 +30,10 @@ public class ActionResponseImpl
 		return PortletRequest.ACTION_PHASE;
 	}
 
+	public boolean isAuthExternalSite() {
+		return _autoExternalSite;
+	}
+
 	@Override
 	public void sendRedirect(String location) throws IOException {
 		if ((location == null) ||
@@ -51,5 +55,11 @@ public class ActionResponseImpl
 	public void sendRedirect(String location, String renderUrlParamName)
 		throws IOException {
 	}
+
+	public void setAuthExternalSite(boolean autoExternalSite) {
+		_autoExternalSite = autoExternalSite;
+	}
+
+	private boolean _autoExternalSite = AUTH_EXTERNAL_SITE;
 
 }

--- a/portal-impl/src/com/liferay/portlet/internal/PortletContainerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/PortletContainerImpl.java
@@ -522,8 +522,12 @@ public class PortletContainerImpl implements PortletContainer {
 				liferayActionResponse.getRedirectLocation();
 
 			if (Validator.isNotNull(redirectLocation)) {
-				return new ActionResult(
-					events, PortalUtil.escapeRedirect(redirectLocation));
+				if (!liferayActionResponse.isAuthExternalSite()) {
+					redirectLocation = PortalUtil.escapeRedirect(
+						redirectLocation);
+				}
+
+				return new ActionResult(events, redirectLocation);
 			}
 
 			if (!portlet.isActionURLRedirect()) {

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/LiferayActionResponse.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/LiferayActionResponse.java
@@ -15,4 +15,11 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface LiferayActionResponse
 	extends ActionResponse, LiferayStateAwareResponse {
+
+	public static final boolean AUTH_EXTERNAL_SITE = false;
+
+	public boolean isAuthExternalSite();
+
+	public void setAuthExternalSite(boolean authExternalSite);
+
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/packageinfo
@@ -1,1 +1,1 @@
-version 28.0.0
+version 28.1.0


### PR DESCRIPTION
Hi Tina,

Resent: https://github.com/brianchandotcom/liferay-portal/pull/144902#issuecomment-1842820242
As BChan thinkS the name is not good, I rename it to "AUTH_EXTERNAL_SIZE", which means if it is authorized, then we redirecte, else if it is not authorized, then we escape. 
Thanks for checking!