### PR TITLE
LPD-86498 Process public render parameters for RuntimeTag portlets

### DIFF
--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/BasePortletContainerTestCase.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/BasePortletContainerTestCase.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import jakarta.portlet.Portlet;
 
@@ -46,7 +47,8 @@ public abstract class BasePortletContainerTestCase {
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
-			new AssumeTestRule("assume"), new LiferayIntegrationTestRule());
+			new AssumeTestRule("assume"), new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	public static void assume() {
 		Assume.assumeFalse(PropsValues.DATABASE_PARTITION_ENABLED);

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PublicRenderParameterTest.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PublicRenderParameterTest.java
@@ -6,16 +6,22 @@
 package com.liferay.portal.osgi.web.portlet.container.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutFriendlyURLRandomizerBumper;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.application.type.ApplicationType;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.portlet.PortletQName;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerBumper;
 import com.liferay.portal.kernel.test.randomizerbumpers.UniqueStringRandomizerBumper;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -23,8 +29,10 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.osgi.web.portlet.container.test.util.PortletContainerTestUtil;
+import com.liferay.portal.test.rule.Inject;
 
 import jakarta.portlet.PortletRequest;
 import jakarta.portlet.RenderRequest;
@@ -44,6 +52,61 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class PublicRenderParameterTest extends BasePortletContainerTestCase {
+
+	@Test
+	@TestInfo("LPD-86498")
+	public void testWithContentLayoutDirectURL() throws Exception {
+		String prpName = "categoryId";
+		String prpValue = RandomTestUtil.randomString(
+			LayoutFriendlyURLRandomizerBumper.INSTANCE,
+			NumericStringRandomizerBumper.INSTANCE,
+			UniqueStringRandomizerBumper.INSTANCE);
+
+		testPortlet = new TestPortlet() {
+
+			@Override
+			public void render(
+					RenderRequest renderRequest, RenderResponse renderResponse)
+				throws IOException {
+
+				PrintWriter printWriter = renderResponse.getWriter();
+
+				printWriter.write(
+					TEST_PORTLET_ID + renderRequest.getParameter(prpName));
+			}
+
+		};
+
+		setUpPortlet(
+			testPortlet,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"jakarta.portlet.supported-public-render-parameter", prpName
+			).put(
+				"jakarta.portlet.version", "3.0"
+			).build(),
+			TEST_PORTLET_ID);
+
+		Layout contentLayout = LayoutTestUtil.addTypeContentLayout(group);
+
+		Layout draftLayout = contentLayout.fetchDraftLayout();
+
+		ContentLayoutTestUtil.addPortletToLayout(draftLayout, TEST_PORTLET_ID);
+
+		ContentLayoutTestUtil.publishLayout(draftLayout, contentLayout);
+
+		PortletContainerTestUtil.Response response =
+			PortletContainerTestUtil.request(
+				StringBundler.concat(
+					"http://localhost:8080/web", group.getFriendlyURL(),
+					contentLayout.getFriendlyURL(LocaleUtil.getDefault()),
+					"?p_r_p_", prpName, "=", prpValue));
+
+		Assert.assertEquals(200, response.getCode());
+
+		String body = response.getBody();
+
+		Assert.assertTrue(body.contains(TEST_PORTLET_ID + prpValue));
+	}
 
 	@Test
 	public void testWithModuleLayoutTypeController() throws Exception {
@@ -189,5 +252,8 @@ public class PublicRenderParameterTest extends BasePortletContainerTestCase {
 
 		Assert.assertTrue(success.get());
 	}
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
 
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PublicRenderParameterTest.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PublicRenderParameterTest.java
@@ -56,11 +56,12 @@ public class PublicRenderParameterTest extends BasePortletContainerTestCase {
 	@Test
 	@TestInfo("LPD-86498")
 	public void testWithContentLayoutDirectURL() throws Exception {
-		String prpName = "categoryId";
-		String prpValue = RandomTestUtil.randomString(
+		final String prpName = "categoryId";
+		final String prpValue = RandomTestUtil.randomString(
 			LayoutFriendlyURLRandomizerBumper.INSTANCE,
 			NumericStringRandomizerBumper.INSTANCE,
 			UniqueStringRandomizerBumper.INSTANCE);
+		final AtomicBoolean success = new AtomicBoolean(false);
 
 		testPortlet = new TestPortlet() {
 
@@ -71,8 +72,13 @@ public class PublicRenderParameterTest extends BasePortletContainerTestCase {
 
 				PrintWriter printWriter = renderResponse.getWriter();
 
-				printWriter.write(
-					TEST_PORTLET_ID + renderRequest.getParameter(prpName));
+				String value = renderRequest.getParameter(prpName);
+
+				if (prpValue.equals(value)) {
+					success.set(true);
+				}
+
+				printWriter.write(value);
 			}
 
 		};
@@ -103,19 +109,18 @@ public class PublicRenderParameterTest extends BasePortletContainerTestCase {
 
 		Assert.assertEquals(200, response.getCode());
 
-		String body = response.getBody();
-
-		Assert.assertTrue(body.contains(TEST_PORTLET_ID + prpValue));
+		Assert.assertTrue(success.get());
 	}
 
 	@Test
 	@TestInfo("LPD-86498")
 	public void testWithContentLayoutRenderURL() throws Exception {
-		String prpName = "categoryId";
-		String prpValue = RandomTestUtil.randomString(
+		final String prpName = "categoryId";
+		final String prpValue = RandomTestUtil.randomString(
 			LayoutFriendlyURLRandomizerBumper.INSTANCE,
 			NumericStringRandomizerBumper.INSTANCE,
 			UniqueStringRandomizerBumper.INSTANCE);
+		final AtomicBoolean success = new AtomicBoolean(false);
 
 		testPortlet = new TestPortlet() {
 
@@ -126,8 +131,13 @@ public class PublicRenderParameterTest extends BasePortletContainerTestCase {
 
 				PrintWriter printWriter = renderResponse.getWriter();
 
-				printWriter.write(
-					TEST_PORTLET_ID + renderRequest.getParameter(prpName));
+				String value = renderRequest.getParameter(prpName);
+
+				if (prpValue.equals(value)) {
+					success.set(true);
+				}
+
+				printWriter.write(value);
 			}
 
 		};
@@ -169,9 +179,7 @@ public class PublicRenderParameterTest extends BasePortletContainerTestCase {
 
 		Assert.assertEquals(200, response.getCode());
 
-		String body = response.getBody();
-
-		Assert.assertTrue(body.contains(TEST_PORTLET_ID + prpValue));
+		Assert.assertTrue(success.get());
 	}
 
 	@Test

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PublicRenderParameterTest.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PublicRenderParameterTest.java
@@ -9,6 +9,8 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutFriendlyURLRandomizerBumper;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.application.type.ApplicationType;
 import com.liferay.portal.kernel.model.Layout;
@@ -16,7 +18,6 @@ import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.portlet.PortletQName;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
-import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
 import com.liferay.portal.kernel.test.TestInfo;
@@ -28,7 +29,6 @@ import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.osgi.web.portlet.container.test.util.PortletContainerTestUtil;
-import com.liferay.portal.test.rule.Inject;
 
 import jakarta.portlet.PortletRequest;
 import jakarta.portlet.RenderRequest;
@@ -37,9 +37,12 @@ import jakarta.portlet.RenderResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -49,142 +52,120 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class PublicRenderParameterTest extends BasePortletContainerTestCase {
 
-	@Test
-	@TestInfo("LPD-86498")
-	public void testWithContentLayoutDirectURL() throws Exception {
-		final String prpName = "categoryId";
-		final String prpValue = RandomTestUtil.randomString(
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		_publicRenderParameterName = "categoryId";
+		_publicRenderParameterValue = RandomTestUtil.randomString(
 			LayoutFriendlyURLRandomizerBumper.INSTANCE,
 			NumericStringRandomizerBumper.INSTANCE,
 			UniqueStringRandomizerBumper.INSTANCE);
-		final AtomicBoolean success = new AtomicBoolean(false);
+	}
 
-		testPortlet = new TestPortlet() {
-
-			@Override
-			public void render(
-					RenderRequest renderRequest, RenderResponse renderResponse)
-				throws IOException {
-
-				PrintWriter printWriter = renderResponse.getWriter();
-
-				String value = renderRequest.getParameter(prpName);
-
-				if (prpValue.equals(value)) {
-					success.set(true);
-				}
-
-				printWriter.write(value);
-			}
-
-		};
-
-		setUpPortlet(
-			testPortlet,
-			HashMapDictionaryBuilder.<String, Object>put(
-				"jakarta.portlet.supported-public-render-parameter", prpName
-			).put(
-				"jakarta.portlet.version", "3.0"
-			).build(),
-			TEST_PORTLET_ID, false);
-
+	@Test
+	@TestInfo("LPD-86498")
+	public void testWithContentLayoutDirectURL() throws Exception {
 		Layout contentLayout = LayoutTestUtil.addTypeContentLayout(group);
 
 		Layout draftLayout = contentLayout.fetchDraftLayout();
 
-		ContentLayoutTestUtil.addPortletToLayout(draftLayout, TEST_PORTLET_ID);
+		_testPublicRenderParameter(
+			() -> {
+				ContentLayoutTestUtil.addPortletToLayout(
+					draftLayout, TEST_PORTLET_ID);
 
-		ContentLayoutTestUtil.publishLayout(draftLayout, contentLayout);
-
-		PortletContainerTestUtil.Response response =
-			PortletContainerTestUtil.request(
-				StringBundler.concat(
-					"http://localhost:8080/web", group.getFriendlyURL(),
-					contentLayout.getFriendlyURL(LocaleUtil.getDefault()),
-					"?p_r_p_", prpName, "=", prpValue));
-
-		Assert.assertEquals(200, response.getCode());
-
-		Assert.assertTrue(success.get());
+				ContentLayoutTestUtil.publishLayout(draftLayout, contentLayout);
+			},
+			Collections.emptyMap(),
+			() -> StringBundler.concat(
+				"http://localhost:8080/web", group.getFriendlyURL(),
+				contentLayout.getFriendlyURL(LocaleUtil.getDefault()),
+				"?p_r_p_", _publicRenderParameterName, "=",
+				_publicRenderParameterValue));
 	}
 
 	@Test
 	@TestInfo("LPD-86498")
 	public void testWithContentLayoutRenderURL() throws Exception {
-		final String prpName = "categoryId";
-		final String prpValue = RandomTestUtil.randomString(
-			LayoutFriendlyURLRandomizerBumper.INSTANCE,
-			NumericStringRandomizerBumper.INSTANCE,
-			UniqueStringRandomizerBumper.INSTANCE);
-		final AtomicBoolean success = new AtomicBoolean(false);
-
-		testPortlet = new TestPortlet() {
-
-			@Override
-			public void render(
-					RenderRequest renderRequest, RenderResponse renderResponse)
-				throws IOException {
-
-				PrintWriter printWriter = renderResponse.getWriter();
-
-				String value = renderRequest.getParameter(prpName);
-
-				if (prpValue.equals(value)) {
-					success.set(true);
-				}
-
-				printWriter.write(value);
-			}
-
-		};
-
-		setUpPortlet(
-			testPortlet,
-			HashMapDictionaryBuilder.<String, Object>put(
-				"jakarta.portlet.supported-public-render-parameter", prpName
-			).put(
-				"jakarta.portlet.version", "3.0"
-			).build(),
-			TEST_PORTLET_ID, false);
-
 		Layout contentLayout = LayoutTestUtil.addTypeContentLayout(group);
 
 		Layout draftLayout = contentLayout.fetchDraftLayout();
 
-		ContentLayoutTestUtil.addPortletToLayout(draftLayout, TEST_PORTLET_ID);
+		_testPublicRenderParameter(
+			() -> {
+				ContentLayoutTestUtil.addPortletToLayout(
+					draftLayout, TEST_PORTLET_ID);
 
-		ContentLayoutTestUtil.publishLayout(draftLayout, contentLayout);
-
-		String portletURLString = PortletURLBuilder.create(
-			PortletURLFactoryUtil.create(
-				PortletContainerTestUtil.getHttpServletRequest(
-					group, contentLayout),
-				TEST_PORTLET_ID, contentLayout.getPlid(),
-				PortletRequest.RENDER_PHASE)
-		).setParameter(
-			prpName, prpValue
-		).buildString();
-
-		Assert.assertTrue(
-			portletURLString,
-			portletURLString.contains(
-				PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE));
-
-		PortletContainerTestUtil.Response response =
-			PortletContainerTestUtil.request(portletURLString);
-
-		Assert.assertEquals(200, response.getCode());
-
-		Assert.assertTrue(success.get());
+				ContentLayoutTestUtil.publishLayout(draftLayout, contentLayout);
+			},
+			Collections.emptyMap(),
+			() -> PortletURLBuilder.create(
+				PortletURLFactoryUtil.create(
+					PortletContainerTestUtil.getHttpServletRequest(
+						group, contentLayout),
+					TEST_PORTLET_ID, contentLayout.getPlid(),
+					PortletRequest.RENDER_PHASE)
+			).setParameter(
+				_publicRenderParameterName, _publicRenderParameterValue
+			).buildString());
 	}
 
 	@Test
 	public void testWithModuleLayoutTypeController() throws Exception {
-		final String prpName = "categoryId";
-		final String prpValue = RandomTestUtil.randomString(
-			LayoutFriendlyURLRandomizerBumper.INSTANCE,
-			NumericStringRandomizerBumper.INSTANCE,
-			UniqueStringRandomizerBumper.INSTANCE);
+		_testPublicRenderParameter(
+			() -> {
+				layout = LayoutTestUtil.addTypeFullPageApplicationLayout(
+					group.getGroupId());
+
+				UnicodeProperties typeSettingsUnicodeProperties =
+					layout.getTypeSettingsProperties();
+
+				typeSettingsUnicodeProperties.setProperty(
+					"fullPageApplicationPortlet", TEST_PORTLET_ID);
+
+				LayoutLocalServiceUtil.updateLayout(layout);
+			},
+			Collections.singletonMap(
+				"com.liferay.portlet.application-type",
+				new String[] {
+					ApplicationType.FULL_PAGE_APPLICATION.toString(),
+					ApplicationType.WIDGET.toString()
+				}),
+			() -> PortletURLBuilder.create(
+				PortletURLFactoryUtil.create(
+					PortletContainerTestUtil.getHttpServletRequest(
+						group, layout),
+					TEST_PORTLET_ID, layout.getPlid(),
+					PortletRequest.RENDER_PHASE)
+			).setParameter(
+				_publicRenderParameterName, _publicRenderParameterValue
+			).buildString());
+	}
+
+	@Test
+	public void testWithPortalLayoutTypeController() throws Exception {
+		_testPublicRenderParameter(
+			() -> LayoutTestUtil.addPortletToLayout(layout, TEST_PORTLET_ID),
+			Collections.emptyMap(),
+			() -> PortletURLBuilder.create(
+				PortletURLFactoryUtil.create(
+					PortletContainerTestUtil.getHttpServletRequest(
+						group, layout),
+					TEST_PORTLET_ID, layout.getPlid(),
+					PortletRequest.RENDER_PHASE)
+			).setParameter(
+				_publicRenderParameterName, _publicRenderParameterValue
+			).buildString());
+	}
+
+	private void _testPublicRenderParameter(
+			UnsafeRunnable<Exception> layoutSetUpUnsafeRunnable,
+			Map<String, Object> portletProperties,
+			UnsafeSupplier<String, Exception> portletURLStringUnsafeSupplier)
+		throws Exception {
+
 		final AtomicBoolean success = new AtomicBoolean(false);
 
 		testPortlet = new TestPortlet() {
@@ -196,9 +177,10 @@ public class PublicRenderParameterTest extends BasePortletContainerTestCase {
 
 				PrintWriter printWriter = renderResponse.getWriter();
 
-				String value = renderRequest.getParameter(prpName);
+				String value = renderRequest.getParameter(
+					_publicRenderParameterName);
 
-				if (prpValue.equals(value)) {
+				if (_publicRenderParameterValue.equals(value)) {
 					success.set(true);
 				}
 
@@ -210,13 +192,12 @@ public class PublicRenderParameterTest extends BasePortletContainerTestCase {
 		setUpPortlet(
 			testPortlet,
 			HashMapDictionaryBuilder.<String, Object>put(
-				"com.liferay.portlet.application-type",
-				new String[] {
-					ApplicationType.FULL_PAGE_APPLICATION.toString(),
-					ApplicationType.WIDGET.toString()
-				}
+				"jakarta.portlet.supported-public-render-parameter",
+				_publicRenderParameterName
 			).put(
-				"jakarta.portlet.supported-public-render-parameter", prpName
+				"jakarta.portlet.version", "3.0"
+			).putAll(
+				portletProperties
 			).build(),
 			TEST_PORTLET_ID, false);
 
@@ -225,24 +206,9 @@ public class PublicRenderParameterTest extends BasePortletContainerTestCase {
 
 		Assert.assertFalse(portlet.isUndeployedPortlet());
 
-		layout = LayoutTestUtil.addTypeFullPageApplicationLayout(
-			group.getGroupId());
+		layoutSetUpUnsafeRunnable.run();
 
-		UnicodeProperties typeSettingsUnicodeProperties =
-			layout.getTypeSettingsProperties();
-
-		typeSettingsUnicodeProperties.setProperty(
-			"fullPageApplicationPortlet", TEST_PORTLET_ID);
-
-		LayoutLocalServiceUtil.updateLayout(layout);
-
-		String portletURLString = PortletURLBuilder.create(
-			PortletURLFactoryUtil.create(
-				PortletContainerTestUtil.getHttpServletRequest(group, layout),
-				TEST_PORTLET_ID, layout.getPlid(), PortletRequest.RENDER_PHASE)
-		).setParameter(
-			prpName, prpValue
-		).buildString();
+		String portletURLString = portletURLStringUnsafeSupplier.get();
 
 		Assert.assertTrue(
 			portletURLString,
@@ -257,66 +223,7 @@ public class PublicRenderParameterTest extends BasePortletContainerTestCase {
 		Assert.assertTrue(success.get());
 	}
 
-	@Test
-	public void testWithPortalLayoutTypeController() throws Exception {
-		final String prpName = "categoryId";
-		final String prpValue = RandomTestUtil.randomString(
-			LayoutFriendlyURLRandomizerBumper.INSTANCE,
-			NumericStringRandomizerBumper.INSTANCE,
-			UniqueStringRandomizerBumper.INSTANCE);
-		final AtomicBoolean success = new AtomicBoolean(false);
-
-		testPortlet = new TestPortlet() {
-
-			@Override
-			public void render(
-					RenderRequest renderRequest, RenderResponse renderResponse)
-				throws IOException {
-
-				PrintWriter printWriter = renderResponse.getWriter();
-
-				String value = renderRequest.getParameter(prpName);
-
-				if (prpValue.equals(value)) {
-					success.set(true);
-				}
-
-				printWriter.write(value);
-			}
-
-		};
-
-		setUpPortlet(
-			testPortlet,
-			HashMapDictionaryBuilder.<String, Object>put(
-				"jakarta.portlet.supported-public-render-parameter", prpName
-			).build(),
-			TEST_PORTLET_ID, false);
-
-		LayoutTestUtil.addPortletToLayout(layout, TEST_PORTLET_ID);
-
-		String portletURLString = PortletURLBuilder.create(
-			PortletURLFactoryUtil.create(
-				PortletContainerTestUtil.getHttpServletRequest(group, layout),
-				TEST_PORTLET_ID, layout.getPlid(), PortletRequest.RENDER_PHASE)
-		).setParameter(
-			prpName, prpValue
-		).buildString();
-
-		Assert.assertTrue(
-			portletURLString,
-			portletURLString.contains(
-				PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE));
-
-		PortletContainerTestUtil.Response response =
-			PortletContainerTestUtil.request(portletURLString);
-
-		Assert.assertEquals(200, response.getCode());
-
-		Assert.assertTrue(success.get());
-	}
-
-	@Inject
-	private LayoutLocalService _layoutLocalService;
+	private String _publicRenderParameterName;
+	private String _publicRenderParameterValue;
 
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PublicRenderParameterTest.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PublicRenderParameterTest.java
@@ -7,7 +7,6 @@ package com.liferay.portal.osgi.web.portlet.container.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
-import com.liferay.layout.test.util.LayoutFriendlyURLRandomizerBumper;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.function.UnsafeSupplier;
@@ -21,8 +20,6 @@ import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
 import com.liferay.portal.kernel.test.TestInfo;
-import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerBumper;
-import com.liferay.portal.kernel.test.randomizerbumpers.UniqueStringRandomizerBumper;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -58,10 +55,7 @@ public class PublicRenderParameterTest extends BasePortletContainerTestCase {
 		super.setUp();
 
 		_publicRenderParameterName = "test_" + RandomTestUtil.randomString();
-		_publicRenderParameterValue = RandomTestUtil.randomString(
-			LayoutFriendlyURLRandomizerBumper.INSTANCE,
-			NumericStringRandomizerBumper.INSTANCE,
-			UniqueStringRandomizerBumper.INSTANCE);
+		_publicRenderParameterValue = RandomTestUtil.randomString();
 	}
 
 	@Test

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PublicRenderParameterTest.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PublicRenderParameterTest.java
@@ -10,10 +10,8 @@ import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutFriendlyURLRandomizerBumper;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.application.type.ApplicationType;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.portlet.PortletQName;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
@@ -25,9 +23,7 @@ import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerBumper;
 import com.liferay.portal.kernel.test.randomizerbumpers.UniqueStringRandomizerBumper;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
@@ -229,17 +225,8 @@ public class PublicRenderParameterTest extends BasePortletContainerTestCase {
 
 		Assert.assertFalse(portlet.isUndeployedPortlet());
 
-		String name = RandomTestUtil.randomString(
-			LayoutFriendlyURLRandomizerBumper.INSTANCE,
-			NumericStringRandomizerBumper.INSTANCE,
-			UniqueStringRandomizerBumper.INSTANCE);
-
-		layout = LayoutLocalServiceUtil.addLayout(
-			null, TestPropsValues.getUserId(), group.getGroupId(), false,
-			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID, name, null, null,
-			"full_page_application", false,
-			StringPool.SLASH + FriendlyURLNormalizerUtil.normalize(name),
-			ServiceContextTestUtil.getServiceContext());
+		layout = LayoutTestUtil.addTypeFullPageApplicationLayout(
+			group.getGroupId());
 
 		UnicodeProperties typeSettingsUnicodeProperties =
 			layout.getTypeSettingsProperties();

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PublicRenderParameterTest.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PublicRenderParameterTest.java
@@ -57,7 +57,7 @@ public class PublicRenderParameterTest extends BasePortletContainerTestCase {
 	public void setUp() throws Exception {
 		super.setUp();
 
-		_publicRenderParameterName = "categoryId";
+		_publicRenderParameterName = "test_" + RandomTestUtil.randomString();
 		_publicRenderParameterValue = RandomTestUtil.randomString(
 			LayoutFriendlyURLRandomizerBumper.INSTANCE,
 			NumericStringRandomizerBumper.INSTANCE,

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PublicRenderParameterTest.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PublicRenderParameterTest.java
@@ -86,7 +86,7 @@ public class PublicRenderParameterTest extends BasePortletContainerTestCase {
 			).put(
 				"jakarta.portlet.version", "3.0"
 			).build(),
-			TEST_PORTLET_ID);
+			TEST_PORTLET_ID, false);
 
 		Layout contentLayout = LayoutTestUtil.addTypeContentLayout(group);
 
@@ -145,7 +145,7 @@ public class PublicRenderParameterTest extends BasePortletContainerTestCase {
 			).put(
 				"jakarta.portlet.version", "3.0"
 			).build(),
-			TEST_PORTLET_ID);
+			TEST_PORTLET_ID, false);
 
 		Layout contentLayout = LayoutTestUtil.addTypeContentLayout(group);
 
@@ -291,7 +291,9 @@ public class PublicRenderParameterTest extends BasePortletContainerTestCase {
 			HashMapDictionaryBuilder.<String, Object>put(
 				"jakarta.portlet.supported-public-render-parameter", prpName
 			).build(),
-			TEST_PORTLET_ID);
+			TEST_PORTLET_ID, false);
+
+		LayoutTestUtil.addPortletToLayout(layout, TEST_PORTLET_ID);
 
 		String portletURLString = PortletURLBuilder.create(
 			PortletURLFactoryUtil.create(

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PublicRenderParameterTest.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PublicRenderParameterTest.java
@@ -109,6 +109,72 @@ public class PublicRenderParameterTest extends BasePortletContainerTestCase {
 	}
 
 	@Test
+	@TestInfo("LPD-86498")
+	public void testWithContentLayoutRenderURL() throws Exception {
+		String prpName = "categoryId";
+		String prpValue = RandomTestUtil.randomString(
+			LayoutFriendlyURLRandomizerBumper.INSTANCE,
+			NumericStringRandomizerBumper.INSTANCE,
+			UniqueStringRandomizerBumper.INSTANCE);
+
+		testPortlet = new TestPortlet() {
+
+			@Override
+			public void render(
+					RenderRequest renderRequest, RenderResponse renderResponse)
+				throws IOException {
+
+				PrintWriter printWriter = renderResponse.getWriter();
+
+				printWriter.write(
+					TEST_PORTLET_ID + renderRequest.getParameter(prpName));
+			}
+
+		};
+
+		setUpPortlet(
+			testPortlet,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"jakarta.portlet.supported-public-render-parameter", prpName
+			).put(
+				"jakarta.portlet.version", "3.0"
+			).build(),
+			TEST_PORTLET_ID);
+
+		Layout contentLayout = LayoutTestUtil.addTypeContentLayout(group);
+
+		Layout draftLayout = contentLayout.fetchDraftLayout();
+
+		ContentLayoutTestUtil.addPortletToLayout(draftLayout, TEST_PORTLET_ID);
+
+		ContentLayoutTestUtil.publishLayout(draftLayout, contentLayout);
+
+		String portletURLString = PortletURLBuilder.create(
+			PortletURLFactoryUtil.create(
+				PortletContainerTestUtil.getHttpServletRequest(
+					group, contentLayout),
+				TEST_PORTLET_ID, contentLayout.getPlid(),
+				PortletRequest.RENDER_PHASE)
+		).setParameter(
+			prpName, prpValue
+		).buildString();
+
+		Assert.assertTrue(
+			portletURLString,
+			portletURLString.contains(
+				PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE));
+
+		PortletContainerTestUtil.Response response =
+			PortletContainerTestUtil.request(portletURLString);
+
+		Assert.assertEquals(200, response.getCode());
+
+		String body = response.getBody();
+
+		Assert.assertTrue(body.contains(TEST_PORTLET_ID + prpValue));
+	}
+
+	@Test
 	public void testWithModuleLayoutTypeController() throws Exception {
 		final String prpName = "categoryId";
 		final String prpValue = RandomTestUtil.randomString(

--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 125.0.2
+Bundle-Version: 125.1.0
 CPE-Name: ${cpe.name}
 Export-Package:\
 	com.liferay.portal.bean,\

--- a/portal-impl/src/com/liferay/portal/action/LayoutAction.java
+++ b/portal-impl/src/com/liferay/portal/action/LayoutAction.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.login.AuthLoginGroupSettingsUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
+import com.liferay.portal.kernel.model.LayoutType;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.User;
@@ -425,8 +426,19 @@ public class LayoutAction implements Action {
 				// Include layout content before the page loads because portlets
 				// on the page can set the page title and page subtitle
 
-				PortletContainerUtil.processPublicRenderParameters(
-					httpServletRequest, layout, portlet);
+				LayoutType layoutType = layout.getLayoutType();
+
+				if (layoutType instanceof LayoutTypePortlet) {
+					LayoutTypePortlet layoutTypePortlet =
+						(LayoutTypePortlet)layoutType;
+
+					List<Portlet> portlets = layoutTypePortlet.getPortlets();
+
+					portlets.remove(portlet);
+
+					PortletContainerUtil.processPublicRenderParameters(
+						httpServletRequest, layout, portlets);
+				}
 
 				if (layout.includeLayoutContent(
 						httpServletRequest, httpServletResponse)) {

--- a/portal-impl/src/com/liferay/portal/action/RenderPortletAction.java
+++ b/portal-impl/src/com/liferay/portal/action/RenderPortletAction.java
@@ -6,6 +6,8 @@
 package com.liferay.portal.action;
 
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutType;
+import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.PortletContainerUtil;
@@ -99,8 +101,15 @@ public class RenderPortletAction implements Action {
 			httpServletRequest, null, columnId, columnPos, columnCount,
 			boundary, decorate);
 
-		PortletContainerUtil.processPublicRenderParameters(
-			httpServletRequest, themeDisplay.getLayout());
+		LayoutType layoutType = layout.getLayoutType();
+
+		if (layoutType instanceof LayoutTypePortlet) {
+			LayoutTypePortlet layoutTypePortlet =
+				(LayoutTypePortlet)layoutType;
+
+			PortletContainerUtil.processPublicRenderParameters(
+				httpServletRequest, layout, layoutTypePortlet.getPortlets());
+		}
 
 		PortletContainerUtil.renderHeaders(
 			httpServletRequest, httpServletResponse, portlet);

--- a/portal-impl/src/com/liferay/portal/action/RenderPortletAction.java
+++ b/portal-impl/src/com/liferay/portal/action/RenderPortletAction.java
@@ -104,8 +104,7 @@ public class RenderPortletAction implements Action {
 		LayoutType layoutType = layout.getLayoutType();
 
 		if (layoutType instanceof LayoutTypePortlet) {
-			LayoutTypePortlet layoutTypePortlet =
-				(LayoutTypePortlet)layoutType;
+			LayoutTypePortlet layoutTypePortlet = (LayoutTypePortlet)layoutType;
 
 			PortletContainerUtil.processPublicRenderParameters(
 				httpServletRequest, layout, layoutTypePortlet.getPortlets());

--- a/portal-impl/src/com/liferay/portlet/RestrictPortletContainerWrapper.java
+++ b/portal-impl/src/com/liferay/portlet/RestrictPortletContainerWrapper.java
@@ -98,6 +98,15 @@ public class RestrictPortletContainerWrapper implements PortletContainer {
 
 	@Override
 	public void processPublicRenderParameters(
+		HttpServletRequest httpServletRequest, Layout layout,
+		List<Portlet> portlets, boolean lifecycleAction) {
+
+		_portletContainer.processPublicRenderParameters(
+			httpServletRequest, layout, portlets, lifecycleAction);
+	}
+
+	@Override
+	public void processPublicRenderParameters(
 		HttpServletRequest httpServletRequest, Layout layout, Portlet portlet) {
 
 		_portletContainer.processPublicRenderParameters(

--- a/portal-impl/src/com/liferay/portlet/RestrictPortletContainerWrapper.java
+++ b/portal-impl/src/com/liferay/portlet/RestrictPortletContainerWrapper.java
@@ -90,27 +90,11 @@ public class RestrictPortletContainerWrapper implements PortletContainer {
 
 	@Override
 	public void processPublicRenderParameters(
-		HttpServletRequest httpServletRequest, Layout layout) {
-
-		_portletContainer.processPublicRenderParameters(
-			httpServletRequest, layout);
-	}
-
-	@Override
-	public void processPublicRenderParameters(
 		HttpServletRequest httpServletRequest, Layout layout,
-		List<Portlet> portlets, boolean lifecycleAction) {
+		List<Portlet> portlets) {
 
 		_portletContainer.processPublicRenderParameters(
-			httpServletRequest, layout, portlets, lifecycleAction);
-	}
-
-	@Override
-	public void processPublicRenderParameters(
-		HttpServletRequest httpServletRequest, Layout layout, Portlet portlet) {
-
-		_portletContainer.processPublicRenderParameters(
-			httpServletRequest, layout, portlet);
+			httpServletRequest, layout, portlets);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/SecurityPortletContainerWrapper.java
+++ b/portal-impl/src/com/liferay/portlet/SecurityPortletContainerWrapper.java
@@ -99,27 +99,11 @@ public class SecurityPortletContainerWrapper implements PortletContainer {
 
 	@Override
 	public void processPublicRenderParameters(
-		HttpServletRequest httpServletRequest, Layout layout) {
-
-		_portletContainer.processPublicRenderParameters(
-			httpServletRequest, layout);
-	}
-
-	@Override
-	public void processPublicRenderParameters(
 		HttpServletRequest httpServletRequest, Layout layout,
-		List<Portlet> portlets, boolean lifecycleAction) {
+		List<Portlet> portlets) {
 
 		_portletContainer.processPublicRenderParameters(
-			httpServletRequest, layout, portlets, lifecycleAction);
-	}
-
-	@Override
-	public void processPublicRenderParameters(
-		HttpServletRequest httpServletRequest, Layout layout, Portlet portlet) {
-
-		_portletContainer.processPublicRenderParameters(
-			httpServletRequest, layout, portlet);
+			httpServletRequest, layout, portlets);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/SecurityPortletContainerWrapper.java
+++ b/portal-impl/src/com/liferay/portlet/SecurityPortletContainerWrapper.java
@@ -107,6 +107,15 @@ public class SecurityPortletContainerWrapper implements PortletContainer {
 
 	@Override
 	public void processPublicRenderParameters(
+		HttpServletRequest httpServletRequest, Layout layout,
+		List<Portlet> portlets, boolean lifecycleAction) {
+
+		_portletContainer.processPublicRenderParameters(
+			httpServletRequest, layout, portlets, lifecycleAction);
+	}
+
+	@Override
+	public void processPublicRenderParameters(
 		HttpServletRequest httpServletRequest, Layout layout, Portlet portlet) {
 
 		_portletContainer.processPublicRenderParameters(

--- a/portal-impl/src/com/liferay/portlet/internal/PortletContainerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/PortletContainerImpl.java
@@ -175,6 +175,65 @@ public class PortletContainerImpl implements PortletContainer {
 
 	@Override
 	public void processPublicRenderParameters(
+		HttpServletRequest httpServletRequest, Layout layout,
+		List<Portlet> portlets, boolean lifecycleAction) {
+
+		PortletQName portletQName = PortletQNameUtil.getPortletQName();
+		Map<String, String[]> publicRenderParameters = null;
+		Map<String, String[]> parameters = httpServletRequest.getParameterMap();
+
+		for (Map.Entry<String, String[]> entry : parameters.entrySet()) {
+			String name = entry.getKey();
+
+			QName qName = portletQName.getQName(name);
+
+			if (qName == null) {
+				continue;
+			}
+
+			for (Portlet portlet : portlets) {
+				PublicRenderParameter publicRenderParameter =
+					portlet.getPublicRenderParameter(
+						qName.getNamespaceURI(), qName.getLocalPart());
+
+				if (publicRenderParameter == null) {
+					continue;
+				}
+
+				if (publicRenderParameters == null) {
+					publicRenderParameters = PublicRenderParametersPool.get(
+						httpServletRequest, layout.getPlid());
+				}
+
+				String publicRenderParameterName =
+					portletQName.getPublicRenderParameterName(qName);
+
+				if (name.startsWith(
+						PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE)) {
+
+					String[] values = entry.getValue();
+
+					if (lifecycleAction) {
+						String[] oldValues = publicRenderParameters.get(
+							publicRenderParameterName);
+
+						if ((oldValues != null) && (oldValues.length != 0)) {
+							values = ArrayUtil.append(values, oldValues);
+						}
+					}
+
+					publicRenderParameters.put(
+						publicRenderParameterName, values);
+				}
+				else {
+					publicRenderParameters.remove(publicRenderParameterName);
+				}
+			}
+		}
+	}
+
+	@Override
+	public void processPublicRenderParameters(
 		HttpServletRequest httpServletRequest, Layout layout, Portlet portlet) {
 
 		LayoutType layoutType = layout.getLayoutType();
@@ -189,7 +248,7 @@ public class PortletContainerImpl implements PortletContainer {
 
 		portlets.remove(portlet);
 
-		_processPublicRenderParameters(
+		processPublicRenderParameters(
 			httpServletRequest, layout, portlets, false);
 	}
 
@@ -348,7 +407,7 @@ public class PortletContainerImpl implements PortletContainer {
 				LanguageUtil.getLanguageId(httpServletRequest));
 		}
 
-		_processPublicRenderParameters(
+		processPublicRenderParameters(
 			httpServletRequest, layout, Arrays.asList(portlet),
 			themeDisplay.isLifecycleAction());
 
@@ -723,64 +782,6 @@ public class PortletContainerImpl implements PortletContainer {
 		}
 
 		themeDisplay.setSiteGroupId(siteGroupId);
-	}
-
-	private void _processPublicRenderParameters(
-		HttpServletRequest httpServletRequest, Layout layout,
-		List<Portlet> portlets, boolean lifecycleAction) {
-
-		PortletQName portletQName = PortletQNameUtil.getPortletQName();
-		Map<String, String[]> publicRenderParameters = null;
-		Map<String, String[]> parameters = httpServletRequest.getParameterMap();
-
-		for (Map.Entry<String, String[]> entry : parameters.entrySet()) {
-			String name = entry.getKey();
-
-			QName qName = portletQName.getQName(name);
-
-			if (qName == null) {
-				continue;
-			}
-
-			for (Portlet portlet : portlets) {
-				PublicRenderParameter publicRenderParameter =
-					portlet.getPublicRenderParameter(
-						qName.getNamespaceURI(), qName.getLocalPart());
-
-				if (publicRenderParameter == null) {
-					continue;
-				}
-
-				if (publicRenderParameters == null) {
-					publicRenderParameters = PublicRenderParametersPool.get(
-						httpServletRequest, layout.getPlid());
-				}
-
-				String publicRenderParameterName =
-					portletQName.getPublicRenderParameterName(qName);
-
-				if (name.startsWith(
-						PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE)) {
-
-					String[] values = entry.getValue();
-
-					if (lifecycleAction) {
-						String[] oldValues = publicRenderParameters.get(
-							publicRenderParameterName);
-
-						if ((oldValues != null) && (oldValues.length != 0)) {
-							values = ArrayUtil.append(values, oldValues);
-						}
-					}
-
-					publicRenderParameters.put(
-						publicRenderParameterName, values);
-				}
-				else {
-					publicRenderParameters.remove(publicRenderParameterName);
-				}
-			}
-		}
 	}
 
 	private void _render(

--- a/portal-impl/src/com/liferay/portlet/internal/PortletContainerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/PortletContainerImpl.java
@@ -12,7 +12,6 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.model.LayoutType;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.PortletApp;
@@ -168,87 +167,10 @@ public class PortletContainerImpl implements PortletContainer {
 
 	@Override
 	public void processPublicRenderParameters(
-		HttpServletRequest httpServletRequest, Layout layout) {
-
-		processPublicRenderParameters(httpServletRequest, layout, null);
-	}
-
-	@Override
-	public void processPublicRenderParameters(
 		HttpServletRequest httpServletRequest, Layout layout,
-		List<Portlet> portlets, boolean lifecycleAction) {
+		List<Portlet> portlets) {
 
-		PortletQName portletQName = PortletQNameUtil.getPortletQName();
-		Map<String, String[]> publicRenderParameters = null;
-		Map<String, String[]> parameters = httpServletRequest.getParameterMap();
-
-		for (Map.Entry<String, String[]> entry : parameters.entrySet()) {
-			String name = entry.getKey();
-
-			QName qName = portletQName.getQName(name);
-
-			if (qName == null) {
-				continue;
-			}
-
-			for (Portlet portlet : portlets) {
-				PublicRenderParameter publicRenderParameter =
-					portlet.getPublicRenderParameter(
-						qName.getNamespaceURI(), qName.getLocalPart());
-
-				if (publicRenderParameter == null) {
-					continue;
-				}
-
-				if (publicRenderParameters == null) {
-					publicRenderParameters = PublicRenderParametersPool.get(
-						httpServletRequest, layout.getPlid());
-				}
-
-				String publicRenderParameterName =
-					portletQName.getPublicRenderParameterName(qName);
-
-				if (name.startsWith(
-						PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE)) {
-
-					String[] values = entry.getValue();
-
-					if (lifecycleAction) {
-						String[] oldValues = publicRenderParameters.get(
-							publicRenderParameterName);
-
-						if ((oldValues != null) && (oldValues.length != 0)) {
-							values = ArrayUtil.append(values, oldValues);
-						}
-					}
-
-					publicRenderParameters.put(
-						publicRenderParameterName, values);
-				}
-				else {
-					publicRenderParameters.remove(publicRenderParameterName);
-				}
-			}
-		}
-	}
-
-	@Override
-	public void processPublicRenderParameters(
-		HttpServletRequest httpServletRequest, Layout layout, Portlet portlet) {
-
-		LayoutType layoutType = layout.getLayoutType();
-
-		if (!(layoutType instanceof LayoutTypePortlet)) {
-			return;
-		}
-
-		LayoutTypePortlet layoutTypePortlet = (LayoutTypePortlet)layoutType;
-
-		List<Portlet> portlets = layoutTypePortlet.getPortlets();
-
-		portlets.remove(portlet);
-
-		processPublicRenderParameters(
+		_processPublicRenderParameters(
 			httpServletRequest, layout, portlets, false);
 	}
 
@@ -407,7 +329,7 @@ public class PortletContainerImpl implements PortletContainer {
 				LanguageUtil.getLanguageId(httpServletRequest));
 		}
 
-		processPublicRenderParameters(
+		_processPublicRenderParameters(
 			httpServletRequest, layout, Arrays.asList(portlet),
 			themeDisplay.isLifecycleAction());
 
@@ -782,6 +704,64 @@ public class PortletContainerImpl implements PortletContainer {
 		}
 
 		themeDisplay.setSiteGroupId(siteGroupId);
+	}
+
+	private void _processPublicRenderParameters(
+		HttpServletRequest httpServletRequest, Layout layout,
+		List<Portlet> portlets, boolean lifecycleAction) {
+
+		PortletQName portletQName = PortletQNameUtil.getPortletQName();
+		Map<String, String[]> publicRenderParameters = null;
+		Map<String, String[]> parameters = httpServletRequest.getParameterMap();
+
+		for (Map.Entry<String, String[]> entry : parameters.entrySet()) {
+			String name = entry.getKey();
+
+			QName qName = portletQName.getQName(name);
+
+			if (qName == null) {
+				continue;
+			}
+
+			for (Portlet portlet : portlets) {
+				PublicRenderParameter publicRenderParameter =
+					portlet.getPublicRenderParameter(
+						qName.getNamespaceURI(), qName.getLocalPart());
+
+				if (publicRenderParameter == null) {
+					continue;
+				}
+
+				if (publicRenderParameters == null) {
+					publicRenderParameters = PublicRenderParametersPool.get(
+						httpServletRequest, layout.getPlid());
+				}
+
+				String publicRenderParameterName =
+					portletQName.getPublicRenderParameterName(qName);
+
+				if (name.startsWith(
+						PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE)) {
+
+					String[] values = entry.getValue();
+
+					if (lifecycleAction) {
+						String[] oldValues = publicRenderParameters.get(
+							publicRenderParameterName);
+
+						if ((oldValues != null) && (oldValues.length != 0)) {
+							values = ArrayUtil.append(values, oldValues);
+						}
+					}
+
+					publicRenderParameters.put(
+						publicRenderParameterName, values);
+				}
+				else {
+					publicRenderParameters.remove(publicRenderParameterName);
+				}
+			}
+		}
 	}
 
 	private void _render(

--- a/portal-impl/src/com/liferay/portlet/packageinfo
+++ b/portal-impl/src/com/liferay/portlet/packageinfo
@@ -1,1 +1,1 @@
-version 11.0.0
+version 11.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletContainer.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletContainer.java
@@ -43,6 +43,10 @@ public interface PortletContainer {
 		HttpServletRequest httpServletRequest, Layout layout);
 
 	public void processPublicRenderParameters(
+		HttpServletRequest httpServletRequest, Layout layout,
+		List<Portlet> portlets, boolean lifecycleAction);
+
+	public void processPublicRenderParameters(
 		HttpServletRequest httpServletRequest, Layout layout, Portlet portlet);
 
 	public void render(

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletContainer.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletContainer.java
@@ -40,14 +40,8 @@ public interface PortletContainer {
 		throws PortletContainerException;
 
 	public void processPublicRenderParameters(
-		HttpServletRequest httpServletRequest, Layout layout);
-
-	public void processPublicRenderParameters(
 		HttpServletRequest httpServletRequest, Layout layout,
-		List<Portlet> portlets, boolean lifecycleAction);
-
-	public void processPublicRenderParameters(
-		HttpServletRequest httpServletRequest, Layout layout, Portlet portlet);
+		List<Portlet> portlets);
 
 	public void render(
 			HttpServletRequest httpServletRequest,

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletContainerUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletContainerUtil.java
@@ -191,6 +191,14 @@ public class PortletContainerUtil {
 	}
 
 	public static void processPublicRenderParameters(
+		HttpServletRequest httpServletRequest, Layout layout,
+		List<Portlet> portlets, boolean lifecycleAction) {
+
+		_portletContainer.processPublicRenderParameters(
+			httpServletRequest, layout, portlets, lifecycleAction);
+	}
+
+	public static void processPublicRenderParameters(
 		HttpServletRequest httpServletRequest, Layout layout, Portlet portlet) {
 
 		_portletContainer.processPublicRenderParameters(

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletContainerUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletContainerUtil.java
@@ -184,25 +184,11 @@ public class PortletContainerUtil {
 	}
 
 	public static void processPublicRenderParameters(
-		HttpServletRequest httpServletRequest, Layout layout) {
-
-		_portletContainer.processPublicRenderParameters(
-			httpServletRequest, layout);
-	}
-
-	public static void processPublicRenderParameters(
 		HttpServletRequest httpServletRequest, Layout layout,
-		List<Portlet> portlets, boolean lifecycleAction) {
+		List<Portlet> portlets) {
 
 		_portletContainer.processPublicRenderParameters(
-			httpServletRequest, layout, portlets, lifecycleAction);
-	}
-
-	public static void processPublicRenderParameters(
-		HttpServletRequest httpServletRequest, Layout layout, Portlet portlet) {
-
-		_portletContainer.processPublicRenderParameters(
-			httpServletRequest, layout, portlet);
+			httpServletRequest, layout, portlets);
 	}
 
 	public static void render(

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/packageinfo
@@ -1,1 +1,1 @@
-version 35.0.0
+version 36.0.0

--- a/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
+++ b/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
@@ -360,7 +360,7 @@ public class RuntimeTag extends TagSupport implements DirectTag {
 
 				PortletContainerUtil.processPublicRenderParameters(
 					httpServletRequest, layout,
-					Collections.singletonList(portlet), false);
+					Collections.singletonList(portlet));
 
 				PortletContainerUtil.render(
 					httpServletRequest, httpServletResponse, portlet);

--- a/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
+++ b/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
@@ -49,6 +49,7 @@ import jakarta.servlet.jsp.JspException;
 import jakarta.servlet.jsp.PageContext;
 import jakarta.servlet.jsp.tagext.TagSupport;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -356,6 +357,10 @@ public class RuntimeTag extends TagSupport implements DirectTag {
 					PortletContainerUtil.renderHeaders(
 						httpServletRequest, httpServletResponse, portlet);
 				}
+
+				PortletContainerUtil.processPublicRenderParameters(
+					httpServletRequest, layout,
+					Collections.singletonList(portlet), false);
 
 				PortletContainerUtil.render(
 					httpServletRequest, httpServletResponse, portlet);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86498

**What is being fixed:** A portlet embedded on a content page via the
RuntimeTag does not receive its supported public render parameters. When
the incoming URL only contains the `p_r_p_<name>=<value>` query parameter
(i.e. a direct URL rather than a `PortletURLBuilder`-generated render
URL), the portlet renders without the PRP value even though its
`jakarta.portlet.supported-public-render-parameter` service property is
declared correctly.

**How it is being fixed:** `RuntimeTag` now calls
`PortletContainerUtil#processPublicRenderParameters` before rendering the
embedded portlet, so the public render parameters are populated into the
pool for the current plid. Along the way, the
`PortletContainer#processPublicRenderParameters` API surface is
simplified: the 2-arg and 3-arg(Portlet) overloads are removed and
replaced by a single 3-arg variant taking `List<Portlet>`; the
lifecycle-action boolean stays on a private helper inside
`PortletContainerImpl`. The existing callers (`RenderPortletAction`,
`LayoutAction`, the two wrappers, and the util) are updated to produce
the portlets list themselves, and the affected package versions are
bumped per baseline. Coverage is added in `PublicRenderParameterTest`
for both a direct `?p_r_p_…` URL and a `PortletURLBuilder`-generated
render URL on a content layout, and the four tests in that class are
refactored onto a single `_testPublicRenderParameter` helper with the
per-test PRP name/value seeded in an overridden `setUp()`. The PRP name
is randomized with a letter-leading prefix so it is always a valid
QName local part.