### PR TITLE
[Urgent][Security Bugs]LPD-1558 Add captcha to avoid insufficient CSRF protection 

### DIFF
--- a/modules/apps/captcha/captcha-api/src/main/java/com/liferay/captcha/simplecaptcha/SimpleCaptchaImpl.java
+++ b/modules/apps/captcha/captcha-api/src/main/java/com/liferay/captcha/simplecaptcha/SimpleCaptchaImpl.java
@@ -106,17 +106,15 @@ public class SimpleCaptchaImpl implements Captcha {
 					return true;
 				}
 			}
+
+			if (isExceededMaxChallenges(httpServletRequest) ||
+				(_captchaConfiguration.maxChallenges() < 0)) {
+
+				return false;
+			}
 		}
 
-		if (isExceededMaxChallenges(httpServletRequest)) {
-			return false;
-		}
-
-		if (_captchaConfiguration.maxChallenges() >= 0) {
-			return true;
-		}
-
-		return false;
+		return true;
 	}
 
 	@Override

--- a/modules/apps/captcha/captcha-api/src/main/java/com/liferay/captcha/simplecaptcha/SimpleCaptchaImpl.java
+++ b/modules/apps/captcha/captcha-api/src/main/java/com/liferay/captcha/simplecaptcha/SimpleCaptchaImpl.java
@@ -13,10 +13,13 @@ import com.liferay.portal.kernel.captcha.CaptchaTextException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Release;
+import com.liferay.portal.kernel.portlet.LiferayPortletConfig;
 import com.liferay.portal.kernel.security.RandomUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -24,6 +27,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.portlet.PortletRequest;
