### PR TITLE
[LPP] LPD-86498 public render parameter handling on content page

### DIFF
--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/BasePortletContainerTestCase.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/BasePortletContainerTestCase.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import jakarta.portlet.Portlet;
 
@@ -46,7 +47,8 @@ public abstract class BasePortletContainerTestCase {
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
-			new AssumeTestRule("assume"), new LiferayIntegrationTestRule());
+			new AssumeTestRule("assume"), new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	public static void assume() {
 		Assume.assumeFalse(PropsValues.DATABASE_PARTITION_ENABLED);

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PublicRenderParameterTest.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PublicRenderParameterTest.java
@@ -6,16 +6,22 @@
 package com.liferay.portal.osgi.web.portlet.container.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutFriendlyURLRandomizerBumper;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.application.type.ApplicationType;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.portlet.PortletQName;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerBumper;
 import com.liferay.portal.kernel.test.randomizerbumpers.UniqueStringRandomizerBumper;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -23,8 +29,10 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.osgi.web.portlet.container.test.util.PortletContainerTestUtil;
+import com.liferay.portal.test.rule.Inject;
 
 import jakarta.portlet.PortletRequest;
 import jakarta.portlet.RenderRequest;
@@ -44,6 +52,61 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class PublicRenderParameterTest extends BasePortletContainerTestCase {
+
+	@Test
+	@TestInfo("LPD-86498")
+	public void testWithContentLayoutDirectURL() throws Exception {
+		String prpName = "categoryId";
+		String prpValue = RandomTestUtil.randomString(
+			LayoutFriendlyURLRandomizerBumper.INSTANCE,
+			NumericStringRandomizerBumper.INSTANCE,
+			UniqueStringRandomizerBumper.INSTANCE);
+
+		testPortlet = new TestPortlet() {
+
+			@Override
+			public void render(
+					RenderRequest renderRequest, RenderResponse renderResponse)
+				throws IOException {
+
+				PrintWriter printWriter = renderResponse.getWriter();
+
+				printWriter.write(
+					TEST_PORTLET_ID + renderRequest.getParameter(prpName));
+			}
+
+		};
+
+		setUpPortlet(
+			testPortlet,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"jakarta.portlet.supported-public-render-parameter", prpName
+			).put(
+				"jakarta.portlet.version", "3.0"
+			).build(),
+			TEST_PORTLET_ID);
+
+		Layout contentLayout = LayoutTestUtil.addTypeContentLayout(group);
+
+		Layout draftLayout = contentLayout.fetchDraftLayout();
+
+		ContentLayoutTestUtil.addPortletToLayout(draftLayout, TEST_PORTLET_ID);
+
+		ContentLayoutTestUtil.publishLayout(draftLayout, contentLayout);
+
+		PortletContainerTestUtil.Response response =
+			PortletContainerTestUtil.request(
+				StringBundler.concat(
+					"http://localhost:8080/web", group.getFriendlyURL(),
+					contentLayout.getFriendlyURL(LocaleUtil.getDefault()),
+					"?p_r_p_", prpName, "=", prpValue));
+
+		Assert.assertEquals(200, response.getCode());
+
+		String body = response.getBody();
+
+		Assert.assertTrue(body.contains(TEST_PORTLET_ID + prpValue));
+	}
 
 	@Test
 	public void testWithModuleLayoutTypeController() throws Exception {
@@ -189,5 +252,8 @@ public class PublicRenderParameterTest extends BasePortletContainerTestCase {
 
 		Assert.assertTrue(success.get());
 	}
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
 
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PublicRenderParameterTest.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PublicRenderParameterTest.java
@@ -109,6 +109,72 @@ public class PublicRenderParameterTest extends BasePortletContainerTestCase {
 	}
 
 	@Test
+	@TestInfo("LPD-86498")
+	public void testWithContentLayoutRenderURL() throws Exception {
+		String prpName = "categoryId";
+		String prpValue = RandomTestUtil.randomString(
+			LayoutFriendlyURLRandomizerBumper.INSTANCE,
+			NumericStringRandomizerBumper.INSTANCE,
+			UniqueStringRandomizerBumper.INSTANCE);
+
+		testPortlet = new TestPortlet() {
+
+			@Override
+			public void render(
+					RenderRequest renderRequest, RenderResponse renderResponse)
+				throws IOException {
+
+				PrintWriter printWriter = renderResponse.getWriter();
+
+				printWriter.write(
+					TEST_PORTLET_ID + renderRequest.getParameter(prpName));
+			}
+
+		};
+
+		setUpPortlet(
+			testPortlet,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"jakarta.portlet.supported-public-render-parameter", prpName
+			).put(
+				"jakarta.portlet.version", "3.0"
+			).build(),
+			TEST_PORTLET_ID);
+
+		Layout contentLayout = LayoutTestUtil.addTypeContentLayout(group);
+
+		Layout draftLayout = contentLayout.fetchDraftLayout();
+
+		ContentLayoutTestUtil.addPortletToLayout(draftLayout, TEST_PORTLET_ID);
+
+		ContentLayoutTestUtil.publishLayout(draftLayout, contentLayout);
+
+		String portletURLString = PortletURLBuilder.create(
+			PortletURLFactoryUtil.create(
+				PortletContainerTestUtil.getHttpServletRequest(
+					group, contentLayout),
+				TEST_PORTLET_ID, contentLayout.getPlid(),
+				PortletRequest.RENDER_PHASE)
+		).setParameter(
+			prpName, prpValue
+		).buildString();
+
+		Assert.assertTrue(
+			portletURLString,
+			portletURLString.contains(
+				PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE));
+
+		PortletContainerTestUtil.Response response =
+			PortletContainerTestUtil.request(portletURLString);
+
+		Assert.assertEquals(200, response.getCode());
+
+		String body = response.getBody();
+
+		Assert.assertTrue(body.contains(TEST_PORTLET_ID + prpValue));
+	}
+
+	@Test
 	public void testWithModuleLayoutTypeController() throws Exception {
 		final String prpName = "categoryId";
 		final String prpValue = RandomTestUtil.randomString(

--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 125.0.1
+Bundle-Version: 125.1.0
 CPE-Name: ${cpe.name}
 Export-Package:\
 	com.liferay.portal.bean,\

--- a/portal-impl/src/com/liferay/portlet/RestrictPortletContainerWrapper.java
+++ b/portal-impl/src/com/liferay/portlet/RestrictPortletContainerWrapper.java
@@ -98,6 +98,15 @@ public class RestrictPortletContainerWrapper implements PortletContainer {
 
 	@Override
 	public void processPublicRenderParameters(
+		HttpServletRequest httpServletRequest, Layout layout,
+		List<Portlet> portlets, boolean lifecycleAction) {
+
+		_portletContainer.processPublicRenderParameters(
+			httpServletRequest, layout, portlets, lifecycleAction);
+	}
+
+	@Override
+	public void processPublicRenderParameters(
 		HttpServletRequest httpServletRequest, Layout layout, Portlet portlet) {
 
 		_portletContainer.processPublicRenderParameters(

--- a/portal-impl/src/com/liferay/portlet/SecurityPortletContainerWrapper.java
+++ b/portal-impl/src/com/liferay/portlet/SecurityPortletContainerWrapper.java
@@ -107,6 +107,15 @@ public class SecurityPortletContainerWrapper implements PortletContainer {
 
 	@Override
 	public void processPublicRenderParameters(
+		HttpServletRequest httpServletRequest, Layout layout,
+		List<Portlet> portlets, boolean lifecycleAction) {
+
+		_portletContainer.processPublicRenderParameters(
+			httpServletRequest, layout, portlets, lifecycleAction);
+	}
+
+	@Override
+	public void processPublicRenderParameters(
 		HttpServletRequest httpServletRequest, Layout layout, Portlet portlet) {
 
 		_portletContainer.processPublicRenderParameters(

--- a/portal-impl/src/com/liferay/portlet/internal/PortletContainerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/PortletContainerImpl.java
@@ -175,6 +175,65 @@ public class PortletContainerImpl implements PortletContainer {
 
 	@Override
 	public void processPublicRenderParameters(
+		HttpServletRequest httpServletRequest, Layout layout,
+		List<Portlet> portlets, boolean lifecycleAction) {
+
+		PortletQName portletQName = PortletQNameUtil.getPortletQName();
+		Map<String, String[]> publicRenderParameters = null;
+		Map<String, String[]> parameters = httpServletRequest.getParameterMap();
+
+		for (Map.Entry<String, String[]> entry : parameters.entrySet()) {
+			String name = entry.getKey();
+
+			QName qName = portletQName.getQName(name);
+
+			if (qName == null) {
+				continue;
+			}
+
+			for (Portlet portlet : portlets) {
+				PublicRenderParameter publicRenderParameter =
+					portlet.getPublicRenderParameter(
+						qName.getNamespaceURI(), qName.getLocalPart());
+
+				if (publicRenderParameter == null) {
+					continue;
+				}
+
+				if (publicRenderParameters == null) {
+					publicRenderParameters = PublicRenderParametersPool.get(
+						httpServletRequest, layout.getPlid());
+				}
+
+				String publicRenderParameterName =
+					portletQName.getPublicRenderParameterName(qName);
+
+				if (name.startsWith(
+						PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE)) {
+
+					String[] values = entry.getValue();
+
+					if (lifecycleAction) {
+						String[] oldValues = publicRenderParameters.get(
+							publicRenderParameterName);
+
+						if ((oldValues != null) && (oldValues.length != 0)) {
+							values = ArrayUtil.append(values, oldValues);
+						}
+					}
+
+					publicRenderParameters.put(
+						publicRenderParameterName, values);
+				}
+				else {
+					publicRenderParameters.remove(publicRenderParameterName);
+				}
+			}
+		}
+	}
+
+	@Override
+	public void processPublicRenderParameters(
 		HttpServletRequest httpServletRequest, Layout layout, Portlet portlet) {
 
 		LayoutType layoutType = layout.getLayoutType();
@@ -189,7 +248,7 @@ public class PortletContainerImpl implements PortletContainer {
 
 		portlets.remove(portlet);
 
-		_processPublicRenderParameters(
+		processPublicRenderParameters(
 			httpServletRequest, layout, portlets, false);
 	}
 
@@ -348,7 +407,7 @@ public class PortletContainerImpl implements PortletContainer {
 				LanguageUtil.getLanguageId(httpServletRequest));
 		}
 
-		_processPublicRenderParameters(
+		processPublicRenderParameters(
 			httpServletRequest, layout, Arrays.asList(portlet),
 			themeDisplay.isLifecycleAction());
 
@@ -723,64 +782,6 @@ public class PortletContainerImpl implements PortletContainer {
 		}
 
 		themeDisplay.setSiteGroupId(siteGroupId);
-	}
-
-	private void _processPublicRenderParameters(
-		HttpServletRequest httpServletRequest, Layout layout,
-		List<Portlet> portlets, boolean lifecycleAction) {
-
-		PortletQName portletQName = PortletQNameUtil.getPortletQName();
-		Map<String, String[]> publicRenderParameters = null;
-		Map<String, String[]> parameters = httpServletRequest.getParameterMap();
-
-		for (Map.Entry<String, String[]> entry : parameters.entrySet()) {
-			String name = entry.getKey();
-
-			QName qName = portletQName.getQName(name);
-
-			if (qName == null) {
-				continue;
-			}
-
-			for (Portlet portlet : portlets) {
-				PublicRenderParameter publicRenderParameter =
-					portlet.getPublicRenderParameter(
-						qName.getNamespaceURI(), qName.getLocalPart());
-
-				if (publicRenderParameter == null) {
-					continue;
-				}
-
-				if (publicRenderParameters == null) {
-					publicRenderParameters = PublicRenderParametersPool.get(
-						httpServletRequest, layout.getPlid());
-				}
-
-				String publicRenderParameterName =
-					portletQName.getPublicRenderParameterName(qName);
-
-				if (name.startsWith(
-						PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE)) {
-
-					String[] values = entry.getValue();
-
-					if (lifecycleAction) {
-						String[] oldValues = publicRenderParameters.get(
-							publicRenderParameterName);
-
-						if ((oldValues != null) && (oldValues.length != 0)) {
-							values = ArrayUtil.append(values, oldValues);
-						}
-					}
-
-					publicRenderParameters.put(
-						publicRenderParameterName, values);
-				}
-				else {
-					publicRenderParameters.remove(publicRenderParameterName);
-				}
-			}
-		}
 	}
 
 	private void _render(

--- a/portal-impl/src/com/liferay/portlet/packageinfo
+++ b/portal-impl/src/com/liferay/portlet/packageinfo
@@ -1,1 +1,1 @@
-version 11.0.0
+version 11.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletContainer.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletContainer.java
@@ -43,6 +43,10 @@ public interface PortletContainer {
 		HttpServletRequest httpServletRequest, Layout layout);
 
 	public void processPublicRenderParameters(
+		HttpServletRequest httpServletRequest, Layout layout,
+		List<Portlet> portlets, boolean lifecycleAction);
+
+	public void processPublicRenderParameters(
 		HttpServletRequest httpServletRequest, Layout layout, Portlet portlet);
 
 	public void render(

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletContainerUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletContainerUtil.java
@@ -191,6 +191,14 @@ public class PortletContainerUtil {
 	}
 
 	public static void processPublicRenderParameters(
+		HttpServletRequest httpServletRequest, Layout layout,
+		List<Portlet> portlets, boolean lifecycleAction) {
+
+		_portletContainer.processPublicRenderParameters(
+			httpServletRequest, layout, portlets, lifecycleAction);
+	}
+
+	public static void processPublicRenderParameters(
 		HttpServletRequest httpServletRequest, Layout layout, Portlet portlet) {
 
 		_portletContainer.processPublicRenderParameters(

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/packageinfo
@@ -1,1 +1,1 @@
-version 35.0.0
+version 35.1.0

--- a/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
+++ b/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
@@ -49,6 +49,7 @@ import jakarta.servlet.jsp.JspException;
 import jakarta.servlet.jsp.PageContext;
 import jakarta.servlet.jsp.tagext.TagSupport;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -356,6 +357,10 @@ public class RuntimeTag extends TagSupport implements DirectTag {
 					PortletContainerUtil.renderHeaders(
 						httpServletRequest, httpServletResponse, portlet);
 				}
+
+				PortletContainerUtil.processPublicRenderParameters(
+					httpServletRequest, layout,
+					Collections.singletonList(portlet), false);
 
 				PortletContainerUtil.render(
 					httpServletRequest, httpServletResponse, portlet);


### PR DESCRIPTION
@tinatian Please see https://liferay.atlassian.net/browse/LPD-86498 and https://liferay.atlassian.net/browse/LPP-63668

Basically there are 2 scenarios:

1. Visiting the page via a render URL generated by a portlet which sets the public render parameter: `http://localhost:8080/home?p_p_id=ipcSender_IpcSenderPortlet_INSTANCE_fxlt&p_p_lifecycle=0&p_p_state=normal&p_p_mode=view&p_r_p_message=Prove+you+can+receive+me`
2. Visiting the page with only the public render parameter: `http://localhost:8080/home?p_r_p_message=Prove+you+can+receive+me`

Since portlets on content pages are rendered by `RuntimeTag` based on fragment entries, the 3 param `processPublicRenderParameters` in `PortletContainerImpl` can't iterate the portlets on the page, so what works for widget page doesn't work on content page. There's no similar API for content page, so I have to add public render parameter processing to `RuntimeTag`.

One concern for this is that when the page is visited by the URL in 1, the `processPublicRenderParameters` will execute twice with the portlet designated by the `p_p_id`. What's your suggestion?