### PR TITLE
LPD-28265 add back log4j-1.2-api to lib/development to make sure "ant build-iw" work

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -84,6 +84,7 @@
 	<classpathentry kind="lib" path="lib/development/jstl-api.jar"/>
 	<classpathentry kind="lib" path="lib/development/jstl-impl.jar"/>
 	<classpathentry kind="lib" path="lib/development/junit.jar"/>
+	<classpathentry kind="lib" path="lib/development/log4j-1.2-api.jar"/>
 	<classpathentry kind="lib" path="lib/development/mail.jar"/>
 	<classpathentry kind="lib" path="lib/development/mariadb.jar"/>
 	<classpathentry kind="lib" path="lib/development/maven-ant-tasks.jar"/>

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -50,6 +50,7 @@
 /development/jstl-api.jar
 /development/jstl-impl.jar
 /development/junit.jar
+/development/log4j-1.2-api.jar
 /development/mail.jar
 /development/mariadb.jar
 /development/maven-ant-tasks.jar

--- a/lib/development/dependencies.properties
+++ b/lib/development/dependencies.properties
@@ -48,6 +48,7 @@ jsp-api=javax.servlet.jsp:jsp-api:2.1
 jstl-api=javax.servlet.jsp.jstl:javax.servlet.jsp.jstl-api:1.2.2
 jstl-impl=org.glassfish.web:javax.servlet.jsp.jstl:1.2.3
 junit=junit:junit:4.13.1
+log4j-1.2-api=org.apache.logging.log4j:log4j-1.2-api:2.17.1
 mail=com.sun.mail:jakarta.mail:1.6.6
 mariadb=org.mariadb.jdbc:mariadb-java-client:3.2.0
 maven-ant-tasks=org.apache.maven:maven-ant-tasks:2.1.3

--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -6062,6 +6062,18 @@
 				</licenses>
 			</library>
 			<library>
+				<file-name>lib/development/log4j-1.2-api.jar</file-name>
+				<version>2.17.1</version>
+				<project-name>Log4j 1.x Compatibility API</project-name>
+				<project-url>http://logging.apache.org/log4j</project-url>
+				<licenses>
+					<license>
+						<license-name>Apache License 2.0</license-name>
+						<license-url>http://www.apache.org/licenses/LICENSE-2.0</license-url>
+					</license>
+				</licenses>
+			</library>
+			<library>
 				<file-name>lib/development/mail.jar</file-name>
 				<version>1.6.6</version>
 				<project-name>JavaMail</project-name>

--- a/lib/versions-ext.xml
+++ b/lib/versions-ext.xml
@@ -591,6 +591,18 @@
 				</licenses>
 			</library>
 			<library>
+				<file-name>lib/development/log4j-1.2-api.jar</file-name>
+				<version>2.17.1</version>
+				<project-name>Log4j 1.x Compatibility API</project-name>
+				<project-url>http://logging.apache.org/log4j</project-url>
+				<licenses>
+					<license>
+						<license-name>Apache License 2.0</license-name>
+						<license-url>http://www.apache.org/licenses/LICENSE-2.0</license-url>
+					</license>
+				</licenses>
+			</library>
+			<library>
 				<file-name>lib/development/mail.jar</file-name>
 				<version>1.6.6</version>
 				<project-name>JavaMail</project-name>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -3130,6 +3130,12 @@
 </tr>
 			
 <tr>
+<td nowrap="nowrap">lib/development/log4j-1.2-api.jar</td><td nowrap="nowrap">2.17.1</td><td nowrap="nowrap"><a href="http://logging.apache.org/log4j">Log4j 1.x Compatibility API</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
+<br>
+</td><td></td>
+</tr>
+			
+<tr>
 <td nowrap="nowrap">lib/development/mail.jar</td><td nowrap="nowrap">1.6.6</td><td nowrap="nowrap"><a href="https://eclipse-ee4j.github.io/mail">JavaMail</a></td><td nowrap><a href="https://opensource.org/licenses/CDDL-1.0">Common Development and Distribution License 1.0</a>
 <br>
 </td><td></td>

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -53,6 +53,7 @@ javac.classpath=\
     lib/development/jstl-api.jar:\
     lib/development/jstl-impl.jar:\
     lib/development/junit.jar:\
+    lib/development/log4j-1.2-api.jar:\
     lib/development/mail.jar:\
     lib/development/mariadb.jar:\
     lib/development/maven-ant-tasks.jar:\


### PR DESCRIPTION
Hi Tina,

This is for ticket https://liferay.atlassian.net/browse/LPD-28265.
I have added back log4j-1.2-api to lib/development as talked, and checked locally, "ant build-iw" can run without error
![Screenshot_20240612_081751](https://github.com/liferay-core-infra/liferay-portal/assets/32234574/44e417e6-0781-4aa4-a909-010eadb5b504)
