### PR TITLE
LPD-53794 fix "bun dle" cannot be read by tomcat 10

### DIFF
--- a/build-dist.xml
+++ b/build-dist.xml
@@ -659,7 +659,7 @@ java -jar ${app.server.weblogic.dir}/${app.server.weblogic.jar.name} -ignoreSysP
 				<matches pattern="10\.\d+\.\d+" string="${app.server.tomcat.version}" />
 			</and>
 			<then>
-				<var name="transformer.agent" value="-javaagent:${CATALINA_HOME}/../tools/portal-tools-jakarta-ee-transformer/com.liferay.portal.tools.jakarta.ee.transformer.jar" />
+				<var name="transformer.agent" value="\&quot;-javaagent:${CATALINA_HOME}/../tools/portal-tools-jakarta-ee-transformer/com.liferay.portal.tools.jakarta.ee.transformer.jar\&quot;" />
 
 				<if>
 					<not>


### PR DESCRIPTION
Hi Tina, 

In Jakarta PR, when we are using tomcat 10, it cannot see "bun dle" as a whole part, and it will break the path with "bun" only. Wrapping them with quation mark in where we add this CATALINA_Home to fix the issue.