### PR TITLE
LPD-38562 Apply HtmlUtil.escape to avoid xss in radio button type custom fields

### DIFF
--- a/modules/apps/expando/expando-web/src/main/java/com/liferay/expando/web/internal/portlet/ExpandoPortlet.java
+++ b/modules/apps/expando/expando-web/src/main/java/com/liferay/expando/web/internal/portlet/ExpandoPortlet.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -409,7 +410,8 @@ public class ExpandoPortlet extends MVCPortlet {
 			value = GetterUtil.getShortValues(values);
 		}
 		else if (type == ExpandoColumnConstants.STRING_ARRAY) {
-			String paramValue = ParamUtil.getString(portletRequest, name);
+			String paramValue = HtmlUtil.escape(
+				ParamUtil.getString(portletRequest, name));
 
 			if (paramValue.contains(StringPool.NEW_LINE)) {
 				delimiter = StringPool.NEW_LINE;


### PR DESCRIPTION
Hi Tina,

This is for https://liferay.atlassian.net/browse/LPD-38562
When we are creating radio button type custom fields, people can inject a javascript into the values.
![Screenshot_20241009_110600](https://github.com/user-attachments/assets/a76960bc-9e77-4fc3-bcbe-edffbb3fa2ef)
we have three kinds of data type: integer, decimal and text.
When we are using integer or decimal, even though we input a javascript into the values, it will get filtered later by GetterUtil, and replace the javascript with default value.
Therefore, text is the only kind of type that we need to take care of, and I try to avoid this xss attack by simply apply HtmlUtil.escape()
Thanks for checking.