### PR TITLE
LPD-38562 Apply HtmlUtil.escape to avoid xss in radio and checkbox type custom fields

### DIFF
--- a/modules/apps/expando/expando-taglib/src/main/resources/META-INF/resources/custom_attribute/page.jsp
+++ b/modules/apps/expando/expando-taglib/src/main/resources/META-INF/resources/custom_attribute/page.jsp
@@ -564,7 +564,7 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 									for (String curDefaultValue : (String[])defaultValue) {
 									%>
 
-										<aui:input checked="<%= (curValue.length > 0) && ArrayUtil.contains(curValue, curDefaultValue) %>" id="<%= StringUtil.randomId() %>" label="<%= String.valueOf(curDefaultValue) %>" name='<%= "ExpandoAttribute--" + HtmlUtil.escapeAttribute(name) + "--" %>' type="checkbox" value="<%= curDefaultValue %>" />
+										<aui:input checked="<%= (curValue.length > 0) && ArrayUtil.contains(curValue, curDefaultValue) %>" id="<%= StringUtil.randomId() %>" label="<%= HtmlUtil.escape(String.valueOf(curDefaultValue)) %>" name='<%= "ExpandoAttribute--" + HtmlUtil.escapeAttribute(name) + "--" %>' type="checkbox" value="<%= curDefaultValue %>" />
 
 									<%
 									}
@@ -577,7 +577,7 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 									for (String curDefaultValue : (String[])defaultValue) {
 									%>
 
-										<aui:input checked="<%= (curValue.length > 0) && ArrayUtil.contains(curValue, curDefaultValue) %>" label="<%= curDefaultValue %>" name='<%= "ExpandoAttribute--" + HtmlUtil.escapeAttribute(name) + "--" %>' type="radio" value="<%= curDefaultValue %>" />
+										<aui:input checked="<%= (curValue.length > 0) && ArrayUtil.contains(curValue, curDefaultValue) %>" label="<%= HtmlUtil.escape(curDefaultValue) %>" name='<%= "ExpandoAttribute--" + HtmlUtil.escapeAttribute(name) + "--" %>' type="radio" value="<%= curDefaultValue %>" />
 
 									<%
 									}


### PR DESCRIPTION
Hi Tina,

Resent https://github.com/liferay-core-infra/liferay-portal/pull/7570#event-14789498729

By diving deeper in `<aui:input cssClass="lfr-textarea-container" helpMessage="enter-one-value-per-line" label="values" name="defaultValue" required="<%= true %>" type="textarea" value="<%= values %>" />`
please see [the link](https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/edit/default_value_input.jspf#L53), the value that we input has been escaped [here](https://github.com/liferay/liferay-portal/blob/7.4.3.128-ga128/portal-web/docroot/html/taglib/aui/input/page.jsp#L317) while presenting, that's why when we reopen the edit link, there is no XSS attack. As we did not modify the value we stored at the server side, then we will also see the same value when we reopen the edit link.

To avoid XSS, instead of escaping the input value while storing, we should escape it while presentening, so that the value that the user input will keep consistent.

Therefore, what I did in this PR is to escape the label that attach to the checkbox and radio while presetning on the browser to avoid xss attack.

Thanks for checking.
