### PR TITLE
LPD-17386 add integration test to exposed unused export-package

### DIFF
--- a/modules/apps/batch-engine/batch-engine-test/bnd.bnd
+++ b/modules/apps/batch-engine/batch-engine-test/bnd.bnd
@@ -18,6 +18,8 @@ Import-Package:\
 	!net.sf.*,\
 	\
 	!org.apache.batik.*,\
+	!org.apache.commons.io.build,\
+	!org.apache.commons.io.file.attribute,\
 	!org.apache.commons.math3.*,\
 	!org.apache.jcp.*,\
 	!org.apache.maven.*,\

--- a/modules/apps/content-dashboard/content-dashboard-test/bnd.bnd
+++ b/modules/apps/content-dashboard/content-dashboard-test/bnd.bnd
@@ -18,6 +18,8 @@ Import-Package:\
 	!net.sf.*,\
 	\
 	!org.apache.batik.*,\
+	!org.apache.commons.io.build,\
+	!org.apache.commons.io.file.attribute,\
 	!org.apache.commons.math3.*,\
 	!org.apache.jcp.*,\
 	!org.apache.maven.*,\

--- a/modules/apps/shared-dependencies/shared-dependencies-apache-commons/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-apache-commons/bnd.bnd
@@ -8,21 +8,53 @@ Import-Package:\
 	\
 	*
 -exportcontents:\
-	org.apache.commons.beanutils.*,\
-	org.apache.commons.codec.*,\
-	org.apache.commons.collections4.*,\
-	org.apache.commons.compress.*,\
+	org.apache.commons.beanutils,\
+	org.apache.commons.beanutils.locale,\
+	org.apache.commons.beanutils.locale.converters,\
+	org.apache.commons.codec,\
+	org.apache.commons.codec.binary,\
+	org.apache.commons.codec.digest,\
+	org.apache.commons.codec.net,\
+	org.apache.commons.collections4,\
+	org.apache.commons.collections4.bidimap,\
+	org.apache.commons.collections4.comparators,\
+	org.apache.commons.collections4.map,\
+	org.apache.commons.collections4.queue,\
+	org.apache.commons.compress,\
+	org.apache.commons.compress.archivers,\
+	org.apache.commons.compress.archivers.ar,\
+	org.apache.commons.compress.archivers.arj,\
+	org.apache.commons.compress.archivers.cpio,\
+	org.apache.commons.compress.archivers.dump,\
+	org.apache.commons.compress.archivers.jar,\
+	org.apache.commons.compress.archivers.sevenz,\
+	org.apache.commons.compress.archivers.tar,\
+	org.apache.commons.compress.archivers.zip,\
+	org.apache.commons.compress.compressors,\
+	org.apache.commons.compress.compressors.bzip2,\
+	org.apache.commons.compress.compressors.deflate,\
+	org.apache.commons.compress.compressors.gzip,\
+	org.apache.commons.compress.compressors.lzma,\
+	org.apache.commons.compress.compressors.pack200,\
+	org.apache.commons.compress.compressors.snappy,\
+	org.apache.commons.compress.compressors.xz,\
+	org.apache.commons.compress.compressors.z,\
+	org.apache.commons.compress.utils,\
 	org.apache.commons.csv,\
-	org.apache.commons.digester.*,\
+	org.apache.commons.digester,\
 	org.apache.commons.fileupload,\
 	org.apache.commons.fileupload.disk,\
 	org.apache.commons.fileupload.servlet,\
 	org.apache.commons.fileupload.util,\
 	org.apache.commons.io,\
-	org.apache.commons.io.build,\
-	org.apache.commons.io.file.attribute,\
 	org.apache.commons.io.input,\
 	org.apache.commons.io.output,\
-	org.apache.commons.math3.*,\
+	org.apache.commons.math3.distribution,\
+	org.apache.commons.math3.exception,\
+	org.apache.commons.math3.linear,\
+	org.apache.commons.math3.random,\
+	org.apache.commons.math3.special,\
+	org.apache.commons.math3.stat.descriptive.moment,\
+	org.apache.commons.math3.stat.regression,\
 	org.apache.commons.validator.routines
 -fixupmessages: Classes found in the wrong directory: ...;is:=ignore

