### PR TITLE
LPD-15422 move jsoup out of require-dependency to shared-dependnecy

### DIFF
--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -4967,6 +4967,18 @@
 				</licenses>
 			</library>
 			<library>
+				<file-name>com.liferay.shared.dependencies.jsoup.jar!jsoup.jar</file-name>
+				<version>1.15.3</version>
+				<project-name>jsoup Java HTML Parser</project-name>
+				<project-url>https://jsoup.org/</project-url>
+				<licenses>
+					<license>
+						<license-name>The MIT License</license-name>
+						<license-url>https://jsoup.org/license</license-url>
+					</license>
+				</licenses>
+			</library>
+			<library>
 				<file-name>com.liferay.shared.dependencies.minidev.jar!accessors-smart.jar</file-name>
 				<version>2.4.9</version>
 				<project-name>ASM based accessors helper used by json-smart</project-name>
@@ -7265,7 +7277,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/spring-orm.jar</file-name>
-				<version>5.2.24.LIFERAY-PATCHED-1</version>
+				<version>5.2.24.LIFERAY-PATCHED-2</version>
 				<project-name>Spring</project-name>
 				<project-url>http://www.springframework.org</project-url>
 				<licenses>
@@ -7278,7 +7290,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/spring-tx.jar</file-name>
-				<version>5.2.24</version>
+				<version>5.2.24.LIFERAY-PATCHED-1</version>
 				<project-name>Spring</project-name>
 				<project-url>http://www.springframework.org</project-url>
 				<licenses>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -2576,6 +2576,12 @@
 </tr>
 			
 <tr>
+<td nowrap="nowrap">com.liferay.shared.dependencies.jsoup.jar!jsoup.jar</td><td nowrap="nowrap">1.15.3</td><td nowrap="nowrap"><a href="https://jsoup.org/">jsoup Java HTML Parser</a></td><td nowrap><a href="https://jsoup.org/license">The MIT License</a>
+<br>
+</td><td></td>
+</tr>
+			
+<tr>
 <td nowrap="nowrap">com.liferay.shared.dependencies.minidev.jar!accessors-smart.jar</td><td nowrap="nowrap">2.4.9</td><td nowrap="nowrap"><a href="https://urielch.github.io/">ASM based accessors helper used by json-smart</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
 <br>
 </td><td></td>
@@ -3740,13 +3746,13 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">lib/portal/spring-orm.jar</td><td nowrap="nowrap">5.2.24.LIFERAY-PATCHED-1</td><td nowrap="nowrap"><a href="http://www.springframework.org">Spring</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
+<td nowrap="nowrap">lib/portal/spring-orm.jar</td><td nowrap="nowrap">5.2.24.LIFERAY-PATCHED-2</td><td nowrap="nowrap"><a href="http://www.springframework.org">Spring</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
 <br>
 </td><td>This does not include missing OSGi headers. See LPS-49575.</td>
 </tr>
 			
 <tr>
-<td nowrap="nowrap">lib/portal/spring-tx.jar</td><td nowrap="nowrap">5.2.24</td><td nowrap="nowrap"><a href="http://www.springframework.org">Spring</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
+<td nowrap="nowrap">lib/portal/spring-tx.jar</td><td nowrap="nowrap">5.2.24.LIFERAY-PATCHED-1</td><td nowrap="nowrap"><a href="http://www.springframework.org">Spring</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
 <br>
 </td><td>This does not include missing OSGi headers. See LPS-49575.</td>
 </tr>

--- a/modules/apps/shared-dependencies/shared-dependencies-jsoup/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-jsoup/bnd.bnd
@@ -1,0 +1,15 @@
+Bundle-Name: Liferay Shared Dependencies Jsoup
+Bundle-SymbolicName: com.liferay.shared.dependencies.jsoup
+Bundle-Version: 1.0.0
+Import-Package:\
+	!javax.annotation.meta,\
+	\
+	*
+-exportcontents:\
+	org.jsoup,\
+	org.jsoup.helper,\
+	org.jsoup.internal,\
+	org.jsoup.nodes,\
+	org.jsoup.parser,\
+	org.jsoup.safety,\
+	org.jsoup.select

--- a/modules/apps/shared-dependencies/shared-dependencies-jsoup/build.gradle
+++ b/modules/apps/shared-dependencies/shared-dependencies-jsoup/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	compileInclude group: "org.jsoup", name: "jsoup", version: "1.15.3"
+}

--- a/modules/apps/static/required-dependencies/required-dependencies/build.gradle
+++ b/modules/apps/static/required-dependencies/required-dependencies/build.gradle
@@ -50,7 +50,6 @@ dependencies {
 	compileOnly group: "org.jboss.classfilewriter", name: "jboss-classfilewriter", version: "1.2.3.Final"
 	compileOnly group: "org.jboss.logging", name: "jboss-logging", version: "3.3.2.Final"
 	compileOnly group: "org.jboss.weld", name: "weld-osgi-bundle", version: "3.0.5.Final"
-	compileOnly group: "org.jsoup", name: "jsoup", version: "1.15.3"
 	compileOnly group: "org.osgi", name: "org.osgi.service.cdi", version: "1.0.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.configurator", version: "1.0.0"


### PR DESCRIPTION
Hi Tina,

As discussed, I am moving jsoup out to shared-dependencies, so that we can avoid having extra jar in osgi/static.
Thanks for checking.