### PR TITLE
LPD-33593 upgrade wstx to 6.4.0 in lib/portal

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -159,6 +159,7 @@
 	<classpathentry kind="lib" path="lib/portal/spring-tx.jar"/>
 	<classpathentry kind="lib" path="lib/portal/spring-web.jar"/>
 	<classpathentry kind="lib" path="lib/portal/stax-ex.jar"/>
+	<classpathentry kind="lib" path="lib/portal/stax2-api.jar"/>
 	<classpathentry kind="lib" path="lib/portal/transaction.jar"/>
 	<classpathentry kind="lib" path="lib/portal/wstx.jar"/>
 	<classpathentry kind="lib" path="lib/portal/xercesImpl.jar"/>

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -131,6 +131,7 @@
 /portal/spring-tx.jar
 /portal/spring-web.jar
 /portal/stax-ex.jar
+/portal/stax2-api.jar
 /portal/transaction.jar
 /portal/wstx.jar
 /portal/xercesImpl.jar

--- a/lib/portal/dependencies.properties
+++ b/lib/portal/dependencies.properties
@@ -33,6 +33,6 @@ spring-tx=com.liferay:org.springframework.tx:5.3.33.LIFERAY-PATCHED-1
 spring-web=org.springframework:spring-web:5.3.34
 stax-ex=org.jvnet.staxex:stax-ex:1.2
 transaction=javax.transaction:javax.transaction-api:1.3
-wstx=org.codehaus.woodstox:wstx-asl:3.2.8
+wstx=com.fasterxml.woodstox:woodstox-core:6.4.0
 xercesImpl=xerces:xercesImpl:2.12.2
 xml-apis=xml-apis:xml-apis:1.4.01

--- a/lib/portal/dependencies.properties
+++ b/lib/portal/dependencies.properties
@@ -32,6 +32,7 @@ spring-orm=com.liferay:org.springframework.orm:5.3.33.LIFERAY-PATCHED-1
 spring-tx=com.liferay:org.springframework.tx:5.3.33.LIFERAY-PATCHED-1
 spring-web=org.springframework:spring-web:5.3.34
 stax-ex=org.jvnet.staxex:stax-ex:1.2
+stax2-api=org.codehaus.woodstox:stax2-api:4.2.1
 transaction=javax.transaction:javax.transaction-api:1.3
 wstx=com.fasterxml.woodstox:woodstox-core:6.4.0
 xercesImpl=xerces:xercesImpl:2.12.2

--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -5,14 +5,13 @@
 	<version>
 		<libraries>
 			<library>
-				<file-name>com.liferay.adaptive.media.image.impl.jar!metadata-extractor.jar</file-name>
-				<version>2.19.0</version>
-				<project-name>metadata-extractor</project-name>
-				<project-url>https://drewnoakes.com/code/exif/</project-url>
+				<file-name>com.liferay.adaptive.media.image.impl.jar!com.drew.metadata.jar</file-name>
+				<version>2.19.0.LIFERAY-PATCHED-1</version>
+				<project-name>com.drew.metadata</project-name>
 				<licenses>
 					<license>
-						<license-name>The Apache Software License, Version 2.0</license-name>
-						<license-url>http://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
+						<license-name>LGPL 2.1</license-name>
+						<license-url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt</license-url>
 					</license>
 				</licenses>
 			</library>
@@ -3770,6 +3769,17 @@
 				</licenses>
 			</library>
 			<library>
+				<file-name>com.liferay.portal.tika.jar!com.drew.metadata.jar</file-name>
+				<version>2.19.0.LIFERAY-PATCHED-1</version>
+				<project-name>com.drew.metadata</project-name>
+				<licenses>
+					<license>
+						<license-name>LGPL 2.1</license-name>
+						<license-url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt</license-url>
+					</license>
+				</licenses>
+			</library>
+			<library>
 				<file-name>com.liferay.portal.tika.jar!commons-exec.jar</file-name>
 				<version>1.3</version>
 				<project-name>Apache Commons Exec</project-name>
@@ -3850,18 +3860,6 @@
 					<license>
 						<license-name>Mozilla Public License 1.1 (MPL 1.1)</license-name>
 						<license-url>http://www.mozilla.org/MPL/MPL-1.1.html</license-url>
