### PR TITLE
LPD-37552 clean up removed spring jars in source-formatter

### DIFF
--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -692,18 +692,13 @@
         org.osgi:osgi.core:6.0.0,\
         org.slf4j:slf4j-api:1.7.26,\
         org.springframework:spring-aop:5.3.39,\
-        org.springframework:spring-aspects:5.3.39,\
         org.springframework:spring-context:5.3.39,\
-        org.springframework:spring-context-support:5.3.39,\
         org.springframework:spring-core:5.3.39,\
         org.springframework:spring-expression:5.3.39,\
         org.springframework:spring-instrument:5.3.39,\
         org.springframework:spring-jdbc:5.3.39,\
-        org.springframework:spring-jms:5.3.39,\
-        org.springframework:spring-oxm:5.3.39,\
         org.springframework:spring-test:5.3.39,\
         org.springframework:spring-web:5.3.39,\
-        org.springframework:spring-webmvc:5.3.39,\
         org.springframework.boot:spring-boot:2.7.18,\
         org.springframework.boot:spring-boot-gradle-plugin:2.7.18,\
         org.springframework.boot:spring-boot-starter-activemq:2.7.18,\


### PR DESCRIPTION
Hi Tina, 
This is for ticket https://liferay.atlassian.net/browse/LPD-37552.
We are not using spring-webmvc in master, and it has been removed in https://liferay.atlassian.net/browse/LPS-151777
In the security bug ticket, it detect the usgea of webmvc in source-formatter only, and I am cleaning up the source-formatter in this PR so that we won't have this issue next time
Thanks for checking