### PR TITLE
LPD-79843 

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -808,6 +808,14 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 	}
 
 	protected boolean isGroupAdminImpl(Group group) throws Exception {
+		if (group == null) {
+			return false;
+		}
+
+		if (group.isCompany()) {
+			return isCompanyAdmin(group.getCompanyId());
+		}
+
 		if (group.isLayout()) {
 			long parentGroupId = group.getParentGroupId();
 
@@ -848,10 +856,6 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 					return true;
 				}
 			}
-		}
-
-		if (group.isCompany()) {
-			return isCompanyAdmin();
 		}
 		else if (group.isLayoutPrototype()) {
 			return LayoutPrototypePermissionUtil.contains(


### PR DESCRIPTION
This is to fix https://liferay.atlassian.net/browse/LPD-79843 

We currently have a vulnerability inside [AdvancedPermissionChecker](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java), this caused by a Global site permission checking problem where the Global site is treated as an instance-level object rather than a site-level object. This allows any users to bypass  and manage Global site resources across 2 different instances.
 In this change, a company ID check is added to the permission logic to ensure the user's instance matches the Global site being accessed.