-					</license>
-				</licenses>
-			</library>
-			<library>
-				<file-name>com.liferay.portal.tika.jar!metadata-extractor.jar</file-name>
-				<version>2.19.0</version>
-				<project-name>metadata-extractor</project-name>
-				<project-url>https://drewnoakes.com/code/exif/</project-url>
-				<licenses>
-					<license>
-						<license-name>The Apache Software License, Version 2.0</license-name>
-						<license-url>http://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
 					</license>
 				</licenses>
 			</library>
@@ -5363,18 +5361,6 @@
 					<license>
 						<license-name>Apache License 2.0</license-name>
 						<license-url>http://www.apache.org/licenses/LICENSE-2.0.html</license-url>
-					</license>
-				</licenses>
-			</library>
-			<library>
-				<file-name>com.liferay.shared.dependencies.woodstox.core.jar!woodstox-core.jar</file-name>
-				<version>6.4.0</version>
-				<project-name>Woodstox</project-name>
-				<project-url>https://github.com/FasterXML/woodstox</project-url>
-				<licenses>
-					<license>
-						<license-name>The Apache Software License, Version 2.0</license-name>
-						<license-url>http://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
 					</license>
 				</licenses>
 			</library>
@@ -7113,6 +7099,18 @@
 				</licenses>
 			</library>
 			<library>
+				<file-name>lib/portal/stax2-api.jar</file-name>
+				<version>4.2.1</version>
+				<project-name>Stax2 API</project-name>
+				<project-url>http://github.com/FasterXML/stax2-api</project-url>
+				<licenses>
+					<license>
+						<license-name>The BSD License</license-name>
+						<license-url>http://www.opensource.org/licenses/bsd-license.php</license-url>
+					</license>
+				</licenses>
+			</library>
+			<library>
 				<file-name>lib/portal/transaction.jar</file-name>
 				<version>1.3</version>
 				<project-name>Project GlassFish Java Transaction API</project-name>
@@ -7124,7 +7122,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/wstx.jar</file-name>
-				<version>3.2.8</version>
+				<version>6.4.0</version>
 				<project-name>Woodstox</project-name>
 				<project-url>http://woodstox.codehaus.org</project-url>
 				<licenses>

--- a/lib/versions-ext.xml
+++ b/lib/versions-ext.xml
@@ -1529,7 +1529,7 @@
 			</library>
 			<library>
 				<file-name>lib/portal/wstx.jar</file-name>
-				<version>3.2.8</version>
+				<version>6.4.0</version>
 				<project-name>Woodstox</project-name>
 				<project-url>http://woodstox.codehaus.org</project-url>
 				<licenses>

--- a/lib/versions-ext.xml
+++ b/lib/versions-ext.xml
@@ -1518,6 +1518,18 @@
 				</licenses>
 			</library>
 			<library>
+				<file-name>lib/portal/stax2-api.jar</file-name>
+				<version>4.2.1</version>
+				<project-name>Stax2 API</project-name>
+				<project-url>http://github.com/FasterXML/stax2-api</project-url>
+				<licenses>
+					<license>
+						<license-name>The BSD License</license-name>
+						<license-url>http://www.opensource.org/licenses/bsd-license.php</license-url>
+					</license>
+				</licenses>
+			</library>
+			<library>
 				<file-name>lib/portal/transaction.jar</file-name>
 				<version>1.3</version>
 				<project-name>Project GlassFish Java Transaction API</project-name>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -44,7 +44,7 @@
 		
 			
 <tr>
-<td nowrap="nowrap">com.liferay.adaptive.media.image.impl.jar!metadata-extractor.jar</td><td nowrap="nowrap">2.19.0</td><td nowrap="nowrap"><a href="https://drewnoakes.com/code/exif/">metadata-extractor</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
+<td nowrap="nowrap">com.liferay.adaptive.media.image.impl.jar!com.drew.metadata.jar</td><td nowrap="nowrap">2.19.0.LIFERAY-PATCHED-1</td><td nowrap="nowrap">com.drew.metadata</td><td nowrap><a href="http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt">LGPL 2.1</a>
 <br>
 </td><td></td>
 </tr>
