### PR TITLE
LPD-82642 

### DIFF
--- a/portal-web/docroot/html/portal/update_email_address.jsp
+++ b/portal-web/docroot/html/portal/update_email_address.jsp
@@ -10,9 +10,9 @@
 <%
 String currentURL = PortalUtil.getCurrentURL(request);
 
-String referer = ParamUtil.getString(request, WebKeys.REFERER, currentURL);
+String referer = PortalUtil.escapeRedirect(ParamUtil.getString(request, WebKeys.REFERER, currentURL));
 
-if (referer.equals(themeDisplay.getPathMain() + "/portal/update_email_address")) {
+if (Validator.isNotNull(referer) && referer.equals(themeDisplay.getPathMain() + "/portal/update_email_address")) {
 	referer = themeDisplay.getPathMain() + "?doAsUserId=" + themeDisplay.getDoAsUserId();
 }
 %>


### PR DESCRIPTION
This is for https://liferay.atlassian.net/browse/LPD-82642

There is a open redirect vulnerability inside the `update_email_address` where a URL parameter is being checked without proper validation, leading to possible exploitation from malicious URL injections.

This fix properly escapes the check by wrapping the referer string with `PortalUtil.escapeRedirect`, and add a Null validation to avoid NPE issues.