### PR TITLE
LPD-61385 Add JAXRSResourceTest to stable routine

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -2283,6 +2283,7 @@
         ${test.batch.class.names.excludes},\
         **/batch-planner/**/*Test.java,\
         **/headless-builder/**/*Test.java,\
+        **/jaxrs-resource-test/**/JAXRSResourceTest.java,\
         **/mulesoft/**/*Test.java,\
         **/portal-search-opensearch2/**/*Test.java,\
         **/sdk/**/gradleTest/**/*Test.java,\


### PR DESCRIPTION
<https://liferay.atlassian.net/browse/LPD-61385>

Adding `JAXRSResourceTest.java` to `stable` so we can enforce [LPD-11531](https://liferay.atlassian.net/browse/LPD-11531) and prevent cases like [LPD-61384](https://liferay.atlassian.net/browse/LPD-61384).

[LPD-11531]: https://liferay.atlassian.net/browse/LPD-11531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-61384]: https://liferay.atlassian.net/browse/LPD-61384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