### PR TITLE
LPD-30984 fix clustering functional test that using 8080 in User.loginPG

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/User.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/User.macro
@@ -2228,6 +2228,10 @@ definition {
 
 	@summary = "Default summary"
 	macro loginPG(idpName = null, password = null, virtualHostsURL = null, userScreenName = null, userEmailAddress = null, newPassword = null, rememberMeChecked = null, nodePort = null) {
+		if (isSet(nodePort) && !(isSet(virtualHostsURL))) {
+			var virtualHostsURL = "http://localhost:${nodePort}";
+		}
+
 		JSONUser.agreeToTermsAndAnswerReminderQuery(
 			portalURL = ${virtualHostsURL},
 			userEmailAddress = ${userEmailAddress});

--- a/portal-web/test/functional/com/liferay/portalweb/macros/User.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/User.macro
@@ -2233,6 +2233,7 @@ definition {
 		}
 
 		JSONUser.agreeToTermsAndAnswerReminderQuery(
+			nodePort = ${nodePort},
 			portalURL = ${virtualHostsURL},
 			userEmailAddress = ${userEmailAddress});
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/company/JSONCompany.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/company/JSONCompany.macro
@@ -119,13 +119,17 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro getCompanyIdNoSelenium(token = null) {
+	macro getCompanyIdNoSelenium(token = null, nodePort = null) {
 		if (!(isSet(portalInstanceName))) {
 			var portalInstanceName = JSONCompany.getPortalInstanceNameNoSelenium();
 		}
 
 		if (!(isSet(portalURL))) {
 			var portalURL = JSONCompany.getDefaultPortalURL();
+		}
+
+		if (isSet(nodePort)) {
+			var portalURL = "http://localhost:${nodePort}";
 		}
 
 		if (isSet(specificURL)) {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/user/JSONUser.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/user/JSONUser.macro
@@ -191,7 +191,7 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro agreeToTermsAndAnswerReminderQuery(creatorPassword = null, portalURL = null, userEmailAddress = null, creatorEmailAddress = null) {
+	macro agreeToTermsAndAnswerReminderQuery(creatorPassword = null, portalURL = null, userEmailAddress = null, creatorEmailAddress = null, nodePort = null) {
 		Variables.assertDefined(parameterList = ${userEmailAddress});
 
 		var portalInstanceName = JSONUserSetter.setPortalInstanceName(portalURL = ${portalURL});
@@ -199,6 +199,7 @@ definition {
 		var userId = JSONUserSetter.setUserId(
 			creatorEmailAddress = ${creatorEmailAddress},
 			creatorPassword = ${creatorPassword},
+			nodePort = ${nodePort},
 			portalInstanceName = ${portalInstanceName},
 			specificURL = ${portalURL},
 			userEmailAddress = ${userEmailAddress});

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/user/JSONUserAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/user/JSONUserAPI.macro
@@ -235,12 +235,13 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro _getUserIdByEmailAddress(portalInstanceName = null, userEmailAddress = null, specificURL = null) {
+	macro _getUserIdByEmailAddress(portalInstanceName = null, userEmailAddress = null, specificURL = null, nodePort = null) {
 		Variables.assertDefined(parameterList = ${userEmailAddress});
 
 		var companyId = JSONCompany.getCompanyIdNoSelenium(
 			creatorEmailAddress = ${creatorEmailAddress},
 			creatorPassword = ${creatorPassword},
+			nodePort = ${nodePort},
 			portalInstanceName = ${portalInstanceName});
 
 		if (isSet(specificURL)) {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/user/JSONUserSetter.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/user/JSONUserSetter.macro
@@ -98,12 +98,13 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro setUserId(creatorPassword = null, portalInstanceName = null, userEmailAddress = null, specificURL = null, creatorEmailAddress = null) {
+	macro setUserId(creatorPassword = null, portalInstanceName = null, userEmailAddress = null, specificURL = null, creatorEmailAddress = null, nodePort = null) {
 		Variables.assertDefined(parameterList = ${userEmailAddress});
 
 		var userId = JSONUserAPI._getUserIdByEmailAddress(
 			creatorEmailAddress = ${creatorEmailAddress},
 			creatorPassword = ${creatorPassword},
+			nodePort = ${nodePort},
 			portalInstanceName = ${portalInstanceName},
 			specificURL = ${specificURL},
 			userEmailAddress = ${userEmailAddress});


### PR DESCRIPTION
Hi Tina,

resend: https://github.com/liferay-core-infra/liferay-portal/pull/7224
As talked, in the clustering functional test, we will use 8080 for User.loginPG all the time even though we set nodeport 9080.
Take `Clustering#CanAccessGogoShellOnAnyClusteredNode as example`
Before the fix: 
![Screenshot_20240708_154953](https://github.com/jeffwu0724/liferay-portal/assets/32234574/e0d7d951-94a9-46c6-8308-e8ac38a7855b)


After the fix:
![Screenshot_20240708_155020](https://github.com/jeffwu0724/liferay-portal/assets/32234574/2dacbfe8-f397-4c5e-8ed2-3240ea9b5832)

cc: @julschong 
