### PR TITLE
LPD-45340 block sensible user data access in freemarker

### DIFF
--- a/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/configuration/FreeMarkerEngineConfiguration.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/configuration/FreeMarkerEngineConfiguration.java
@@ -62,7 +62,7 @@ public interface FreeMarkerEngineConfiguration {
 	public String[] restrictedClasses();
 
 	@Meta.AD(
-		deflt = "com.liferay.portal.model.impl.CompanyImpl#getKey",
+		deflt = "com.liferay.portal.model.impl.CompanyImpl#getKey|com.liferay.portal.model.impl.UserImpl#getPassword|com.liferay.portal.model.impl.UserImpl#getPasswordEncrypted|com.liferay.portal.model.impl.UserImpl#getPasswordReset|com.liferay.portal.model.impl.UserImpl#getReminderQueryQuestion|com.liferay.portal.model.impl.UserImpl#getReminderQueryAnswer|com.liferay.portal.model.impl.UserImpl#getLoginDate|com.liferay.portal.model.impl.UserImpl#getLoginIP|com.liferay.portal.model.impl.UserImpl#getLastLoginDate|com.liferay.portal.model.impl.UserImpl#getLastLoginIP|com.liferay.portal.model.impl.UserImpl#getLastFailedLoginDate|com.liferay.portal.model.impl.UserImpl#toString",
 		name = "restricted-methods", required = false
 	)
 	public String[] restrictedMethods();

--- a/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/internal/LiferayFreeMarkerStringModel.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/internal/LiferayFreeMarkerStringModel.java
@@ -49,6 +49,33 @@ public class LiferayFreeMarkerStringModel extends StringModel {
 		return super.get(key);
 	}
 
+	@Override
+	public String getAsString() {
+		try {
+			if (_restrictedMethodNames == null) {
+				throw new TemplateModelException(
+					"Denied access to method or field toString of " +
+						object.getClass());
+			}
+
+			for (String restrictedMethodName : _restrictedMethodNames) {
+				if (restrictedMethodName.endsWith(
+						StringUtil.toLowerCase("toString"))) {
+
+					throw new TemplateModelException(
+						"Denied access to method or field toString of " +
+							object.getClass());
+				}
+			}
+
+			return super.getAsString();
+		}
+		catch (TemplateModelException templateModelException) {
+			throw new RuntimeException(
+				templateModelException.getMessage(), templateModelException);
+		}
+	}
+
 	public void setRestrictedMethodNames(Set<String> restrictedMethodNames) {
 		_restrictedMethodNames = restrictedMethodNames;
 	}

--- a/modules/apps/portal-template/portal-template-freemarker/src/test/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapperTest.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/test/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapperTest.java
@@ -280,6 +280,37 @@ public class RestrictedLiferayObjectWrapperTest
 		}
 	}
 
+	@Test
+	public void testRestrictedMethodToString() throws Exception {
+		RestrictedLiferayObjectWrapper restrictedLiferayObjectWrapper =
+			new RestrictedLiferayObjectWrapper(
+				null, null,
+				new String[] {
+					TestLiferayMethodObject.class.getName() + "#toString"
+				});
+
+		TemplateModel templateModel = restrictedLiferayObjectWrapper.wrap(
+			new TestLiferayMethodObject("test"));
+
+		Assert.assertThat(
+			templateModel,
+			CoreMatchers.instanceOf(LiferayFreeMarkerStringModel.class));
+
+		LiferayFreeMarkerStringModel liferayFreeMarkerStringModel =
+			(LiferayFreeMarkerStringModel)templateModel;
+
+		_testRestrictedMethodToString(liferayFreeMarkerStringModel);
+
+		SimpleMethodModel simpleMethodModel =
+			(SimpleMethodModel)liferayFreeMarkerStringModel.get("generate");
+
+		TemplateModel resultTemplateModel =
+			(TemplateModel)simpleMethodModel.exec(
+				Collections.singletonList(new SimpleScalar("generate")));
+
+		Assert.assertEquals("test-generate", resultTemplateModel.toString());
+	}
+
 	@NewEnv(type = NewEnv.Type.CLASSLOADER)
 	@Test
 	public void testWrapWithCompanyRestrictForFalse() throws Exception {
@@ -536,6 +567,29 @@ public class RestrictedLiferayObjectWrapperTest
 					"Denied access to method or field ", key, " of ",
 					TestLiferayMethodObject.class),
 				templateModelException.getMessage());
