### PR TITLE
[Spring Beans]LPS-200689 Move com.liferay.portal.security.* to modules to avoid using spring-beans

### DIFF
--- a/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/model/listener/GroupModelListener.java
+++ b/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/model/listener/GroupModelListener.java
@@ -3,15 +3,20 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.portal.security.permission;
+package com.liferay.portal.security.permission.internal.model.listener;
 
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.security.permission.PermissionCacheUtil;
+
+import org.osgi.service.component.annotations.Component;
 
 /**
  * @author Preston Crary
  */
+@Component(service = ModelListener.class)
 public class GroupModelListener extends BaseModelListener<Group> {
 
 	@Override

--- a/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/model/listener/ResourcePermissionModelListener.java
+++ b/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/model/listener/ResourcePermissionModelListener.java
@@ -3,15 +3,20 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.portal.security.permission;
+package com.liferay.portal.security.permission.internal.model.listener;
 
 import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.model.impl.ResourcePermissionModelImpl;
+import com.liferay.portal.security.permission.PermissionCacheUtil;
+
+import org.osgi.service.component.annotations.Component;
 
 /**
  * @author Preston Crary
  */
+@Component(service = ModelListener.class)
 public class ResourcePermissionModelListener
 	extends BaseModelListener<ResourcePermission> {
 

--- a/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/model/listener/TeamModelListener.java
+++ b/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/model/listener/TeamModelListener.java
@@ -3,15 +3,20 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.portal.security.permission;
+package com.liferay.portal.security.permission.internal.model.listener;
 
 import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.Team;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.security.permission.PermissionCacheUtil;
+
+import org.osgi.service.component.annotations.Component;
 
 /**
  * @author Preston Crary
  */
+@Component(service = ModelListener.class)
 public class TeamModelListener extends BaseModelListener<Team> {
 
 	@Override

--- a/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/model/listener/UserGroupGroupRoleModelListener.java
+++ b/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/model/listener/UserGroupGroupRoleModelListener.java
@@ -3,14 +3,19 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.portal.security.permission;
+package com.liferay.portal.security.permission.internal.model.listener;
 
 import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.UserGroupGroupRole;
+import com.liferay.portal.security.permission.PermissionCacheUtil;
+
+import org.osgi.service.component.annotations.Component;
 
 /**
  * @author Preston Crary
  */
+@Component(service = ModelListener.class)
 public class UserGroupGroupRoleModelListener
 	extends BaseModelListener<UserGroupGroupRole> {
 

--- a/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/model/listener/UserGroupRoleModelListener.java
+++ b/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/model/listener/UserGroupRoleModelListener.java
@@ -1,0 +1,61 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.permission.internal.model.listener;
+
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.model.UserGroupRole;
+import com.liferay.portal.model.impl.UserGroupRoleModelImpl;
+import com.liferay.portal.security.permission.PermissionCacheUtil;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Preston Crary
+ */
+@Component(service = ModelListener.class)
+public class UserGroupRoleModelListener
+	extends BaseModelListener<UserGroupRole> {
+
+	@Override
+	public void onAfterCreate(UserGroupRole userGroupRole) {
+		_clearCache(userGroupRole);
+	}
+
+	@Override
+	public void onAfterRemove(UserGroupRole userGroupRole) {
+		_clearCache(userGroupRole);
+	}
+
+	@Override
+	public void onAfterUpdate(
+		UserGroupRole originalUserGroupRole, UserGroupRole userGroupRole) {
+
+		_clearCache(userGroupRole);
+	}
+
+	@Override
+	public void onBeforeUpdate(
+		UserGroupRole originalUserGroupRole, UserGroupRole userGroupRole) {
+
+		UserGroupRoleModelImpl userGroupRoleModelImpl =
+			(UserGroupRoleModelImpl)userGroupRole;
+
+		long originalUserId = userGroupRoleModelImpl.getColumnOriginalValue(
+			"userId");
+
+		if (originalUserId != userGroupRoleModelImpl.getUserId()) {
+			PermissionCacheUtil.clearCache(originalUserId);
+		}
+	}
+
+	private void _clearCache(UserGroupRole userGroupRole) {
+		if (userGroupRole != null) {
+			PermissionCacheUtil.clearCache(userGroupRole.getUserId());
+		}
+	}
+
+}

--- a/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/model/listener/UserModelListener.java
+++ b/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/model/listener/UserModelListener.java
@@ -3,14 +3,19 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.portal.security.permission;
+package com.liferay.portal.security.permission.internal.model.listener;
 
 import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.security.permission.PermissionCacheUtil;
+
+import org.osgi.service.component.annotations.Component;
 
 /**
  * @author Preston Crary
  */
+@Component(service = ModelListener.class)
 public class UserModelListener extends BaseModelListener<User> {
 
 	@Override

--- a/portal-impl/src/META-INF/model-listener-spring.xml
+++ b/portal-impl/src/META-INF/model-listener-spring.xml
@@ -9,7 +9,6 @@
 >
 	<bean class="com.liferay.portal.security.permission.GroupModelListener" id="com.liferay.portal.security.permission.GroupModelListener" />
 	<bean class="com.liferay.portal.security.permission.ResourcePermissionModelListener" id="com.liferay.portal.security.permission.ResourcePermissionModelListener" />
-	<bean class="com.liferay.portal.security.permission.TeamModelListener" id="com.liferay.portal.security.permission.TeamModelListener" />
 	<bean class="com.liferay.portal.security.permission.UserGroupRoleModelListener" id="com.liferay.portal.security.permission.UserGroupRoleModelListener" />
 	<bean class="com.liferay.portal.service.impl.LayoutSetPrototypeLayoutModelListener" id="com.liferay.portal.service.impl.LayoutSetPrototypeLayoutModelListener" />
 	<bean class="com.liferay.portal.service.impl.LayoutSetPrototypeLayoutSetModelListener" id="com.liferay.portal.service.impl.LayoutSetPrototypeLayoutSetModelListener" />

--- a/portal-impl/src/META-INF/model-listener-spring.xml
+++ b/portal-impl/src/META-INF/model-listener-spring.xml
@@ -7,7 +7,6 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd"
 >
-	<bean class="com.liferay.portal.security.permission.GroupModelListener" id="com.liferay.portal.security.permission.GroupModelListener" />
 	<bean class="com.liferay.portal.security.permission.UserGroupRoleModelListener" id="com.liferay.portal.security.permission.UserGroupRoleModelListener" />
 	<bean class="com.liferay.portal.service.impl.LayoutSetPrototypeLayoutModelListener" id="com.liferay.portal.service.impl.LayoutSetPrototypeLayoutModelListener" />
 	<bean class="com.liferay.portal.service.impl.LayoutSetPrototypeLayoutSetModelListener" id="com.liferay.portal.service.impl.LayoutSetPrototypeLayoutSetModelListener" />

--- a/portal-impl/src/META-INF/model-listener-spring.xml
+++ b/portal-impl/src/META-INF/model-listener-spring.xml
@@ -10,7 +10,6 @@
 	<bean class="com.liferay.portal.security.permission.GroupModelListener" id="com.liferay.portal.security.permission.GroupModelListener" />
 	<bean class="com.liferay.portal.security.permission.ResourcePermissionModelListener" id="com.liferay.portal.security.permission.ResourcePermissionModelListener" />
 	<bean class="com.liferay.portal.security.permission.TeamModelListener" id="com.liferay.portal.security.permission.TeamModelListener" />
-	<bean class="com.liferay.portal.security.permission.UserGroupGroupRoleModelListener" id="com.liferay.portal.security.permission.UserGroupGroupRoleModelListener" />
 	<bean class="com.liferay.portal.security.permission.UserGroupRoleModelListener" id="com.liferay.portal.security.permission.UserGroupRoleModelListener" />
 	<bean class="com.liferay.portal.service.impl.LayoutSetPrototypeLayoutModelListener" id="com.liferay.portal.service.impl.LayoutSetPrototypeLayoutModelListener" />
 	<bean class="com.liferay.portal.service.impl.LayoutSetPrototypeLayoutSetModelListener" id="com.liferay.portal.service.impl.LayoutSetPrototypeLayoutSetModelListener" />

--- a/portal-impl/src/META-INF/model-listener-spring.xml
+++ b/portal-impl/src/META-INF/model-listener-spring.xml
@@ -12,7 +12,6 @@
 	<bean class="com.liferay.portal.security.permission.TeamModelListener" id="com.liferay.portal.security.permission.TeamModelListener" />
 	<bean class="com.liferay.portal.security.permission.UserGroupGroupRoleModelListener" id="com.liferay.portal.security.permission.UserGroupGroupRoleModelListener" />
 	<bean class="com.liferay.portal.security.permission.UserGroupRoleModelListener" id="com.liferay.portal.security.permission.UserGroupRoleModelListener" />
-	<bean class="com.liferay.portal.security.permission.UserModelListener" id="com.liferay.portal.security.permission.UserModelListener" />
 	<bean class="com.liferay.portal.service.impl.LayoutSetPrototypeLayoutModelListener" id="com.liferay.portal.service.impl.LayoutSetPrototypeLayoutModelListener" />
 	<bean class="com.liferay.portal.service.impl.LayoutSetPrototypeLayoutSetModelListener" id="com.liferay.portal.service.impl.LayoutSetPrototypeLayoutSetModelListener" />
 </beans>

--- a/portal-impl/src/META-INF/model-listener-spring.xml
+++ b/portal-impl/src/META-INF/model-listener-spring.xml
@@ -8,7 +8,6 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd"
 >
 	<bean class="com.liferay.portal.security.permission.GroupModelListener" id="com.liferay.portal.security.permission.GroupModelListener" />
-	<bean class="com.liferay.portal.security.permission.ResourcePermissionModelListener" id="com.liferay.portal.security.permission.ResourcePermissionModelListener" />
 	<bean class="com.liferay.portal.security.permission.UserGroupRoleModelListener" id="com.liferay.portal.security.permission.UserGroupRoleModelListener" />
 	<bean class="com.liferay.portal.service.impl.LayoutSetPrototypeLayoutModelListener" id="com.liferay.portal.service.impl.LayoutSetPrototypeLayoutModelListener" />
 	<bean class="com.liferay.portal.service.impl.LayoutSetPrototypeLayoutSetModelListener" id="com.liferay.portal.service.impl.LayoutSetPrototypeLayoutSetModelListener" />

--- a/portal-impl/src/com/liferay/portal/security/permission/UserGroupRoleModelListener.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/UserGroupRoleModelListener.java
@@ -12,7 +12,6 @@ import com.liferay.portal.kernel.model.UserGroupRole;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.SearchException;
-import com.liferay.portal.model.impl.UserGroupRoleModelImpl;
 
 /**
  * @author Preston Crary
@@ -22,13 +21,11 @@ public class UserGroupRoleModelListener
 
 	@Override
 	public void onAfterCreate(UserGroupRole userGroupRole) {
-		_clearCache(userGroupRole);
 		_reindexUser(userGroupRole.getUserId());
 	}
 
 	@Override
 	public void onAfterRemove(UserGroupRole userGroupRole) {
-		_clearCache(userGroupRole);
 		_reindexUser(userGroupRole.getUserId());
 	}
 
@@ -36,29 +33,7 @@ public class UserGroupRoleModelListener
 	public void onAfterUpdate(
 		UserGroupRole originalUserGroupRole, UserGroupRole userGroupRole) {
 
-		_clearCache(userGroupRole);
 		_reindexUser(userGroupRole.getUserId());
-	}
-
-	@Override
-	public void onBeforeUpdate(
-		UserGroupRole originalUserGroupRole, UserGroupRole userGroupRole) {
-
-		UserGroupRoleModelImpl userGroupRoleModelImpl =
-			(UserGroupRoleModelImpl)userGroupRole;
-
-		long originalUserId = userGroupRoleModelImpl.getColumnOriginalValue(
-			"userId");
-
-		if (originalUserId != userGroupRoleModelImpl.getUserId()) {
-			PermissionCacheUtil.clearCache(originalUserId);
-		}
-	}
-
-	private void _clearCache(UserGroupRole userGroupRole) {
-		if (userGroupRole != null) {
-			PermissionCacheUtil.clearCache(userGroupRole.getUserId());
-		}
 	}
 
 	private void _reindexUser(long userId) {


### PR DESCRIPTION
Hi Tina, Shuyang,

Resent https://github.com/liferay-core-infra/liferay-portal/pull/6165
As discussed, keep the reindex logic in spring bean, and only move cache clean up to permission module.
For the remaining spring bean UserGroupRoleModelListener, will take care of it later
This PR is for https://liferay.atlassian.net/browse/LPS-200689.
I am trying to remove spring-beans, and moved them to modules to use component instead
```
 <bean class="com.liferay.portal.security.permission.GroupModelListener" id="com.liferay.portal.security.permission.GroupModelListener" />
	<bean class="com.liferay.portal.security.permission.ResourcePermissionModelListener" id="com.liferay.portal.security.permission.ResourcePermissionModelListener" />
	<bean class="com.liferay.portal.security.permission.TeamModelListener" id="com.liferay.portal.security.permission.TeamModelListener" />
	<bean class="com.liferay.portal.security.permission.UserGroupGroupRoleModelListener" id="com.liferay.portal.security.permission.UserGroupGroupRoleModelListener" />
	<bean class="com.liferay.portal.security.permission.UserModelListener" id="com.liferay.portal.security.permission.UserModelListener" />
```
Thanks for checking