### PR TITLE
LPD-62070 Upgrade nimbus-jose-jwt to 10.0.2

### DIFF
--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -5345,7 +5345,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.shared.dependencies.netty.jar!nimbus-jose-jwt.jar</file-name>
-				<version>9.40</version>
+				<version>10.0.2</version>
 				<project-name>Nimbus JOSE+JWT</project-name>
 				<project-url>https://connect2id.com</project-url>
 				<licenses>
@@ -5405,7 +5405,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.shared.dependencies.nimbusds.jar!nimbus-jose-jwt.jar</file-name>
-				<version>9.40</version>
+				<version>10.0.2</version>
 				<project-name>Nimbus JOSE+JWT</project-name>
 				<project-url>https://connect2id.com</project-url>
 				<licenses>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -2781,7 +2781,7 @@
                 </tr>
                 			
                 <tr>
-                    <td nowrap="nowrap">com.liferay.shared.dependencies.netty.jar!nimbus-jose-jwt.jar</td><td nowrap="nowrap">9.40</td><td nowrap="nowrap"><a href="https://connect2id.com">Nimbus JOSE+JWT</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
+                    <td nowrap="nowrap">com.liferay.shared.dependencies.netty.jar!nimbus-jose-jwt.jar</td><td nowrap="nowrap">10.0.2</td><td nowrap="nowrap"><a href="https://connect2id.com">Nimbus JOSE+JWT</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
                         <br>
                     </td><td></td>
                 </tr>
@@ -2811,7 +2811,7 @@
                 </tr>
                 			
                 <tr>
-                    <td nowrap="nowrap">com.liferay.shared.dependencies.nimbusds.jar!nimbus-jose-jwt.jar</td><td nowrap="nowrap">9.40</td><td nowrap="nowrap"><a href="https://connect2id.com">Nimbus JOSE+JWT</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
+                    <td nowrap="nowrap">com.liferay.shared.dependencies.nimbusds.jar!nimbus-jose-jwt.jar</td><td nowrap="nowrap">10.0.2</td><td nowrap="nowrap"><a href="https://connect2id.com">Nimbus JOSE+JWT</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
                         <br>
                     </td><td></td>
                 </tr>

--- a/modules/apps/mail/mail-outlook-auth-connector-provider/build.gradle
+++ b/modules/apps/mail/mail-outlook-auth-connector-provider/build.gradle
@@ -4,7 +4,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.nimbusds", name: "content-type", version: "2.3"
 	compileOnly group: "com.nimbusds", name: "lang-tag", version: "1.7"
-	compileOnly group: "com.nimbusds", name: "nimbus-jose-jwt", version: "9.40"
+	compileOnly group: "com.nimbusds", name: "nimbus-jose-jwt", version: "10.0.2"
 	compileOnly group: "com.nimbusds", name: "oauth2-oidc-sdk", version: "11.13"
 	compileOnly group: "net.minidev", name: "accessors-smart", version: "2.4.9"
 	compileOnly group: "net.minidev", name: "json-smart", version: "2.4.10"

--- a/modules/apps/oauth-client/oauth-client-persistence-service/build.gradle
+++ b/modules/apps/oauth-client/oauth-client-persistence-service/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.nimbusds", name: "content-type", version: "2.3"
 	compileOnly group: "com.nimbusds", name: "lang-tag", version: "1.7"
-	compileOnly group: "com.nimbusds", name: "nimbus-jose-jwt", version: "9.40"
+	compileOnly group: "com.nimbusds", name: "nimbus-jose-jwt", version: "10.0.2"
 	compileOnly group: "com.nimbusds", name: "oauth2-oidc-sdk", version: "11.13"
 	compileOnly group: "jakarta.activation", name: "jakarta.activation-api", version: "2.1.3"
 	compileOnly group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/build.gradle
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.nimbusds", name: "content-type", version: "2.3"
 	compileOnly group: "com.nimbusds", name: "lang-tag", version: "1.7"
-	compileOnly group: "com.nimbusds", name: "nimbus-jose-jwt", version: "9.40"
+	compileOnly group: "com.nimbusds", name: "nimbus-jose-jwt", version: "10.0.2"
 	compileOnly group: "com.nimbusds", name: "oauth2-oidc-sdk", version: "11.13"
 	compileOnly group: "jakarta.activation", name: "jakarta.activation-api", version: "2.1.3"
 	compileOnly group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-service/build.gradle
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-service/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.nimbusds", name: "content-type", version: "2.3"
 	compileOnly group: "com.nimbusds", name: "lang-tag", version: "1.7"
-	compileOnly group: "com.nimbusds", name: "nimbus-jose-jwt", version: "9.40"
+	compileOnly group: "com.nimbusds", name: "nimbus-jose-jwt", version: "10.0.2"
 	compileOnly group: "com.nimbusds", name: "oauth2-oidc-sdk", version: "11.13"
 	compileOnly group: "net.minidev", name: "accessors-smart", version: "2.4.9"
 	compileOnly group: "net.minidev", name: "json-smart", version: "2.4.10"

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-test/build.gradle
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-test/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
 	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
