### PR TITLE
[ObjectEntry-UnsupportedOperationException]LPD-86957 Make LayoutServiceContextHelperImpl also update the corresp…

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutServiceContextHelperImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutServiceContextHelperImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.layout.internal.util;
 
 import com.liferay.layout.util.LayoutServiceContextHelper;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -20,6 +21,7 @@ import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.model.Theme;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
@@ -150,6 +152,10 @@ public class LayoutServiceContextHelperImpl
 
 			_company = company;
 
+			_companyIdSafeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					_company.getCompanyId());
+
 			_attributes = ConcurrentHashMapBuilder.<String, Object>put(
 				WebKeys.CTX,
 				ServletContextPool.get(_portal.getServletContextName())
@@ -257,6 +263,8 @@ public class LayoutServiceContextHelperImpl
 				_originalPermissionChecker);
 			PrincipalThreadLocal.setName(_originalName, false);
 			ServiceContextThreadLocal.popServiceContext();
+
+			_companyIdSafeCloseable.close();
 
 			if (_originalHttpServletRequest == null) {
 				return;
@@ -518,6 +526,7 @@ public class LayoutServiceContextHelperImpl
 
 		private final Map<String, Object> _attributes;
 		private final Company _company;
+		private final SafeCloseable _companyIdSafeCloseable;
 		private final Group _group;
 		private final HttpServletRequest _httpServletRequest;
 		private final HttpServletResponse _httpServletResponse;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86957


The issue only can be reproduced by the first visit on the site of the non-default virtual instance after the first startup of portal with a db that generated by SampleSQLBuilder for test case ObjectEntry, 

 The `UnsupportedOperationException` is thrown by `com.liferay.portal.util.PortalInstances.getCompanyId(HttpServletRequest request)`  but it also enforces a consistency check:
 It retrieves the companyId from the request attribute `WebKeys.COMPANY_ID` (which was the companId of the non-default company).
 It retrieves the currentCompanyId from` CompanyThreadLocal.getCompanyId()` (which was the companId of the default company).
If the thread local is already set to a specific company (not SYSTEM/0), and the request attribute suggests a different company that is
         also not the default instance, portal throws this `UnsupportedOperationException`
The stack trace shows the error occurring during the rendering of an editor (ckeditor5_classic.jsp) which calls `ItemSelectorImpl.getItemSelectorURL`, the culprit is `LayoutServiceContextHelperImpl `was responsible for temporarily changing the context to a different company to perform service calls or render UI components, it updated the HttpServletRequest attribute `WebKeys.COMPANY_ID`, but it did not update the `CompanyThreadLocal`, the Result is the `HttpServletRequest` and the `CompanyThreadLocal` became out of sync.



Hi @victorhcunha 

Please run a all-database and a normal runtime performance test on Object Entry test case on the head of master, make sure the portal version includes the change of [LPD-73762](https://github.com/liferay/liferay-portal/commit/18c5353cffcd13c21bfaaa566057a2769352abf8), please upload the test results zip for warmup and the normal run, thanks!

[LPD-73762]: https://liferay.atlassian.net/browse/LPD-73762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