--- a/modules/apps/shared-dependencies/shared-dependencies-asm/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-asm/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Shared Dependencies ASM
 Bundle-SymbolicName: com.liferay.shared.dependencies.asm
 Bundle-Version: 1.0.2
--exportcontents: org.objectweb.asm.*;version='7.0.0'
+-exportcontents: org.objectweb.asm;version='7.0.0'

--- a/modules/apps/shared-dependencies/shared-dependencies-groovy-all/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-groovy-all/bnd.bnd
@@ -22,50 +22,15 @@ Import-Package:\
 	\
 	*
 -exportcontents:\
-	groovy.beans,\
-	\
-	groovy.cli.*,\
-	\
-	groovy.grape,\
-	\
-	groovy.inspect.*,\
-	\
-	groovy.io,\
-	\
-	groovy.jmx.builder,\
-	\
-	groovy.json,\
-	\
-	groovy.junit5.plugin,\
-	\
 	groovy.lang,\
 	\
-	groovy.mock.interceptor,\
-	\
-	groovy.model,\
-	\
-	groovy.security,\
-	\
-	groovy.servlet,\
-	\
-	groovy.sql,\
-	\
-	groovy.swing.*,\
-	\
-	groovy.test,\
-	\
-	groovy.text.*,\
-	\
-	groovy.time,\
-	\
-	groovy.transform.*,\
-	\
-	groovy.ui.*,\
-	\
-	groovy.util.*,\
-	\
-	groovy.xml.*,\
-	\
-	org.apache.groovy.*,\
-	\
-	org.codehaus.groovy.*
+	org.codehaus.groovy.ast,\
+	org.codehaus.groovy.ast.expr,\
+	org.codehaus.groovy.control,\
+	org.codehaus.groovy.control.customizers,\
+	org.codehaus.groovy.reflection,\
+	org.codehaus.groovy.runtime,\
+	org.codehaus.groovy.runtime.metaclass,\
+	org.codehaus.groovy.runtime.typehandling,\
+	org.codehaus.groovy.syntax,\
+	org.codehaus.groovy.tools

--- a/modules/apps/shared-dependencies/shared-dependencies-groovy-all/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-groovy-all/bnd.bnd
@@ -30,6 +30,7 @@ Import-Package:\
 	org.codehaus.groovy.control.customizers,\
 	org.codehaus.groovy.reflection,\
 	org.codehaus.groovy.runtime,\
+	org.codehaus.groovy.runtime.callsite,\
 	org.codehaus.groovy.runtime.metaclass,\
 	org.codehaus.groovy.runtime.typehandling,\
 	org.codehaus.groovy.syntax,\

--- a/modules/apps/shared-dependencies/shared-dependencies-gson/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-gson/bnd.bnd
@@ -1,5 +1,9 @@
 Bundle-Name: Liferay Shared Dependencies Gson
 Bundle-SymbolicName: com.liferay.shared.dependencies.gson
 Bundle-Version: 6.0.1
--exportcontents: com.google.gson.*
+-exportcontents:\
+	com.google.gson,\
+	com.google.gson.annotations,\
+	com.google.gson.reflect,\
+	com.google.gson.stream
 -fixupmessages: "^Classes found in the wrong directory: \\\\{META-INF/versions/9/";is:=warning

--- a/modules/apps/shared-dependencies/shared-dependencies-guava/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-guava/bnd.bnd
@@ -1,4 +1,16 @@
 Bundle-Name: Liferay Shared Dependencies Guava
 Bundle-SymbolicName: com.liferay.shared.dependencies.guava
 Bundle-Version: 9.0.1
--exportcontents: com.google.common.*
+-exportcontents:\
+	com.google.common.base,\
+	com.google.common.cache,\
+	com.google.common.collect,\
+	com.google.common.escape,\
+	com.google.common.hash,\
+	com.google.common.io,\
+	com.google.common.math,\
+	com.google.common.net,\
+	com.google.common.primitives,\
+	com.google.common.reflect,\
+	com.google.common.util.concurrent,\
+	com.google.common.xml