+		}
+	}
+
+	private void _testRestrictedMethodToString(
+		LiferayFreeMarkerStringModel liferayFreeMarkerStringModel) {
+
+		try {
+			liferayFreeMarkerStringModel.getAsString();
+
+			Assert.fail("Should throw RuntimeException for toString");
+		}
+		catch (RuntimeException runtimeException) {
+			Throwable throwable = runtimeException.getCause();
+
+			Assert.assertTrue(
+				"Expected TemplateModelException but got " +
+					throwable.getClass(),
+				throwable instanceof TemplateModelException);
+
+			Assert.assertEquals(
+				"Denied access to method or field toString of " +
+					TestLiferayMethodObject.class,
+				runtimeException.getMessage());
 		}
 	}
 

--- a/modules/apps/portal-template/portal-template-freemarker/src/test/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapperTest.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/test/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapperTest.java
@@ -227,7 +227,8 @@ public class RestrictedLiferayObjectWrapperTest
 			new RestrictedLiferayObjectWrapper(
 				null, null,
 				new String[] {
-					TestLiferayMethodObject.class.getName() + "#getName"
+					TestLiferayMethodObject.class.getName() + "#getName",
+					TestLiferayMethodObject.class.getName() + "#toString"
 				});
 
 		TemplateModel templateModel = restrictedLiferayObjectWrapper.wrap(
@@ -244,6 +245,7 @@ public class RestrictedLiferayObjectWrapperTest
 		_testRestrictedMethodNames(liferayFreeMarkerStringModel, "Name");
 		_testRestrictedMethodNames(liferayFreeMarkerStringModel, "getName");
 		_testRestrictedMethodNames(liferayFreeMarkerStringModel, "getname");
+		_testRestrictedMethodToString(liferayFreeMarkerStringModel);
 
 		SimpleMethodModel simpleMethodModel =
 			(SimpleMethodModel)liferayFreeMarkerStringModel.get("generate");
@@ -278,37 +280,6 @@ public class RestrictedLiferayObjectWrapperTest
 					"\"className#methodName\""),
 				logEntry.getMessage());
 		}
-	}
-
-	@Test
-	public void testRestrictedMethodToString() throws Exception {
-		RestrictedLiferayObjectWrapper restrictedLiferayObjectWrapper =
-			new RestrictedLiferayObjectWrapper(
-				null, null,
-				new String[] {
-					TestLiferayMethodObject.class.getName() + "#toString"
-				});
-
-		TemplateModel templateModel = restrictedLiferayObjectWrapper.wrap(
-			new TestLiferayMethodObject("test"));
-
-		Assert.assertThat(
-			templateModel,
-			CoreMatchers.instanceOf(LiferayFreeMarkerStringModel.class));
-
-		LiferayFreeMarkerStringModel liferayFreeMarkerStringModel =
-			(LiferayFreeMarkerStringModel)templateModel;
-
-		_testRestrictedMethodToString(liferayFreeMarkerStringModel);
-
-		SimpleMethodModel simpleMethodModel =
-			(SimpleMethodModel)liferayFreeMarkerStringModel.get("generate");
-
-		TemplateModel resultTemplateModel =
-			(TemplateModel)simpleMethodModel.exec(
-				Collections.singletonList(new SimpleScalar("generate")));
-
-		Assert.assertEquals("test-generate", resultTemplateModel.toString());
 	}
 
 	@NewEnv(type = NewEnv.Type.CLASSLOADER)


### PR DESCRIPTION
Hi Tina,

This is for https://liferay.atlassian.net/browse/LPD-45340.
I have test locally by calling all the sensitive get method likd ${user.getPassword()} , and also ${user}, ${user.toString()), they all get blocked.
Thanks for checking