### PR TITLE
LPD-86403 Fix ServiceContext memory leak during layout reindexing and copying

### DIFF
--- a/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/internal/info/item/provider/test/BlogsEntryInfoItemFieldValuesProviderTest.java
+++ b/modules/apps/blogs/blogs-web-test/src/testIntegration/java/com/liferay/blogs/web/internal/info/item/provider/test/BlogsEntryInfoItemFieldValuesProviderTest.java
@@ -113,9 +113,6 @@ public class BlogsEntryInfoItemFieldValuesProviderTest {
 
 	@Test
 	public void testGetInfoItemFieldValuesWithCoverImage() throws Exception {
-		ServiceContext originalServiceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
 		ThemeDisplay themeDisplay = _getThemeDisplay();
 
 		ServiceContextThreadLocal.pushServiceContext(
@@ -151,17 +148,13 @@ public class BlogsEntryInfoItemFieldValuesProviderTest {
 				blogsEntry.getCoverImageURL(themeDisplay), webImage.getURL());
 		}
 		finally {
-			ServiceContextThreadLocal.pushServiceContext(
-				originalServiceContext);
+			ServiceContextThreadLocal.popServiceContext();
 		}
 	}
 
 	@Test
 	public void testGetInfoItemFieldValuesWithCoverImageAndSmallImage()
 		throws Exception {
-
-		ServiceContext originalServiceContext =
-			ServiceContextThreadLocal.getServiceContext();
 
 		ThemeDisplay themeDisplay = _getThemeDisplay();
 
@@ -200,16 +193,12 @@ public class BlogsEntryInfoItemFieldValuesProviderTest {
 				blogsEntry.getSmallImageURL(themeDisplay), webImage.getURL());
 		}
 		finally {
-			ServiceContextThreadLocal.pushServiceContext(
-				originalServiceContext);
+			ServiceContextThreadLocal.popServiceContext();
 		}
 	}
 
 	@Test
 	public void testGetInfoItemFieldValuesWithSmallImage() throws Exception {
-		ServiceContext originalServiceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
 		ThemeDisplay themeDisplay = _getThemeDisplay();
 
 		ServiceContextThreadLocal.pushServiceContext(
@@ -245,8 +234,7 @@ public class BlogsEntryInfoItemFieldValuesProviderTest {
 				blogsEntry.getSmallImageURL(themeDisplay), webImage.getURL());
 		}
 		finally {
-			ServiceContextThreadLocal.pushServiceContext(
-				originalServiceContext);
+			ServiceContextThreadLocal.popServiceContext();
 		}
 	}
 