--- a/modules/apps/shared-dependencies/shared-dependencies-jdom2/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-jdom2/bnd.bnd
@@ -1,4 +1,9 @@
 Bundle-Name: Liferay Shared Dependencies JDOM2
 Bundle-SymbolicName: com.liferay.shared.dependencies.jdom2
 Bundle-Version: 1.0.2
--exportcontents: org.jdom2.*;version='2.0.6'
+-exportcontents:\
+	org.jdom2;version='2.0.6',\
+	org.jdom2.filter;version='2.0.6',\
+	org.jdom2.input;version='2.0.6',\
+	org.jdom2.input.sax;version='2.0.6',\
+	org.jdom2.output;version='2.0.6'

--- a/modules/apps/shared-dependencies/shared-dependencies-jericho-html/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-jericho-html/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Shared Dependencies Jericho Html
 Bundle-SymbolicName: com.liferay.shared.dependencies.jericho.html
 Bundle-Version: 1.0.3
--exportcontents: net.htmlparser.jericho.*
+-exportcontents: net.htmlparser.jericho

--- a/modules/apps/shared-dependencies/shared-dependencies-jfree/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-jfree/bnd.bnd
@@ -1,4 +1,22 @@
 Bundle-Name: Liferay Shared Dependencies Jfree
 Bundle-SymbolicName: com.liferay.shared.dependencies.jfree
 Bundle-Version: 1.0.2
--exportcontents: org.jfree.*
+-exportcontents:\
+	org.jfree.chart,\
+	org.jfree.chart.axis,\
+	org.jfree.chart.entity,\
+	org.jfree.chart.labels,\
+	org.jfree.chart.plot,\
+	org.jfree.chart.plot.dial,\
+	org.jfree.chart.renderer.category,\
+	org.jfree.chart.renderer.xy,\
+	org.jfree.chart.title,\
+	org.jfree.data,\
+	org.jfree.data.category,\
+	org.jfree.data.gantt,\
+	org.jfree.data.general,\
+	org.jfree.data.time,\
+	org.jfree.data.xy,\
+	org.jfree.date,\
+	org.jfree.ui,\
+	org.jfree.util

--- a/modules/apps/shared-dependencies/shared-dependencies-joda/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-joda/bnd.bnd
@@ -2,5 +2,9 @@ Bundle-Name: Liferay Shared Dependencies Joda
 Bundle-SymbolicName: com.liferay.shared.dependencies.joda
 Bundle-Version: 1.0.2
 -exportcontents:\
-	org.joda.convert.*,\
-	org.joda.time.*
+	org.joda.convert,\
+	org.joda.time,\
+	org.joda.time.chrono,\
+	org.joda.time.field,\
+	org.joda.time.format,\
+	org.joda.time.tz

--- a/modules/apps/shared-dependencies/shared-dependencies-jsoup/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-jsoup/bnd.bnd
@@ -7,9 +7,5 @@ Import-Package:\
 	*
 -exportcontents:\
 	org.jsoup,\
-	org.jsoup.helper,\
-	org.jsoup.internal,\
 	org.jsoup.nodes,\
-	org.jsoup.parser,\
-	org.jsoup.safety,\
 	org.jsoup.select

--- a/modules/apps/shared-dependencies/shared-dependencies-minidev/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-minidev/bnd.bnd
@@ -1,4 +1,7 @@
 Bundle-Name: Liferay Shared Dependencies Minidev
 Bundle-SymbolicName: com.liferay.shared.dependencies.minidev
 Bundle-Version: 1.0.2
--exportcontents: net.minidev.*
+-exportcontents:\
+	net.minidev.json,\
+	net.minidev.json.parser,\
+	net.minidev.json.writer

--- a/modules/apps/shared-dependencies/shared-dependencies-netty/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-netty/bnd.bnd
@@ -2,4 +2,23 @@ Bundle-Name: Liferay Shared Dependencies Netty
 Bundle-SymbolicName: com.liferay.shared.dependencies.netty
 Bundle-Version: 1.0.6
 Import-Package: !com.aayushatharva.brotli4j.*
