### PR TITLE
LPD-66871 Object entries generated by the sample SQL builder are not visible in the portal 

### DIFF
--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -8275,6 +8275,8 @@ public class DataFactory {
 
 		// Other fields
 
+		objectEntryModel.setHeadObjectEntryId(
+			objectEntryModel.getObjectEntryId());
 		objectEntryModel.setObjectDefinitionId(objectDefinitionId);
 		objectEntryModel.setStatus(WorkflowConstants.STATUS_APPROVED);
 		objectEntryModel.setStatusByUserId(_sampleUserId);


### PR DESCRIPTION
Issue [LPD-66871](https://liferay.atlassian.net/browse/LPD-66871)

Hey, this change is necessary because, after [LPD-59721](https://liferay.atlassian.net/browse/LPD-59721), all object entries are required to have the headObjectEntryId populated.

[LPD-66871]: https://liferay.atlassian.net/browse/LPD-66871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-59721]: https://liferay.atlassian.net/browse/LPD-59721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