### PR TITLE
[Test Fix] LPD-59371

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/User.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/User.macro
@@ -130,7 +130,7 @@ definition {
 			var localizedSignIn = "登录";
 		}
 		else if (${localization} == "IT") {
-			var localizedSignIn = "Accedi";
+			var localizedSignIn = "Login";
 		}
 		else if (${localization} == "ES") {
 			var localizedSignIn = "Acceder";


### PR DESCRIPTION
This fix is for these functional tests:

- [LocalFile.Locale#ViewLocaleInNewVirtualInstance](https://testray.liferay.com/home#/project/35392/routines/82964/build/231094326/case-result/231218759)
- [LocalFile.Locale#LanguageWithVariantDoesNotCauseInfiniteRedirectLoop](https://testray.liferay.com/home#/project/35392/routines/82964/build/231094326/case-result/231132526)

The functional tests fail because they are not able to locate the "Sign In" button when using the Italian locale (`it`). The fix looks strange, but it is technically correct:
- <https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties#L17333>
- <https://github.com/liferay/liferay-portal/commit/28688f6bc60c895425a27673cc95cc34419e3cda>