--exportcontents: io.netty.*
+-exportcontents:\
+	io.netty.bootstrap,\
+	io.netty.buffer,\
+	io.netty.channel,\
+	io.netty.channel.group,\
+	io.netty.channel.nio,\
+	io.netty.channel.socket,\
+	io.netty.handler.codec,\
+	io.netty.handler.codec.base64,\
+	io.netty.handler.codec.http,\
+	io.netty.handler.codec.http2,\
+	io.netty.handler.flush,\
+	io.netty.handler.proxy,\
+	io.netty.handler.ssl,\
+	io.netty.handler.timeout,\
+	io.netty.resolver,\
+	io.netty.resolver.dns,\
+	io.netty.util,\
+	io.netty.util.collection,\
+	io.netty.util.concurrent

--- a/modules/apps/shared-dependencies/shared-dependencies-pdfbox/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-pdfbox/bnd.bnd
@@ -11,4 +11,30 @@ Import-Package:\
 	org.apache.fontbox.ttf,\
 	org.apache.jempbox.xmp,\
 	org.apache.jempbox.xmp.pdfa,\
-	org.apache.pdfbox.*;-noimport:=true
+	org.apache.pdfbox.contentstream,\
+	org.apache.pdfbox.cos,\
+	org.apache.pdfbox.filter,\
+	org.apache.pdfbox.io,\
+	org.apache.pdfbox.pdfparser,\
+	org.apache.pdfbox.pdmodel,\
+	org.apache.pdfbox.pdmodel.common,\
+	org.apache.pdfbox.pdmodel.common.filespecification,\
+	org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure,\
+	org.apache.pdfbox.pdmodel.documentinterchange.markedcontent,\
+	org.apache.pdfbox.pdmodel.encryption,\
+	org.apache.pdfbox.pdmodel.fixup,\
+	org.apache.pdfbox.pdmodel.fixup.processor,\
+	org.apache.pdfbox.pdmodel.font,\
+	org.apache.pdfbox.pdmodel.graphics.color,\
+	org.apache.pdfbox.pdmodel.graphics.form,\
+	org.apache.pdfbox.pdmodel.graphics.image,\
+	org.apache.pdfbox.pdmodel.graphics.pattern,\
+	org.apache.pdfbox.pdmodel.graphics.state,\
+	org.apache.pdfbox.pdmodel.interactive.action,\
+	org.apache.pdfbox.pdmodel.interactive.annotation,\
+	org.apache.pdfbox.pdmodel.interactive.digitalsignature,\
+	org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline,\
+	org.apache.pdfbox.pdmodel.interactive.form,\
+	org.apache.pdfbox.rendering,\
+	org.apache.pdfbox.text,\
+	org.apache.pdfbox.util

--- a/modules/apps/shared-dependencies/shared-dependencies-poi/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-poi/bnd.bnd
@@ -38,8 +38,64 @@ Import-Package:\
 	\
 	*
 -exportcontents:\