@@ -1970,6 +1970,12 @@
 </tr>
 			
 <tr>
+<td nowrap="nowrap">com.liferay.portal.tika.jar!com.drew.metadata.jar</td><td nowrap="nowrap">2.19.0.LIFERAY-PATCHED-1</td><td nowrap="nowrap">com.drew.metadata</td><td nowrap><a href="http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt">LGPL 2.1</a>
+<br>
+</td><td></td>
+</tr>
+			
+<tr>
 <td nowrap="nowrap">com.liferay.portal.tika.jar!commons-exec.jar</td><td nowrap="nowrap">1.3</td><td nowrap="nowrap"><a href="http://commons.apache.org/proper/commons-exec/">Apache Commons Exec</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
 <br>
 </td><td></td>
@@ -2007,12 +2013,6 @@
 			
 <tr>
 <td nowrap="nowrap">com.liferay.portal.tika.jar!juniversalchardet.jar</td><td nowrap="nowrap">1.0.3</td><td nowrap="nowrap"><a href="http://juniversalchardet.googlecode.com/">juniversalchardet</a></td><td nowrap><a href="http://www.mozilla.org/MPL/MPL-1.1.html">Mozilla Public License 1.1 (MPL 1.1)</a>
-<br>
-</td><td></td>
-</tr>
-			
-<tr>
-<td nowrap="nowrap">com.liferay.portal.tika.jar!metadata-extractor.jar</td><td nowrap="nowrap">2.19.0</td><td nowrap="nowrap"><a href="https://drewnoakes.com/code/exif/">metadata-extractor</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -2775,12 +2775,6 @@
 			
 <tr>
 <td nowrap="nowrap">com.liferay.shared.dependencies.swagger.jar!swagger-models.jar</td><td nowrap="nowrap">2.0.6</td><td nowrap="nowrap">swagger-models</td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache License 2.0</a>
-<br>
-</td><td></td>
-</tr>
-			
-<tr>
-<td nowrap="nowrap">com.liferay.shared.dependencies.woodstox.core.jar!woodstox-core.jar</td><td nowrap="nowrap">6.4.0</td><td nowrap="nowrap"><a href="https://github.com/FasterXML/woodstox">Woodstox</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -3662,13 +3656,19 @@
 </tr>
 			
 <tr>
+<td nowrap="nowrap">lib/portal/stax2-api.jar</td><td nowrap="nowrap">4.2.1</td><td nowrap="nowrap"><a href="http://github.com/FasterXML/stax2-api">Stax2 API</a></td><td nowrap><a href="http://www.opensource.org/licenses/bsd-license.php">The BSD License</a>
+<br>
+</td><td></td>
+</tr>
+			
+<tr>
 <td nowrap="nowrap">lib/portal/transaction.jar</td><td nowrap="nowrap">1.3</td><td nowrap="nowrap"><a href="http://jta-spec.java.net">Project GlassFish Java Transaction API</a></td><td nowrap><a href=""></a>
 <br>
 </td><td></td>
 </tr>
 			
 <tr>
-<td nowrap="nowrap">lib/portal/wstx.jar</td><td nowrap="nowrap">3.2.8</td><td nowrap="nowrap"><a href="http://woodstox.codehaus.org">Woodstox</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
+<td nowrap="nowrap">lib/portal/wstx.jar</td><td nowrap="nowrap">6.4.0</td><td nowrap="nowrap"><a href="http://woodstox.codehaus.org">Woodstox</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>
 <br>
 </td><td></td>
 </tr>

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/build.gradle
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/build.gradle
@@ -113,15 +113,6 @@ deploy {
 	finalizedBy deploySidecar
 }
 