-	testIntegrationImplementation group: "com.nimbusds", name: "nimbus-jose-jwt", version: "9.40"
+	testIntegrationImplementation group: "com.nimbusds", name: "nimbus-jose-jwt", version: "10.0.2"
 	testIntegrationImplementation group: "com.nimbusds", name: "oauth2-oidc-sdk", version: "11.13"
 	testIntegrationImplementation project(":apps:oauth-client:oauth-client-persistence-api")
 	testIntegrationImplementation project(":apps:portal-security-sso:portal-security-sso-openid-connect-api")

--- a/modules/apps/portal-store/portal-store-azure/build.gradle
+++ b/modules/apps/portal-store/portal-store-azure/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.nimbusds", name: "content-type", version: "2.3"
 	compileOnly group: "com.nimbusds", name: "lang-tag", version: "1.7"
-	compileOnly group: "com.nimbusds", name: "nimbus-jose-jwt", version: "9.40"
+	compileOnly group: "com.nimbusds", name: "nimbus-jose-jwt", version: "10.0.2"
 	compileOnly group: "com.nimbusds", name: "oauth2-oidc-sdk", version: "11.13"
 	compileOnly group: "io.netty", name: "netty-buffer", version: "4.1.119.Final"
 	compileOnly group: "io.netty", name: "netty-codec", version: "4.1.119.Final"

--- a/modules/apps/shared-dependencies/shared-dependencies-netty/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-netty/bnd.bnd
@@ -4,7 +4,11 @@ Bundle-Version: 1.0.9
 Import-Package:\
 	!com.aayushatharva.brotli4j.*,\
 	\
+	!com.github.luben.zstd,\
 	!com.github.luben.zstd.util.*,\
+	\
+	!com.google.crypto.tink.subtle.*,\
+	!com.google.errorprone.annotations.*,\
 	\
 	!com.nimbusds.common.contenttype.*,\
 	!com.nimbusds.langtag.*,\

--- a/modules/apps/shared-dependencies/shared-dependencies-netty/build.gradle
+++ b/modules/apps/shared-dependencies/shared-dependencies-netty/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-	compileInclude group: "com.nimbusds", name: "nimbus-jose-jwt", version: "9.40"
+	compileInclude group: "com.nimbusds", name: "nimbus-jose-jwt", version: "10.0.2"
 	compileInclude group: "com.nimbusds", name: "oauth2-oidc-sdk", version: "11.13"
 	compileInclude group: "io.netty", name: "netty-buffer", version: "4.1.119.Final"
 	compileInclude group: "io.netty", name: "netty-codec", version: "4.1.119.Final"

--- a/modules/apps/shared-dependencies/shared-dependencies-nimbusds/bnd.bnd
+++ b/modules/apps/shared-dependencies/shared-dependencies-nimbusds/bnd.bnd
@@ -3,6 +3,7 @@ Bundle-SymbolicName: com.liferay.shared.dependencies.nimbusds
 Bundle-Version: 1.0.3
 Import-Package:\
 	!com.google.crypto.tink.*,\
+	!com.google.errorprone.annotations.*,\
 	\
 	!javax.servlet.*,\
 	\

--- a/modules/apps/shared-dependencies/shared-dependencies-nimbusds/build.gradle
+++ b/modules/apps/shared-dependencies/shared-dependencies-nimbusds/build.gradle
@@ -2,6 +2,6 @@ dependencies {
 	compileInclude group: "com.github.stephenc.jcip", name: "jcip-annotations", version: "1.0-1"
 	compileInclude group: "com.nimbusds", name: "content-type", version: "2.3"
 	compileInclude group: "com.nimbusds", name: "lang-tag", version: "1.7"
-	compileInclude group: "com.nimbusds", name: "nimbus-jose-jwt", version: "9.40"
+	compileInclude group: "com.nimbusds", name: "nimbus-jose-jwt", version: "10.0.2"
 	compileInclude group: "com.nimbusds", name: "oauth2-oidc-sdk", version: "11.13"
 }

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -732,7 +732,7 @@
         com.mysql:mysql-connector-j:8.3.0,\
         com.nimbusds:content-type:2.3,\
         com.nimbusds:lang-tag:1.7,\
-        com.nimbusds:nimbus-jose-jwt:9.40,\
+        com.nimbusds:nimbus-jose-jwt:10.0.2,\
         com.nimbusds:oauth2-oidc-sdk:11.13,\
         com.rometools:rome:1.16.0,\
         com.rometools:rome-utils:1.16.0,\


### PR DESCRIPTION
This is to upgrade nimbus-jose-jwt to 10.0.2, as the version 9.40 has a potential vulnerability. 
See https://liferay.atlassian.net/browse/LPD-62070 for more context.