-	org.apache.poi.*,\
-	org.apache.xmlbeans.*,\
+	org.apache.poi,\
+	org.apache.poi.common,\
+	org.apache.poi.common.usermodel,\
+	org.apache.poi.common.usermodel.fonts,\
+	org.apache.poi.ddf,\
+	org.apache.poi.extractor,\
+	org.apache.poi.hpsf,\
+	org.apache.poi.hpsf.extractor,\
+	org.apache.poi.hssf.eventusermodel,\
+	org.apache.poi.hssf.extractor,\
+	org.apache.poi.hssf.model,\
+	org.apache.poi.hssf.record,\
+	org.apache.poi.hssf.record.chart,\
+	org.apache.poi.hssf.record.common,\
+	org.apache.poi.hssf.record.crypto,\
+	org.apache.poi.hssf.usermodel,\
+	org.apache.poi.hssf.util,\
+	org.apache.poi.ooxml,\
+	org.apache.poi.ooxml.extractor,\
+	org.apache.poi.openxml4j.exceptions,\
+	org.apache.poi.openxml4j.opc,\
+	org.apache.poi.openxml4j.opc.internal,\
+	org.apache.poi.openxml4j.util,\
+	org.apache.poi.poifs.crypt,\
+	org.apache.poi.poifs.crypt.cryptoapi,\
+	org.apache.poi.poifs.crypt.standard,\
+	org.apache.poi.poifs.filesystem,\
+	org.apache.poi.poifs.macros,\
+	org.apache.poi.sl.draw,\
+	org.apache.poi.sl.draw.geom,\
+	org.apache.poi.sl.extractor,\
+	org.apache.poi.sl.image,\
+	org.apache.poi.sl.usermodel,\
+	org.apache.poi.ss.formula.eval,\
+	org.apache.poi.ss.usermodel,\
+	org.apache.poi.ss.util,\
+	org.apache.poi.util,\
+	org.apache.poi.wp.usermodel,\
+	org.apache.poi.xdgf.usermodel,\
+	org.apache.poi.xslf.extractor,\
+	org.apache.poi.xslf.usermodel,\
+	org.apache.poi.xssf.binary,\
+	org.apache.poi.xssf.eventusermodel,\
+	org.apache.poi.xssf.extractor,\
+	org.apache.poi.xssf.model,\
+	org.apache.poi.xssf.usermodel,\
+	org.apache.poi.xssf.usermodel.helpers,\
+	org.apache.poi.xwpf.extractor,\
+	org.apache.poi.xwpf.model,\
+	org.apache.poi.xwpf.usermodel,\
+	org.apache.xmlbeans,\
+	org.apache.xmlbeans.impl.schema,\
+	org.apache.xmlbeans.impl.values,\
 	\
-	org.openxmlformats.schemas.*
+	org.openxmlformats.schemas.drawingml.x2006.main,\
+	org.openxmlformats.schemas.drawingml.x2006.spreadsheetDrawing,\
+	org.openxmlformats.schemas.officeDocument.x2006.customProperties,\
+	org.openxmlformats.schemas.officeDocument.x2006.extendedProperties,\
+	org.openxmlformats.schemas.presentationml.x2006.main,\
+	org.openxmlformats.schemas.wordprocessingml.x2006.main
 -fixupmessages: "^Classes found in the wrong directory: \\\\{META-INF/versions/9/";is:=warning

--- a/modules/apps/shared-dependencies/shared-dependencies-woodstox-core/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-woodstox-core/bnd.bnd
@@ -1,4 +1,7 @@
 Bundle-Name: Liferay Shared Dependencies woodstox-core
 Bundle-SymbolicName: com.liferay.shared.dependencies.woodstox.core
 Bundle-Version: 1.0.3
--exportcontents: com.ctc.wstx.*
+-exportcontents:\
+	com.ctc.wstx.api,\
+	com.ctc.wstx.msv,\
+	com.ctc.wstx.stax

--- a/modules/apps/shared-dependencies/shared-dependencies-xmlsec/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-xmlsec/bnd.bnd
@@ -7,15 +7,12 @@ Import-Package:\
 	*
 -exportcontents:\
 	org.apache.xml.security,\
-	org.apache.xml.security.algorithms.JCEMapper,\
 	org.apache.xml.security.c14n,\
 	org.apache.xml.security.encryption,\
 	org.apache.xml.security.exceptions,\
 	org.apache.xml.security.keys,\
 	org.apache.xml.security.signature,\
 	org.apache.xml.security.stax.ext,\
-	org.apache.xml.security.stax.ext.XMLSecurityConstants,\
 	org.apache.xml.security.transforms,\
 	org.apache.xml.security.transforms.params,\
-	org.apache.xml.security.utils,\
-	org.apache.xml.security.utils.Base64
+	org.apache.xml.security.utils

--- a/modules/apps/shared-dependencies/shared-dependencies-xmpcore/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-xmpcore/bnd.bnd
@@ -1,4 +1,8 @@
 Bundle-Name: Liferay Shared Dependencies Xmpcore
 Bundle-SymbolicName: com.liferay.shared.dependencies.xmpcore
 Bundle-Version: 1.0.2
