### PR TITLE
LPD-56178 work on  "captcha.enforce.disabled=true"

### DIFF
--- a/modules/test/playwright/env/portal-ext.properties
+++ b/modules/test/playwright/env/portal-ext.properties
@@ -8,3 +8,5 @@ setup.wizard.enabled=false
 virtual.hosts.default.site.name=
 virtual.hosts.valid.hosts=*
 web.server.http.port=8080
+
+captcha.enforce.disabled=true

--- a/modules/test/playwright/tests/account-admin-web/main/env/portal-ext.properties
+++ b/modules/test/playwright/tests/account-admin-web/main/env/portal-ext.properties
@@ -1,3 +1,1 @@
 company.security.strangers.verify=false
-
-captcha.enforce.disabled=true

--- a/modules/test/playwright/tests/document-library-web/main/env/portal-ext.properties
+++ b/modules/test/playwright/tests/document-library-web/main/env/portal-ext.properties
@@ -1,3 +1,1 @@
 dl.actions.visible=true
-
-captcha.enforce.disabled=true

--- a/modules/test/playwright/tests/layout-set-prototype-web/main/env/portal-ext.properties
+++ b/modules/test/playwright/tests/layout-set-prototype-web/main/env/portal-ext.properties
@@ -1,1 +1,0 @@
-captcha.enforce.disabled=true

--- a/modules/test/playwright/tests/portal-security-ldap/main/env/portal-ext.properties
+++ b/modules/test/playwright/tests/portal-security-ldap/main/env/portal-ext.properties
@@ -1,1 +1,0 @@
-captcha.enforce.disabled=true

--- a/modules/test/playwright/tests/saml-web/main/env/portal-ext.properties
+++ b/modules/test/playwright/tests/saml-web/main/env/portal-ext.properties
@@ -1,1 +1,0 @@
-captcha.enforce.disabled=true

--- a/modules/test/playwright/tests/scim-configuration-web/main/env/portal-ext.properties
+++ b/modules/test/playwright/tests/scim-configuration-web/main/env/portal-ext.properties
@@ -1,2 +1,1 @@
-captcha.enforce.disabled=true
 feature.flag.LPS-96845=true

--- a/portal-impl/src/portal-developer.properties
+++ b/portal-impl/src/portal-developer.properties
@@ -23,3 +23,7 @@ template.engine.cache.enabled=false
 com.liferay.portal.servlet.filters.etag.ETagFilter=false
 com.liferay.portal.servlet.filters.header.HeaderFilter=false
 com.liferay.portal.servlet.filters.themepreview.ThemePreviewFilter=true
+
+captcha.enforce.disabled=true
+
+configuration.override.com.liferay.captcha.configuration.CaptchaConfiguration_maxChallenges=I"-1"


### PR DESCRIPTION
Hi Tina, 

This is for https://liferay.atlassian.net/browse/LPD-57068
I am adding both 
```
captcha.enforce.disabled=true
configuration.override.com.liferay.captcha.configuration.CaptchaConfiguration_maxChallenges=I"-1"
``` 
to portal-developer.properties. If the users would like to turn it off, they can easily override to use this properties in portal-ext.properties.

For the test side: As there are some require captcha, then we cannot easily turn off captcha for all the test.
Therefore, 
**for poshi test:** we manully set `captcha.enforce.disabled=true`, so the captcha are not enforced and able to be override by maxChallenges. This maxChallenges are set to -1 by default in poshi test, unless the test need captcha and will bypass this.
**for playwright test:** we will also set this `captcha.enforce.disabled=true` by default, which means the default value will be 1, and captcha will show only once, which will allow the test to test captcha by default. If the test need to get rid of captcha, then they can apply maxChallenges=-1 by themselves. 