### PR TITLE
LPD-30984 fix clustering functional test that using 8080 in User.loginPG

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/User.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/User.macro
@@ -2235,29 +2235,25 @@ definition {
 				portalURL = ${portalURL},
 				userEmailAddress = ${userEmailAddress});
 
-			Navigator.openSpecificURL(url = "${virtualHostsURL}/web/guest?SM_USER=${userEmailAddress}");
+			Navigator.openSpecificURL(url = "${portalURL}/web/guest?SM_USER=${userEmailAddress}");
 		}
 		else if (isSet(nodePort)) {
-			var baseURL = "http://localhost:${nodePort}";
-
-			var portalURL = ${baseURL};
+			var portalURL = "http://localhost:${nodePort}";
 
 			JSONUser.agreeToTermsAndAnswerReminderQuery(
 				portalURL = ${portalURL},
 				userEmailAddress = ${userEmailAddress});
 
-			Navigator.openSpecificURL(url = "${baseURL}/web/guest?SM_USER=${userEmailAddress}");
+			Navigator.openSpecificURL(url = "${portalURL}/web/guest?SM_USER=${userEmailAddress}");
 		}
 		else {
-			var baseURL = JSONCompany.getPortalURL();
-
-			var portalURL = ${baseURL};
+			var portalURL = JSONCompany.getPortalURL();
 
 			JSONUser.agreeToTermsAndAnswerReminderQuery(
 				portalURL = ${portalURL},
 				userEmailAddress = ${userEmailAddress});
 
-			Navigator.openSpecificURL(url = "${baseURL}/web/guest?SM_USER=${userEmailAddress}");
+			Navigator.openSpecificURL(url = "${portalURL}/web/guest?SM_USER=${userEmailAddress}");
 		}
 
 		// TODO Remove below macro after password reminder gets completely cleaned out with JSON

--- a/portal-web/test/functional/com/liferay/portalweb/macros/User.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/User.macro
@@ -2230,31 +2230,19 @@ definition {
 	macro loginPG(idpName = null, password = null, virtualHostsURL = null, userScreenName = null, userEmailAddress = null, newPassword = null, rememberMeChecked = null, nodePort = null) {
 		if (isSet(virtualHostsURL)) {
 			var portalURL = ${virtualHostsURL};
-
-			JSONUser.agreeToTermsAndAnswerReminderQuery(
-				portalURL = ${portalURL},
-				userEmailAddress = ${userEmailAddress});
-
-			Navigator.openSpecificURL(url = "${portalURL}/web/guest?SM_USER=${userEmailAddress}");
 		}
 		else if (isSet(nodePort)) {
 			var portalURL = "http://localhost:${nodePort}";
-
-			JSONUser.agreeToTermsAndAnswerReminderQuery(
-				portalURL = ${portalURL},
-				userEmailAddress = ${userEmailAddress});
-
-			Navigator.openSpecificURL(url = "${portalURL}/web/guest?SM_USER=${userEmailAddress}");
 		}
 		else {
 			var portalURL = JSONCompany.getPortalURL();
-
-			JSONUser.agreeToTermsAndAnswerReminderQuery(
-				portalURL = ${portalURL},
-				userEmailAddress = ${userEmailAddress});
-
-			Navigator.openSpecificURL(url = "${portalURL}/web/guest?SM_USER=${userEmailAddress}");
 		}
+
+		JSONUser.agreeToTermsAndAnswerReminderQuery(
+			portalURL = ${portalURL},
+			userEmailAddress = ${userEmailAddress});
+
+		Navigator.openSpecificURL(url = "${portalURL}/web/guest?SM_USER=${userEmailAddress}");
 
 		// TODO Remove below macro after password reminder gets completely cleaned out with JSON
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/User.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/User.macro
@@ -2228,20 +2228,34 @@ definition {
 
 	@summary = "Default summary"
 	macro loginPG(idpName = null, password = null, virtualHostsURL = null, userScreenName = null, userEmailAddress = null, newPassword = null, rememberMeChecked = null, nodePort = null) {
-		JSONUser.agreeToTermsAndAnswerReminderQuery(
-			portalURL = ${virtualHostsURL},
-			userEmailAddress = ${userEmailAddress});
-
 		if (isSet(virtualHostsURL)) {
+			var portalURL = ${virtualHostsURL};
+
+			JSONUser.agreeToTermsAndAnswerReminderQuery(
+				portalURL = ${portalURL},
+				userEmailAddress = ${userEmailAddress});
+
 			Navigator.openSpecificURL(url = "${virtualHostsURL}/web/guest?SM_USER=${userEmailAddress}");
 		}
 		else if (isSet(nodePort)) {
 			var baseURL = "http://localhost:${nodePort}";
 
+			var portalURL = ${baseURL};
+
+			JSONUser.agreeToTermsAndAnswerReminderQuery(
+				portalURL = ${portalURL},
+				userEmailAddress = ${userEmailAddress});
+
 			Navigator.openSpecificURL(url = "${baseURL}/web/guest?SM_USER=${userEmailAddress}");
 		}
 		else {
 			var baseURL = JSONCompany.getPortalURL();
+
+			var portalURL = ${baseURL};
+
+			JSONUser.agreeToTermsAndAnswerReminderQuery(
+				portalURL = ${portalURL},
+				userEmailAddress = ${userEmailAddress});
 
 			Navigator.openSpecificURL(url = "${baseURL}/web/guest?SM_USER=${userEmailAddress}");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/user/JSONUserAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/user/JSONUserAPI.macro
@@ -241,7 +241,8 @@ definition {
 		var companyId = JSONCompany.getCompanyIdNoSelenium(
 			creatorEmailAddress = ${creatorEmailAddress},
 			creatorPassword = ${creatorPassword},
-			portalInstanceName = ${portalInstanceName});
+			portalInstanceName = ${portalInstanceName},
+			portalURL = ${specificURL});
 
 		if (isSet(specificURL)) {
 			var portalURL = ${specificURL};

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/user/JSONUserAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/user/JSONUserAPI.macro
@@ -238,12 +238,6 @@ definition {
 	macro _getUserIdByEmailAddress(portalInstanceName = null, userEmailAddress = null, specificURL = null) {
 		Variables.assertDefined(parameterList = ${userEmailAddress});
 
-		var companyId = JSONCompany.getCompanyIdNoSelenium(
-			creatorEmailAddress = ${creatorEmailAddress},
-			creatorPassword = ${creatorPassword},
-			portalInstanceName = ${portalInstanceName},
-			portalURL = ${specificURL});
-
 		if (isSet(specificURL)) {
 			var portalURL = ${specificURL};
 		}
@@ -263,6 +257,12 @@ definition {
 		if (!(isSet(creatorPassword))) {
 			var creatorPassword = JSONUtil2.getSuperAdminUserPassword();
 		}
+
+		var companyId = JSONCompany.getCompanyIdNoSelenium(
+			creatorEmailAddress = ${creatorEmailAddress},
+			creatorPassword = ${creatorPassword},
+			portalInstanceName = ${portalInstanceName},
+			portalURL = ${specificURL});
 
 		var curl = '''
 			${portalURL}/api/jsonws/user/get-user-by-email-address/company-id/${companyId}/email-address/${userEmailAddress} \


### PR DESCRIPTION
Hi Tina,

resend: https://github.com/liferay-core-infra/liferay-portal/pull/7265
As talked, in the clustering functional test, we will use 8080 for User.loginPG all the time even though we set nodeport 9080.
Trying to fix this in the PR
Thanks for checking