--exportcontents: com.adobe.internal.xmp.*
+-exportcontents:\
+	com.adobe.internal.xmp,\
+	com.adobe.internal.xmp.impl,\
+	com.adobe.internal.xmp.options,\
+	com.adobe.internal.xmp.properties

--- a/modules/apps/shared-dependencies/shared-dependencies-xstream/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-xstream/bnd.bnd
@@ -17,4 +17,18 @@ Import-Package:\
 	!org.xmlpull.mxp1,\
 	\
 	*
--exportcontents: com.thoughtworks.xstream.*
+-exportcontents:\
+	com.thoughtworks.xstream,\
+	com.thoughtworks.xstream.annotations,\
+	com.thoughtworks.xstream.converters,\
+	com.thoughtworks.xstream.converters.basic,\
+	com.thoughtworks.xstream.converters.collections,\
+	com.thoughtworks.xstream.converters.extended,\
+	com.thoughtworks.xstream.converters.reflection,\
+	com.thoughtworks.xstream.core,\
+	com.thoughtworks.xstream.core.util,\
+	com.thoughtworks.xstream.io,\
+	com.thoughtworks.xstream.io.json,\
+	com.thoughtworks.xstream.io.xml,\
+	com.thoughtworks.xstream.mapper,\
+	com.thoughtworks.xstream.security

--- a/modules/test/third-party-library-dependencies-test/bnd.bnd
+++ b/modules/test/third-party-library-dependencies-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Third Party Library Dependencies Test
+Bundle-SymbolicName: com.liferay.third.party.library.dependencies.test
+Bundle-Version: 1.0.0

--- a/modules/test/third-party-library-dependencies-test/build.gradle
+++ b/modules/test/third-party-library-dependencies-test/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/test/third-party-library-dependencies-test/src/testIntegration/java/com/liferay/third/party/library/dependencies/test/ThirdPartyLibraryDependenciesTest.java
+++ b/modules/test/third-party-library-dependencies-test/src/testIntegration/java/com/liferay/third/party/library/dependencies/test/ThirdPartyLibraryDependenciesTest.java
@@ -1,0 +1,156 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.third.party.library.dependencies.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.wiring.BundleRevision;
+import org.osgi.framework.wiring.BundleWire;
+import org.osgi.framework.wiring.BundleWiring;
+import org.osgi.resource.Capability;
+
+/**
+ * @author Jiefeng Wu
+ */
+@RunWith(Arquillian.class)
+public class ThirdPartyLibraryDependenciesTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testIfExistedUnusedExportPackageFromSharedDependencies() {
+		Bundle bundle = FrameworkUtil.getBundle(
+			ThirdPartyLibraryDependenciesTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		for (Bundle curBundle : bundleContext.getBundles()) {
+			String curBundleSymbolicName = curBundle.getSymbolicName();
+
+			if (!curBundleSymbolicName.contains(
+					"com.liferay.shared.dependencies.")) {
+
+				continue;
+			}
+
+			Set<String> inUseExportPackage = _getInUseExportPackages(curBundle);
+
+			for (String exportPackageFromManifest :
+					_getExportPackagesFromManifest(curBundle)) {
+
+				if (!inUseExportPackage.contains(exportPackageFromManifest)) {
+					_updatedExportComponents.put(
+						curBundle.getSymbolicName(), inUseExportPackage);
+
+					break;
+				}
+			}
+		}
+
+		Assert.assertTrue(
+			"These bundles has unused export-package, please update: \n" +
+				_printUpdatedExportComponents(_updatedExportComponents),
+			_updatedExportComponents.isEmpty());
+	}
+
+	private List<String> _getExportPackagesFromManifest(Bundle bundle) {
+		List<String> exportPackageFromManifest = new ArrayList<>();
+
+		Dictionary<String, String> headers = bundle.getHeaders(
+			StringPool.BLANK);
+
+		String rawExportPackages = headers.get("Export-Package");
+
+		for (String rawExportPackage : rawExportPackages.split("\",")) {
+			String[] filteredExportPackage = rawExportPackage.split(";");
+
+			exportPackageFromManifest.add(filteredExportPackage[0]);
+		}
+
+		return exportPackageFromManifest;
+	}
+
+	private Set<String> _getInUseExportPackages(Bundle bundle) {
+		Set<String> inUseExportPackages = new HashSet<>();
+
+		BundleWiring bundleWiring = bundle.adapt(BundleWiring.class);
+
+		for (BundleWire bundleWire :
+				bundleWiring.getProvidedWires(
+					BundleRevision.PACKAGE_NAMESPACE)) {
+
+			Capability capability = bundleWire.getCapability();
+
+			Map<String, Object> attributes = capability.getAttributes();
+
+			String inUseExportPackage = (String)attributes.get(
+				BundleRevision.PACKAGE_NAMESPACE);
+
+			inUseExportPackages.add(inUseExportPackage);
+		}
+
+		return inUseExportPackages;
+	}
+
+	private String _printUpdatedExportComponents(
+		Map<String, Set<String>> updatedExportComponents) {
+
+		StringBuilder sb = new StringBuilder();
+
+		for (Map.Entry<String, Set<String>> entry :
+				updatedExportComponents.entrySet()) {
+
+			sb.append(
+				entry.getKey()
+			).append(
+				StringPool.COLON
+			).append(
+				StringPool.NEW_LINE
+			);
+
+			for (String value : entry.getValue()) {
+				sb.append(
+					value
+				).append(
+					",\\"
+				).append(
+					StringPool.NEW_LINE
+				);
+			}
+
+			sb.append("\n");
+		}
+
+		return sb.toString();
+	}
+
+	private final Map<String, Set<String>> _updatedExportComponents =
+		new HashMap<>();
+
+}