--- a/modules/apps/content-dashboard/content-dashboard-blogs-test/src/testIntegration/java/com/liferay/content/dashboard/blogs/internal/item/action/provider/test/PreviewImageBlogsEntryContentDashboardItemActionProviderTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-blogs-test/src/testIntegration/java/com/liferay/content/dashboard/blogs/internal/item/action/provider/test/PreviewImageBlogsEntryContentDashboardItemActionProviderTest.java
@@ -74,9 +74,6 @@ public class PreviewImageBlogsEntryContentDashboardItemActionProviderTest {
 
 	@Test
 	public void testGetContentDashboardItemAction() throws Exception {
-		ServiceContext originalServiceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
 		try {
 			FileEntry fileEntry = _getTempFileEntry(
 				TestPropsValues.getUserId(), RandomTestUtil.randomString(),
@@ -120,8 +117,7 @@ public class PreviewImageBlogsEntryContentDashboardItemActionProviderTest {
 				contentDashboardItemAction.getURL());
 		}
 		finally {
-			ServiceContextThreadLocal.pushServiceContext(
-				originalServiceContext);
+			ServiceContextThreadLocal.popServiceContext();
 		}
 	}
 
@@ -140,9 +136,6 @@ public class PreviewImageBlogsEntryContentDashboardItemActionProviderTest {
 
 	@Test
 	public void testIsShow() throws Exception {
-		ServiceContext originalServiceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
 		try {
 			FileEntry fileEntry = _getTempFileEntry(
 				TestPropsValues.getUserId(), RandomTestUtil.randomString(),
@@ -181,8 +174,7 @@ public class PreviewImageBlogsEntryContentDashboardItemActionProviderTest {
 					blogsEntry, mockHttpServletRequest));
 		}
 		finally {
-			ServiceContextThreadLocal.pushServiceContext(
-				originalServiceContext);
+			ServiceContextThreadLocal.popServiceContext();
 		}
 	}
 

--- a/modules/apps/content-dashboard/content-dashboard-journal-test/src/testIntegration/java/com/liferay/content/dashboard/journal/internal/item/action/provider/test/PreviewImageJournalArticleContentDashboardItemActionProviderTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-journal-test/src/testIntegration/java/com/liferay/content/dashboard/journal/internal/item/action/provider/test/PreviewImageJournalArticleContentDashboardItemActionProviderTest.java
@@ -71,9 +71,6 @@ public class PreviewImageJournalArticleContentDashboardItemActionProviderTest {
 
 	@Test
 	public void testGetContentDashboardItemAction() throws Exception {
-		ServiceContext originalServiceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
 		ThemeDisplay themeDisplay = _getThemeDisplay();
 
 		ServiceContextThreadLocal.pushServiceContext(
@@ -125,8 +122,7 @@ public class PreviewImageJournalArticleContentDashboardItemActionProviderTest {
 				contentDashboardItemAction.getURL());
 		}
 		finally {
-			ServiceContextThreadLocal.pushServiceContext(
-				originalServiceContext);
+			ServiceContextThreadLocal.popServiceContext();
 		}
 	}
 
@@ -145,9 +141,6 @@ public class PreviewImageJournalArticleContentDashboardItemActionProviderTest {
 
 	@Test
 	public void testIsShow() throws Exception {
-		ServiceContext originalServiceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
 		ServiceContextThreadLocal.pushServiceContext(
 			_getServiceContext(_getThemeDisplay()));
 
@@ -192,8 +185,7 @@ public class PreviewImageJournalArticleContentDashboardItemActionProviderTest {
 					journalArticle, new MockHttpServletRequest()));
 		}
 		finally {
-			ServiceContextThreadLocal.pushServiceContext(
-				originalServiceContext);
+			ServiceContextThreadLocal.popServiceContext();
 		}
 	}
 

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/contributor/test/FragmentCollectionContributorPropagationTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/contributor/test/FragmentCollectionContributorPropagationTest.java
@@ -252,9 +252,6 @@ public class FragmentCollectionContributorPropagationTest {
 		String modifiedHTML =
 			"<div>" + RandomTestUtil.randomString() + "</div>";
 
-		ServiceContext originalServiceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
 		try {
 			_setUpServiceContext();
 
@@ -276,8 +273,7 @@ public class FragmentCollectionContributorPropagationTest {
 			_assertCompanyContext(TestPropsValues.getCompanyId());
 		}
 		finally {
-			ServiceContextThreadLocal.pushServiceContext(
-				originalServiceContext);
+			ServiceContextThreadLocal.popServiceContext();
 		}
 
 		Map<Long, String> companyIdsMap =

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/info/item/provider/test/JournalArticleInfoItemFieldValuesProviderTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/info/item/provider/test/JournalArticleInfoItemFieldValuesProviderTest.java
@@ -206,9 +206,6 @@ public class JournalArticleInfoItemFieldValuesProviderTest {
 				0, 0, 0, 0, 0, 0, 0, 0, true, 0, 0, 0, 0, 0, true, true, false,
 				0, 0, null, null, serviceContext);
 
-		ServiceContext originalServiceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
 		ServiceContextThreadLocal.pushServiceContext(
 			_getServiceContext(_getThemeDisplay()));
 
@@ -227,8 +224,7 @@ public class JournalArticleInfoItemFieldValuesProviderTest {
 			_assertInfoFieldValue(fieldName2, journalArticle);
 		}
 		finally {
-			ServiceContextThreadLocal.pushServiceContext(
-				originalServiceContext);
+			ServiceContextThreadLocal.popServiceContext();
 		}
 	}
 
@@ -272,9 +268,6 @@ public class JournalArticleInfoItemFieldValuesProviderTest {
 
 	@Test
 	public void testGetInfoItemFieldValuesWithSmallImage() throws Exception {
-		ServiceContext originalServiceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
 		ThemeDisplay themeDisplay = _getThemeDisplay();
 
 		ServiceContextThreadLocal.pushServiceContext(
@@ -330,8 +323,7 @@ public class JournalArticleInfoItemFieldValuesProviderTest {
 				webImage.getURL());
 		}
 		finally {
-			ServiceContextThreadLocal.pushServiceContext(
-				originalServiceContext);
+			ServiceContextThreadLocal.popServiceContext();
 		}
 	}
 

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutServiceContextHelperImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutServiceContextHelperImpl.java
@@ -159,22 +159,22 @@ public class LayoutServiceContextHelperImpl
 				PermissionThreadLocal.getPermissionChecker();
 			_originalName = PrincipalThreadLocal.getName();
 
-			_originalServiceContext =
+			ServiceContext originalServiceContext =
 				ServiceContextThreadLocal.getServiceContext();
 
-			if (_originalServiceContext == null) {
+			if (originalServiceContext == null) {
 				_httpServletRequest = _createMockHttpServletRequest();
 				_httpServletResponse = new DummyHttpServletResponse();
 				_originalHttpServletRequest = null;
 			}
 			else {
 				ThemeDisplay themeDisplay =
-					_originalServiceContext.getThemeDisplay();
+					originalServiceContext.getThemeDisplay();
 
-				if (_originalServiceContext.getRequest() != null) {
-					_httpServletRequest = _originalServiceContext.getRequest();
+				if (originalServiceContext.getRequest() != null) {
+					_httpServletRequest = originalServiceContext.getRequest();
 					_originalHttpServletRequest =
-						_originalServiceContext.getRequest();
+						originalServiceContext.getRequest();
 				}
 				else if ((themeDisplay != null) &&
 						 (themeDisplay.getRequest() != null)) {
@@ -187,9 +187,8 @@ public class LayoutServiceContextHelperImpl
 					_originalHttpServletRequest = null;
 				}
 
-				if (_originalServiceContext.getResponse() != null) {
-					_httpServletResponse =
-						_originalServiceContext.getResponse();
+				if (originalServiceContext.getResponse() != null) {
+					_httpServletResponse = originalServiceContext.getResponse();
 				}
 				else if ((themeDisplay != null) &&
 						 (themeDisplay.getResponse() != null)) {
@@ -257,8 +256,7 @@ public class LayoutServiceContextHelperImpl
 			PermissionThreadLocal.setPermissionChecker(
 				_originalPermissionChecker);
 			PrincipalThreadLocal.setName(_originalName, false);
-			ServiceContextThreadLocal.pushServiceContext(
-				_originalServiceContext);
+			ServiceContextThreadLocal.popServiceContext();
 
 			if (_originalHttpServletRequest == null) {
 				return;
@@ -558,7 +556,6 @@ public class LayoutServiceContextHelperImpl
 			_originalHttpServletRequestAttributesMap;
 		private final String _originalName;
 		private final PermissionChecker _originalPermissionChecker;
-		private final ServiceContext _originalServiceContext;
 		private final PermissionChecker _permissionChecker;
 		private final User _user;
 

--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
@@ -196,6 +196,8 @@ public class LayoutLocalServiceWrapper
 		ServiceContext currentServiceContext =
 			ServiceContextThreadLocal.getServiceContext();
 
+		boolean pushedServiceContext = false;
+
 		try (SafeCloseable safeCloseable =
 				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
 					layout.getCtCollectionId())) {
@@ -213,6 +215,8 @@ public class LayoutLocalServiceWrapper
 				serviceContext.setUserId(user.getUserId());
 
 				ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
+				pushedServiceContext = true;
 			}
 
 			TransactionInvokerUtil.invoke(
@@ -236,7 +240,9 @@ public class LayoutLocalServiceWrapper
 		finally {
 			CopyLayoutThreadLocal.setCopyLayout(copyLayout);
 
-			ServiceContextThreadLocal.pushServiceContext(currentServiceContext);
+			if (pushedServiceContext) {
+				ServiceContextThreadLocal.popServiceContext();
+			}
 		}
 	}
 
@@ -333,6 +339,8 @@ public class LayoutLocalServiceWrapper
 		ServiceContext currentServiceContext =
 			ServiceContextThreadLocal.getServiceContext();
 
+		boolean pushedServiceContext = false;
+
 		long ctCollectionId = sourceLayout.getCtCollectionId();
 
 		if (ctCollectionId == 0) {
@@ -362,6 +370,8 @@ public class LayoutLocalServiceWrapper
 				serviceContext.setUserId(user.getUserId());
 
 				ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
+				pushedServiceContext = true;
 			}
 
 			return TransactionInvokerUtil.invoke(
@@ -381,7 +391,9 @@ public class LayoutLocalServiceWrapper
 		finally {
 			CopyLayoutThreadLocal.setCopyLayout(copyLayout);
 
-			ServiceContextThreadLocal.pushServiceContext(currentServiceContext);
+			if (pushedServiceContext) {
+				ServiceContextThreadLocal.popServiceContext();
+			}
 		}
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86403

**What is being fixed:**
Content page reindexing and certain layout copying/updating operations were causing OutOfMemoryErrors. This was due to a memory leak in `ServiceContextThreadLocal`, which uses a stack-based implementation. Several utility classes and wrappers were pushing a temporary `ServiceContext` onto the stack but incorrectly "restoring" the state by pushing the original context back on top instead of popping the temporary one. This caused the stack to grow indefinitely during long-running operations like full site reindexing.

**How it is being fixed:**
The fixes across `LayoutServiceContextHelperImpl`, `LayoutLocalServiceWrapper`, and various integration tests replace the incorrect "push-to-restore" pattern with a proper `popServiceContext()`. 
In `LayoutServiceContextHelperImpl`, the `ServiceContextTemporarySwapper` now properly pops the temporary context in its `close()` method.
In `LayoutLocalServiceWrapper`, a boolean flag is introduced to track if a temporary context was pushed, ensuring it is only popped if it was actually added to the stack.
The same pattern was corrected in several integration tests to prevent stack growth and ensure a clean thread-local state during test execution.