### PR TITLE
LPD-53769 set preservelastmodified to true for jakarta

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -2469,6 +2469,7 @@ war.path=${app.server.portal.dir}/</echo>
 						<delete dir="${test.app.server.parent.dir}" />
 
 						<copy
+							preservelastmodified="true"
 							todir="${test.app.server.parent.dir}"
 						>
 							<fileset


### PR DESCRIPTION
Hi Tina, 

This PR is to set preservelastmodified to true while we are runing clustering test on Jakarta PR with jspc on. 
In CI, it will go through a zipping process, which makes the file timestamp mismatch, es the captured timestamp of init.jsp, and this leads to the test time out.
