### PR TITLE
LPD-61744 Service builder fails outside of git repository

### DIFF
--- a/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
+++ b/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
@@ -36,6 +36,7 @@ import com.liferay.portal.kernel.util.TextFormatter;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.Validator_IW;
 import com.liferay.portal.tools.ArgumentsUtil;
+import com.liferay.portal.tools.GitException;
 import com.liferay.portal.tools.GitUtil;
 import com.liferay.portal.tools.ToolsUtil;
 import com.liferay.portal.tools.java.parser.JavaParser;
@@ -6330,9 +6331,19 @@ public class ServiceBuilder {
 	}
 
 	private boolean _hasLocalChanges(File propsFile) throws Exception {
-		for (String localChangesFileName :
-				GitUtil.getLocalChangesFileNames(_gitSearchStartDirName)) {
+		List<String> localChangesFileNames;
 
+		try {
+			localChangesFileNames = GitUtil.getLocalChangesFileNames(
+				_gitSearchStartDirName);
+		}
+		catch (GitException gitException) {
+			System.out.println("Cannot get local changed file names from git");
+
+			return false;
+		}
+
+		for (String localChangesFileName : localChangesFileNames) {
 			if (localChangesFileName.equals(propsFile.getPath())) {
 				return true;
 			}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-61744

In https://github.com/brianchandotcom/liferay-portal/pull/162528 we added a new check to avoid incrementing the `service.properties` if no sql file was modified and to avoid updating it if it was already modified locally, executing `git` (GitUtil.getLocalChangesFileNames) to avoid incrementing if buildService is executed several times.

But this change causes problem if service builder is executed outside a git repository.

To solve it, I am catching the `GitException` error generated if executed outside a git repository and returning false, considering that wasn't modified.

I am sending again this PR because it seems according to this comment https://liferay.atlassian.net/browse/LPD-61744?focusedCommentId=5021855 there is a customer affected with forcing executing the git command in service builder.