### PR TITLE
LPD-25981 no error message show in gogo shell with wrong captcha

### DIFF
--- a/modules/apps/gogo-shell/gogo-shell-web/src/main/java/com/liferay/gogo/shell/web/internal/portlet/GogoShellPortlet.java
+++ b/modules/apps/gogo-shell/gogo-shell-web/src/main/java/com/liferay/gogo/shell/web/internal/portlet/GogoShellPortlet.java
@@ -144,6 +144,8 @@ public class GogoShellPortlet extends MVCPortlet {
 
 			SessionMessages.add(
 				actionRequest, "requestProcessed", successMessage);
+
+			sendRedirect(actionRequest, actionResponse);
 		}
 		catch (Exception exception) {
 			hideDefaultErrorMessage(actionRequest);

--- a/modules/apps/gogo-shell/gogo-shell-web/src/main/java/com/liferay/gogo/shell/web/internal/portlet/GogoShellPortlet.java
+++ b/modules/apps/gogo-shell/gogo-shell-web/src/main/java/com/liferay/gogo/shell/web/internal/portlet/GogoShellPortlet.java
@@ -8,7 +8,6 @@ package com.liferay.gogo.shell.web.internal.portlet;
 import com.liferay.captcha.util.CaptchaUtil;
 import com.liferay.gogo.shell.web.internal.constants.GogoShellPortletKeys;
 import com.liferay.gogo.shell.web.internal.constants.GogoShellWebKeys;
-import com.liferay.portal.kernel.captcha.CaptchaException;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.portal.kernel.language.Language;
@@ -91,12 +90,7 @@ public class GogoShellPortlet extends MVCPortlet {
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {
 
-		try {
-			CaptchaUtil.check(actionRequest);
-		}
-		catch (CaptchaException captchaException) {
-			throw new PortletException(captchaException);
-		}
+		CaptchaUtil.check(actionRequest);
 
 		String command = ParamUtil.getString(actionRequest, "command");
 

--- a/modules/apps/gogo-shell/gogo-shell-web/src/main/java/com/liferay/gogo/shell/web/internal/portlet/GogoShellPortlet.java
+++ b/modules/apps/gogo-shell/gogo-shell-web/src/main/java/com/liferay/gogo/shell/web/internal/portlet/GogoShellPortlet.java
@@ -144,6 +144,12 @@ public class GogoShellPortlet extends MVCPortlet {
 			if (Validator.isNotNull(errorContent)) {
 				throw new Exception(errorContent);
 			}
+
+			String successMessage = ParamUtil.getString(
+				actionRequest, "successMessage");
+
+			SessionMessages.add(
+				actionRequest, "requestProcessed", successMessage);
 		}
 		catch (Exception exception) {
 			hideDefaultErrorMessage(actionRequest);

--- a/modules/apps/gogo-shell/gogo-shell-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/gogo-shell/gogo-shell-web/src/main/resources/META-INF/resources/init.jsp
@@ -24,6 +24,7 @@ page import="com.liferay.portal.kernel.captcha.CaptchaTextException" %><%@
 page import="com.liferay.portal.kernel.servlet.SessionMessages" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.JavaConstants" %><%@
+page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %>
 
 <%@ page import="javax.portlet.PortletRequest" %>

--- a/modules/apps/gogo-shell/gogo-shell-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/gogo-shell/gogo-shell-web/src/main/resources/META-INF/resources/view.jsp
@@ -11,7 +11,7 @@
 
 <clay:container-fluid>
 	<aui:form action="<%= executeCommandURL %>" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + liferayPortletResponse.getNamespace() + "executeCommand();" %>'>
-		<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
+		<aui:input name="redirect" type="hidden" value="<%= PortalUtil.getCurrentURL(request) %>" />
 
 		<liferay-ui:error exception="<%= CaptchaConfigurationException.class %>" message="a-captcha-error-occurred-please-contact-an-administrator" />
 		<liferay-ui:error exception="<%= CaptchaException.class %>" message="captcha-verification-failed" />

--- a/modules/apps/gogo-shell/gogo-shell-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/gogo-shell/gogo-shell-web/src/main/resources/META-INF/resources/view.jsp
@@ -7,15 +7,15 @@
 
 <%@ include file="/init.jsp" %>
 
-<liferay-ui:error exception="<%= CaptchaConfigurationException.class %>" message="a-captcha-error-occurred-please-contact-an-administrator" />
-<liferay-ui:error exception="<%= CaptchaException.class %>" message="captcha-verification-failed" />
-<liferay-ui:error exception="<%= CaptchaTextException.class %>" message="text-verification-failed" />
-
 <portlet:actionURL name="executeCommand" var="executeCommandURL" />
 
 <clay:container-fluid>
 	<aui:form action="<%= executeCommandURL %>" method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + liferayPortletResponse.getNamespace() + "executeCommand();" %>'>
 		<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
+
+		<liferay-ui:error exception="<%= CaptchaConfigurationException.class %>" message="a-captcha-error-occurred-please-contact-an-administrator" />
+		<liferay-ui:error exception="<%= CaptchaException.class %>" message="captcha-verification-failed" />
+		<liferay-ui:error exception="<%= CaptchaTextException.class %>" message="text-verification-failed" />
 
 		<liferay-ui:error key="gogo">
 


### PR DESCRIPTION
Hi Tina,

These are the other bugs we found about captcha. 
1. When we are using captcha in gogoshell, it will not show succesfuf and error message. 
2. After the first bug is fixed, we will have antoher issue that, no matter we enter a correct/wrong captcha, the captcha input will not clean up in the ui

I include more details in the ticket. https://liferay.atlassian.net/browse/LPD-25981