--- a/modules/test/third-party-library-dependencies-test/src/testIntegration/java/com/liferay/third/party/library/dependencies/test/ThirdPartyLibraryDependenciesTest.java
+++ b/modules/test/third-party-library-dependencies-test/src/testIntegration/java/com/liferay/third/party/library/dependencies/test/ThirdPartyLibraryDependenciesTest.java
@@ -8,6 +8,7 @@ package com.liferay.third.party.library.dependencies.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.ArrayList;
@@ -63,6 +64,12 @@ public class ThirdPartyLibraryDependenciesTest {
 
 			for (String exportPackageFromManifest :
 					_getExportPackagesFromManifest(curBundle)) {
+
+				if (_integrationTestNeededPackages.contains(
+						exportPackageFromManifest)) {
+
+					continue;
+				}
 
 				if (!inUseExportPackage.contains(exportPackageFromManifest)) {
 					_updatedExportComponents.put(
@@ -149,6 +156,10 @@ public class ThirdPartyLibraryDependenciesTest {
 
 		return sb.toString();
 	}
+
+	private static final Set<String> _integrationTestNeededPackages =
+		SetUtil.fromArray(
+			new String[] {"org.codehaus.groovy.runtime.callsite"});
 
 	private final Map<String, Set<String>> _updatedExportComponents =
 		new HashMap<>();

--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 101.1.1
+Bundle-Version: 101.2.0
 Export-Package:\
 	com.liferay.portal.bean,\
 	com.liferay.portal.dao.orm.hibernate,\

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 64.1.0
+version 64.2.0

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 139.0.1
+Bundle-Version: 139.1.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 77.1.0
+version 77.2.0


### PR DESCRIPTION
Hi Tina,

Resend: https://github.com/liferay-core-infra/liferay-portal/pull/6617
This is for ticket https://liferay.atlassian.net/browse/LPD-17386
This PR is to add an integration test to expose all the unused export-package from shared-dependencies.
My main idea is:

get all the export package from bundle wiring, which are the packages are in used by others, we will call it A for now

get all the export package from manifest, which are all the packages we export, we will call it B for now

if A does not contain a package from B, which means this package is not used by anyone, and it should be removed.

I will print out the redundant package and the shared-dependencies that export this package in the log (pls see the screenshot)
![image](https://github.com/liferay-core-infra/liferay-portal/assets/32234574/e366a134-e443-479f-bcbe-bfee56ea4e02)