@@ -89,6 +94,20 @@ public class SimpleCaptchaImpl implements Captcha {
 
 	@Override
 	public boolean isEnabled(HttpServletRequest httpServletRequest) {
+		LiferayPortletConfig liferayPortletConfig =
+			(LiferayPortletConfig)httpServletRequest.getAttribute(
+				JavaConstants.JAVAX_PORTLET_CONFIG);
+
+		if (liferayPortletConfig != null) {
+			String portletName = liferayPortletConfig.getPortletName();
+
+			for (String name : _maxChallengesBlacklistedPortletNames) {
+				if (Objects.equals(name, portletName)) {
+					return true;
+				}
+			}
+		}
+
 		if (isExceededMaxChallenges(httpServletRequest)) {
 			return false;
 		}
@@ -489,6 +508,13 @@ public class SimpleCaptchaImpl implements Captcha {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		SimpleCaptchaImpl.class);
+
+	private static final Set<String> _maxChallengesBlacklistedPortletNames =
+		SetUtil.fromArray(
+			new String[] {
+				"com_liferay_server_admin_web_portlet_ServerAdminPortlet",
+				"com_liferay_gogo_shell_web_internal_portlet_GogoShellPortlet"
+			});
 
 	private BackgroundProducer[] _backgroundProducers;
 	private volatile CaptchaConfiguration _captchaConfiguration;

--- a/modules/apps/gogo-shell/gogo-shell-web/build.gradle
+++ b/modules/apps/gogo-shell/gogo-shell-web/build.gradle
@@ -6,6 +6,8 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly project(":apps:application-list:application-list-api")
+	compileOnly project(":apps:captcha:captcha-api")
+	compileOnly project(":apps:captcha:captcha-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:learn:learn-taglib")

--- a/modules/apps/gogo-shell/gogo-shell-web/src/main/java/com/liferay/gogo/shell/web/internal/portlet/GogoShellPortlet.java
+++ b/modules/apps/gogo-shell/gogo-shell-web/src/main/java/com/liferay/gogo/shell/web/internal/portlet/GogoShellPortlet.java
@@ -5,8 +5,10 @@
 
 package com.liferay.gogo.shell.web.internal.portlet;
 
+import com.liferay.captcha.util.CaptchaUtil;
 import com.liferay.gogo.shell.web.internal.constants.GogoShellPortletKeys;
 import com.liferay.gogo.shell.web.internal.constants.GogoShellWebKeys;
+import com.liferay.portal.kernel.captcha.CaptchaException;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.portal.kernel.language.Language;
@@ -151,6 +153,13 @@ public class GogoShellPortlet extends MVCPortlet {
 	public void processAction(
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws IOException, PortletException {
+
+		try {
+			CaptchaUtil.check(actionRequest);
+		}
+		catch (CaptchaException captchaException) {
+			throw new PortletException(captchaException);
+		}
 
 		_checkOmniadmin();
 

--- a/modules/apps/gogo-shell/gogo-shell-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/gogo-shell/gogo-shell-web/src/main/resources/META-INF/resources/init.jsp
@@ -10,13 +10,17 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/captcha" prefix="liferay-captcha" %><%@
 taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/learn" prefix="liferay-learn" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
-<%@ page import="com.liferay.portal.kernel.servlet.SessionMessages" %><%@
+<%@ page import="com.liferay.portal.kernel.captcha.CaptchaConfigurationException" %><%@
+page import="com.liferay.portal.kernel.captcha.CaptchaException" %><%@
+page import="com.liferay.portal.kernel.captcha.CaptchaTextException" %><%@
+page import="com.liferay.portal.kernel.servlet.SessionMessages" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %>
 

--- a/modules/apps/gogo-shell/gogo-shell-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/gogo-shell/gogo-shell-web/src/main/resources/META-INF/resources/view.jsp
@@ -11,6 +11,10 @@
 String commandOutput = (String)SessionMessages.get(renderRequest, "commandOutput");
 %>
 
+<liferay-ui:error exception="<%= CaptchaConfigurationException.class %>" message="a-captcha-error-occurred-please-contact-an-administrator" />
+<liferay-ui:error exception="<%= CaptchaException.class %>" message="captcha-verification-failed" />
+<liferay-ui:error exception="<%= CaptchaTextException.class %>" message="text-verification-failed" />
+
 <portlet:actionURL name="executeCommand" var="executeCommandURL" />
 
 <clay:container-fluid>
@@ -38,6 +42,8 @@ String commandOutput = (String)SessionMessages.get(renderRequest, "commandOutput
 				</aui:fieldset>
 			</div>
 		</div>
+
+		<liferay-captcha:captcha />
 
 		<aui:button-row>
 			<aui:button primary="<%= true %>" type="submit" value="execute" />

--- a/modules/apps/server/server-admin-web/build.gradle
+++ b/modules/apps/server/server-admin-web/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:application-list:application-list-api")
 	compileOnly project(":apps:captcha:captcha-api")
+	compileOnly project(":apps:captcha:captcha-taglib")
 	compileOnly project(":apps:configuration-admin:configuration-admin-api")
 	compileOnly project(":apps:document-library:document-library-preview-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")

--- a/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/portlet/action/EditServerMVCActionCommand.java
+++ b/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/portlet/action/EditServerMVCActionCommand.java
@@ -258,6 +258,7 @@ public class EditServerMVCActionCommand extends BaseMVCActionCommand {
 			_runScript(actionRequest, actionResponse);
 		}
 		else if (cmd.equals("shutdown")) {
+			CaptchaUtil.check(actionRequest);
 			_shutdown(actionRequest);
 		}
 		else if (cmd.equals("threadDump")) {

--- a/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/portlet/action/EditServerMVCActionCommand.java
+++ b/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/portlet/action/EditServerMVCActionCommand.java
@@ -270,6 +270,7 @@ public class EditServerMVCActionCommand extends BaseMVCActionCommand {
 			_updateLogLevels(actionRequest);
 		}
 		else if (cmd.equals("updateMail")) {
+			CaptchaUtil.check(actionRequest);
 			_updateMail(actionRequest, portletPreferences);
 		}
 		else if (cmd.equals("updatePortalProperties")) {

--- a/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/portlet/action/EditServerMVCActionCommand.java
+++ b/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/portlet/action/EditServerMVCActionCommand.java
@@ -5,6 +5,7 @@
 
 package com.liferay.server.admin.web.internal.portlet.action;
 
+import com.liferay.captcha.util.CaptchaUtil;
 import com.liferay.configuration.admin.constants.ConfigurationAdminPortletKeys;
 import com.liferay.document.library.kernel.document.conversion.DocumentConversion;
 import com.liferay.document.library.kernel.model.DLProcessorConstants;
@@ -253,6 +254,7 @@ public class EditServerMVCActionCommand extends BaseMVCActionCommand {
 			_gc();
 		}
 		else if (cmd.equals("runScript")) {
+			CaptchaUtil.check(actionRequest);
 			_runScript(actionRequest, actionResponse);
 		}
 		else if (cmd.equals("shutdown")) {

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -10,6 +10,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/captcha" prefix="liferay-captcha" %><%@
 taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
@@ -32,6 +33,9 @@ page import="com.liferay.portal.convert.documentlibrary.FileSystemStoreRootDirEx
 page import="com.liferay.portal.kernel.backgroundtask.BackgroundTask" %><%@
 page import="com.liferay.portal.kernel.backgroundtask.BackgroundTaskManagerUtil" %><%@
 page import="com.liferay.portal.kernel.backgroundtask.constants.BackgroundTaskConstants" %><%@
+page import="com.liferay.portal.kernel.captcha.CaptchaConfigurationException" %><%@
+page import="com.liferay.portal.kernel.captcha.CaptchaException" %><%@
+page import="com.liferay.portal.kernel.captcha.CaptchaTextException" %><%@
 page import="com.liferay.portal.kernel.dao.search.SearchContainer" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.model.*" %><%@

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/mail.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/mail.jsp
@@ -7,6 +7,10 @@
 
 <%@ include file="/init.jsp" %>
 
+<liferay-ui:error exception="<%= CaptchaConfigurationException.class %>" message="a-captcha-error-occurred-please-contact-an-administrator" />
+<liferay-ui:error exception="<%= CaptchaException.class %>" message="captcha-verification-failed" />
+<liferay-ui:error exception="<%= CaptchaTextException.class %>" message="text-verification-failed" />
+
 <%
 long preferencesCompanyId = CompanyConstants.SYSTEM;
 
@@ -16,6 +20,8 @@ Function<String, String> defaultValueFunction = key -> PropsUtil.get(key);
 <div class="sheet">
 	<div class="panel-group panel-group-flush">
 		<%@ include file="/mail_fields.jspf" %>
+
+		<liferay-captcha:captcha />
 
 		<aui:button-row>
 			<aui:button cssClass="save-server-button" data-cmd="updateMail" primary="<%= true %>" value="save" />

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/script.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/script.jsp
@@ -29,6 +29,10 @@ if (SessionMessages.contains(renderRequest, "script")) {
 String scriptOutput = (String)SessionMessages.get(renderRequest, "scriptOutput");
 %>
 
+<liferay-ui:error exception="<%= CaptchaConfigurationException.class %>" message="a-captcha-error-occurred-please-contact-an-administrator" />
+<liferay-ui:error exception="<%= CaptchaException.class %>" message="captcha-verification-failed" />
+<liferay-ui:error exception="<%= CaptchaTextException.class %>" message="text-verification-failed" />
+
 <liferay-ui:error exception="<%= ScriptingException.class %>">
 
 	<%
@@ -60,6 +64,8 @@ String scriptOutput = (String)SessionMessages.get(renderRequest, "scriptOutput")
 		</aui:select>
 
 		<aui:input cssClass="lfr-textarea-container" name="script" resizable="<%= true %>" type="textarea" value="<%= script %>" />
+
+		<liferay-captcha:captcha />
 
 		<aui:button-row>
 			<aui:button cssClass="save-server-button" data-cmd="runScript" primary="<%= true %>" value="execute" />

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/shutdown.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/shutdown.jsp
@@ -7,6 +7,10 @@
 
 <%@ include file="/init.jsp" %>
 
+<liferay-ui:error exception="<%= CaptchaConfigurationException.class %>" message="a-captcha-error-occurred-please-contact-an-administrator" />
+<liferay-ui:error exception="<%= CaptchaException.class %>" message="captcha-verification-failed" />
+<liferay-ui:error exception="<%= CaptchaTextException.class %>" message="text-verification-failed" />
+
 <liferay-ui:error key="shutdownMinutes" message="please-enter-the-number-of-minutes" />
 
 <c:choose>
@@ -22,6 +26,8 @@
 				</aui:input>
 
 				<aui:input cssClass="lfr-textarea-container" label="custom-message" name="message" type="textarea" />
+
+				<liferay-captcha:captcha />
 
 				<aui:button cssClass="save-server-button" data-cmd="shutdown" primary="<%= true %>" value="shutdown" />
 			</div>


### PR DESCRIPTION
Hi Tina,

This PR is for ticket https://liferay.atlassian.net/browse/LPD-1558.
Based on the discussion with AppSec and Security team, their expected solution for core team will be in:

- Server Administration: Script, Mail, Shutdown
- Gogo Shell

We should [enable captcha in these portlets every time](https://liferay.atlassian.net/browse/LPD-1558?focusedCommentId=2612377), and [hardcode a blacklist](https://liferay.atlassian.net/browse/LPD-1558?focusedCommentId=2569258) so that these portlets will ignore the [maxChallenges](https://liferay.atlassian.net/browse/LPD-1558?focusedCommentId=2553020) in `CaptchaConfiguration.java` that limits the captcha only show once. 

Thanks for checking.
cc: @stian-sigvartsen @topolik @ericyanLr 