-deployDependencies {
-	from configurations.compileOnly
-
-	include "stax2-api-*.jar"
-
-	rename(/stax2-api-(.+)\.jar/, "org.codehaus.stax2" + renameSuffix)
-
-}
-
 deploySidecar {
 	dependsOn cleanSidecar
 

--- a/modules/apps/shared-dependencies/shared-dependencies-woodstox-core/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-woodstox-core/bnd.bnd
@@ -1,4 +1,0 @@
-Bundle-Name: Liferay Shared Dependencies woodstox-core
-Bundle-SymbolicName: com.liferay.shared.dependencies.woodstox.core
-Bundle-Version: 1.0.3
--exportcontents: com.ctc.wstx.*

--- a/modules/apps/shared-dependencies/shared-dependencies-woodstox-core/build.gradle
+++ b/modules/apps/shared-dependencies/shared-dependencies-woodstox-core/build.gradle
@@ -1,3 +1,0 @@
-dependencies {
-	compileInclude group: "com.fasterxml.woodstox", name: "woodstox-core", version: "6.4.0"
-}

--- a/modules/core/portal-bootstrap/system.packages.extra.bnd
+++ b/modules/core/portal-bootstrap/system.packages.extra.bnd
@@ -191,6 +191,8 @@ Export-Package:\
 	org.apache.xmlcommons;version='1.4.01',\
 	org.apache.xpath.*;version='2.7.1',\
 	\
+	org.codehaus.stax2.*;version='4.2.1',\
+	\
 	org.dom4j.*;version='2.1.3',\
 	\
 	org.hibernate.engine.jdbc.batch.internal;version='5.6.7',\
@@ -271,6 +273,7 @@ Provide-Capability:\
 	@../../../lib/portal/spring-orm.jar,\
 	@../../../lib/portal/spring-tx.jar,\
 	@../../../lib/portal/spring-web.jar,\
+	@../../../lib/portal/stax2-api.jar,\
 	@../../../lib/portal/wstx.jar,\
 	@../../../lib/portal/xercesImpl.jar,\
 	@../../../lib/portal/xml-apis.jar,\

--- a/modules/core/portal-bootstrap/system.packages.extra.bnd
+++ b/modules/core/portal-bootstrap/system.packages.extra.bnd
@@ -91,6 +91,8 @@ Export-Package:\
 	\
 	!unicode-license.txt,\
 	\
+	com.ctc.wstx.*;version='6.4.0',\
+	\
 	com.ibm.crypto.provider,\
 	\
 	com.sun.security.auth.module,\
@@ -269,6 +271,7 @@ Provide-Capability:\
 	@../../../lib/portal/spring-orm.jar,\
 	@../../../lib/portal/spring-tx.jar,\
 	@../../../lib/portal/spring-web.jar,\
+	@../../../lib/portal/wstx.jar,\
 	@../../../lib/portal/xercesImpl.jar,\
 	@../../../lib/portal/xml-apis.jar,\
 	@../../../portal-impl/portal-impl.jar,\

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -128,6 +128,7 @@ javac.classpath=\
     lib/portal/spring-tx.jar:\
     lib/portal/spring-web.jar:\
     lib/portal/stax-ex.jar:\
+    lib/portal/stax2-api.jar:\
     lib/portal/transaction.jar:\
     lib/portal/wstx.jar:\
     lib/portal/xercesImpl.jar:\

--- a/portal-impl/test/unit/com/liferay/portal/security/xml/SecureXMLFactoryProviderImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/security/xml/SecureXMLFactoryProviderImplTest.java
@@ -5,6 +5,8 @@
 
 package com.liferay.portal.security.xml;
 
+import com.ctc.wstx.api.WstxInputProperties;
+
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.NewEnv;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -123,6 +125,10 @@ public class SecureXMLFactoryProviderImplTest {
 			public void run(String xml) throws Exception {
 				XMLInputFactory xmlInputFactory =
 					_secureXMLFactoryProviderImpl.newXMLInputFactory();
+
+				xmlInputFactory.setProperty(
+					WstxInputProperties.P_MAX_ENTITY_COUNT,
+					Integer.valueOf(Integer.MAX_VALUE));
 
 				XMLEventReader xmlEventReader =
 					xmlInputFactory.createXMLEventReader(new StringReader(xml));


### PR DESCRIPTION
Hi Tina,

This is for ticket https://liferay.atlassian.net/browse/LPD-33593.
As discussed, I am upgrading wstx to 6.4.0 in lib/portal, in order to make it work as wstx-6.4.0 needs stax2-api, I also needed to add back stax2-api in lib/portal.
Thanks for checking.