### PR TITLE
LPD-84062

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/struts/UpdateLayoutStrutsAction.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/struts/UpdateLayoutStrutsAction.java
@@ -60,8 +60,6 @@ import jakarta.portlet.PortletPreferences;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import java.util.Set;
-
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -421,17 +419,14 @@ public class UpdateLayoutStrutsAction implements StrutsAction {
 				0, ActionKeys.ADD_TO_PAGE);
 		}
 
-		Set<String> categoryNames = portlet.getCategoryNames();
-
-		PortletCategory portletCategory = (PortletCategory)WebAppPool.get(
+		PortletCategory rootPortletCategory = (PortletCategory)WebAppPool.get(
 			themeDisplay.getCompanyId(), WebKeys.PORTLET_CATEGORY);
 
-		for (PortletCategory curPortletCategory :
-				portletCategory.getCategories()) {
+		for (String categoryName : portlet.getCategoryNames()) {
+			PortletCategory portletCategory = rootPortletCategory.getCategory(
+				categoryName);
 
-			if (_containsPortletCategoryPermission(
-					categoryNames, curPortletCategory)) {
-
+			if ((portletCategory != null) && !portletCategory.isHidden()) {
 				return;
 			}
 		}
@@ -441,29 +436,6 @@ public class UpdateLayoutStrutsAction implements StrutsAction {
 			StringBundler.concat(
 				Portlet.class.getName(), StringPool.UNDERLINE, portletId),
 			0, ActionKeys.ADD_TO_PAGE);
-	}
-
-	private boolean _containsPortletCategoryPermission(
-		Set<String> categoryNames, PortletCategory portletCategory) {
-
-		if (!portletCategory.isHidden() &&
-			(categoryNames.contains(portletCategory.getName()) ||
-			 categoryNames.contains(portletCategory.getPath()))) {
-
-			return true;
-		}
-
-		for (PortletCategory childPortletCategory :
-				portletCategory.getCategories()) {
-
-			if (_containsPortletCategoryPermission(
-					categoryNames, childPortletCategory)) {
-
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	@Reference

--- a/modules/apps/portal/portal-deploy-hot-test/src/testIntegration/java/com/liferay/portal/deploy/hot/test/PortletHotDeployListenerTest.java
+++ b/modules/apps/portal/portal-deploy-hot-test/src/testIntegration/java/com/liferay/portal/deploy/hot/test/PortletHotDeployListenerTest.java
@@ -13,16 +13,21 @@ import com.liferay.portal.deploy.hot.PortletHotDeployListener;
 import com.liferay.portal.kernel.deploy.hot.HotDeployEvent;
 import com.liferay.portal.kernel.deploy.hot.HotDeployUtil;
 import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.model.PortletCategory;
 import com.liferay.portal.kernel.servlet.ServletContextClassLoaderPool;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.AggregateClassLoader;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.WebAppPool;
 
 import jakarta.servlet.ServletContext;
 
@@ -53,7 +58,7 @@ public class PortletHotDeployListenerTest {
 		new LiferayIntegrationTestRule();
 
 	@Test
-	public void testPortletCategoryNames() {
+	public void testPortletCategoryNames() throws Exception {
 		_testPortletCategoryNames(
 			Collections.singletonMap(
 				_PORTLET_NAME_PREFIX + RandomTestUtil.randomString(), null));
@@ -192,7 +197,8 @@ public class PortletHotDeployListenerTest {
 	}
 
 	private void _testPortletCategoryNames(
-		Map<String, String> portletCategoryNames) {
+			Map<String, String> portletCategoryNames)
+		throws Exception {
 
 		Set<String> portletNames = portletCategoryNames.keySet();
 
@@ -223,6 +229,10 @@ public class PortletHotDeployListenerTest {
 				portletList.toString(), portletCategoryNames.size(),
 				portletList.size());
 
+			PortletCategory rootPortletCategory =
+				(PortletCategory)WebAppPool.get(
+					TestPropsValues.getCompanyId(), WebKeys.PORTLET_CATEGORY);
+
 			for (Portlet portlet : portletList) {
 				Assert.assertTrue(
 					portletNames.contains(portlet.getPortletName()));
@@ -237,11 +247,54 @@ public class PortletHotDeployListenerTest {
 						categoryNames.toString(),
 						Collections.singleton("category.undefined"),
 						categoryNames);
+
+					PortletCategory portletCategory =
+						rootPortletCategory.getCategory("category.undefined");
+
+					Assert.assertEquals(
+						"category.undefined", portletCategory.getName());
+					Assert.assertEquals(
+						"root//category.undefined", portletCategory.getPath());
+
+					Set<String> portletIds = portletCategory.getPortletIds();
+
+					Assert.assertTrue(
+						portletIds.toString(),
+						portletIds.contains(portlet.getPortletId()));
 				}
 				else {
 					Assert.assertEquals(
 						categoryNames.toString(),
 						Collections.singleton(categoryName), categoryNames);
+
+					String[] nestedCategoryNames = StringUtil.split(
+						categoryName, StringPool.DOUBLE_SLASH);
+
+					PortletCategory portletCategory = rootPortletCategory;
+
+					StringBundler sb = new StringBundler();
+
+					sb.append("root");
+
+					for (String nestedCategoryName : nestedCategoryNames) {
+						portletCategory = portletCategory.getCategory(
+							nestedCategoryName);
+
+						Assert.assertEquals(
+							nestedCategoryName, portletCategory.getName());
+
+						sb.append(StringPool.DOUBLE_SLASH);
+						sb.append(nestedCategoryName);
+
+						Assert.assertEquals(
+							sb.toString(), portletCategory.getPath());
+					}
+
+					Set<String> portletIds = portletCategory.getPortletIds();
+
+					Assert.assertTrue(
+						portletIds.toString(),
+						portletIds.contains(portlet.getPortletId()));
 				}
 			}
 		}

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PortletTrackerTest.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PortletTrackerTest.java
@@ -323,6 +323,95 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 	}
 
 	@Test
+	public void testPortletDisplayCategoryWithNestedCategories()
+		throws Exception {
+
+		String childCategoryName = RandomTestUtil.randomString();
+		String parentCategoryName = RandomTestUtil.randomString();
+
+		String displayCategory = StringBundler.concat(
+			parentCategoryName, StringPool.DOUBLE_SLASH, childCategoryName);
+
+		try {
+			setUpPortlet(
+				_internalClassTestPortlet,
+				HashMapDictionaryBuilder.<String, Object>put(
+					"com.liferay.portlet.display-category", displayCategory
+				).build(),
+				RandomTestUtil.randomString(), false);
+
+			PortletCategory rootCategory1 = (PortletCategory)WebAppPool.get(
+				_company1.getCompanyId(), WebKeys.PORTLET_CATEGORY);
+
+			PortletCategory parentCategory1 = rootCategory1.getCategory(
+				parentCategoryName);
+
+			Assert.assertEquals(parentCategoryName, parentCategory1.getName());
+			Assert.assertEquals(
+				"root//" + parentCategoryName, parentCategory1.getPath());
+
+			PortletCategory childCategory1 = parentCategory1.getCategory(
+				childCategoryName);
+
+			Assert.assertEquals(childCategoryName, childCategory1.getName());
+			Assert.assertEquals(
+				"root//" + displayCategory, childCategory1.getPath());
+
+			PortletCategory rootCategory2 = (PortletCategory)WebAppPool.get(
+				_company2.getCompanyId(), WebKeys.PORTLET_CATEGORY);
+
+			PortletCategory parentCategory2 = rootCategory2.getCategory(
+				parentCategoryName);
+
+			Assert.assertEquals(parentCategoryName, parentCategory2.getName());
+			Assert.assertEquals(
+				"root//" + parentCategoryName, parentCategory2.getPath());
+
+			PortletCategory childCategory2 = parentCategory2.getCategory(
+				childCategoryName);
+
+			Assert.assertEquals(childCategoryName, childCategory2.getName());
+			Assert.assertEquals(
+				"root//" + displayCategory, childCategory2.getPath());
+
+			Company company = CompanyTestUtil.addCompany();
+
+			try {
+				PortletCategory rootCategory3 = (PortletCategory)WebAppPool.get(
+					company.getCompanyId(), WebKeys.PORTLET_CATEGORY);
+
+				PortletCategory parentCategory3 = rootCategory3.getCategory(
+					parentCategoryName);
+
+				Assert.assertEquals(
+					parentCategoryName, parentCategory3.getName());
+				Assert.assertEquals(
+					"root//" + parentCategoryName, parentCategory3.getPath());
+
+				PortletCategory childCategory3 = parentCategory3.getCategory(
+					childCategoryName);
+
+				Assert.assertEquals(
+					childCategoryName, childCategory3.getName());
+				Assert.assertEquals(
+					"root//" + displayCategory, childCategory3.getPath());
+			}
+			finally {
+				_companyLocalService.deleteCompany(company);
+			}
+		}
+		finally {
+			for (ServiceRegistration<?> serviceRegistration :
+					serviceRegistrations) {
+
+				serviceRegistration.unregister();
+			}
+
+			serviceRegistrations.clear();
+		}
+	}
+
+	@Test
 	public void testPortletTrackerBundleStopCleanup() throws Exception {
 		Assume.assumeFalse(PropsValues.DATABASE_PARTITION_ENABLED);
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PortletTrackerTest.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/PortletTrackerTest.java
@@ -12,6 +12,8 @@ import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Portlet;
@@ -222,25 +224,39 @@ public class PortletTrackerTest extends BasePortletContainerTestCase {
 				).build(),
 				RandomTestUtil.randomString(), false);
 
-			PortletCategory portletCategory1 = (PortletCategory)WebAppPool.get(
+			PortletCategory rootCategory1 = (PortletCategory)WebAppPool.get(
 				_company1.getCompanyId(), WebKeys.PORTLET_CATEGORY);
 
-			Assert.assertNotNull(portletCategory1.getCategory(displayCategory));
+			PortletCategory portletCategory1 = rootCategory1.getCategory(
+				displayCategory);
 
-			PortletCategory portletCategory2 = (PortletCategory)WebAppPool.get(
+			Assert.assertEquals(displayCategory, portletCategory1.getName());
+			Assert.assertEquals(
+				"root//" + displayCategory, portletCategory1.getPath());
+
+			PortletCategory rootCategory2 = (PortletCategory)WebAppPool.get(
 				_company2.getCompanyId(), WebKeys.PORTLET_CATEGORY);
 
-			Assert.assertNotNull(portletCategory2.getCategory(displayCategory));
+			PortletCategory portletCategory2 = rootCategory2.getCategory(
+				displayCategory);
+
+			Assert.assertEquals(displayCategory, portletCategory2.getName());
+			Assert.assertEquals(
+				"root//" + displayCategory, portletCategory2.getPath());
 
 			Company company = CompanyTestUtil.addCompany();
 
 			try {
-				PortletCategory portletCategory3 =
-					(PortletCategory)WebAppPool.get(
-						company.getCompanyId(), WebKeys.PORTLET_CATEGORY);
+				PortletCategory rootCategory3 = (PortletCategory)WebAppPool.get(
+					company.getCompanyId(), WebKeys.PORTLET_CATEGORY);
 
-				Assert.assertNotNull(
-					portletCategory3.getCategory(displayCategory));
+				PortletCategory portletCategory3 = rootCategory3.getCategory(
+					displayCategory);
+
+				Assert.assertEquals(
+					displayCategory, portletCategory3.getName());
+				Assert.assertEquals(
+					"root//" + displayCategory, portletCategory3.getPath());
 			}
 			finally {
 				_companyLocalService.deleteCompany(company);

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -166,15 +166,13 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 			return;
 		}
 
+		PortletCategory rootPortletCategory = new PortletCategory();
+
 		PortletCategory newPortletCategory = new PortletCategory(categoryName);
 
-		if (newPortletCategory.getParentCategory() == null) {
-			PortletCategory rootPortletCategory = new PortletCategory();
+		rootPortletCategory.addCategory(newPortletCategory.getRootCategory());
 
-			rootPortletCategory.addCategory(newPortletCategory);
-		}
-
-		portletCategory.merge(newPortletCategory.getRootCategory());
+		portletCategory.merge(rootPortletCategory);
 	}
 
 	@Override
@@ -2958,20 +2956,19 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 		portletCategory.separate(portlet.getPortletId());
 
 		for (String categoryName : portlet.getCategoryNames()) {
+			PortletCategory rootPortletCategory = new PortletCategory();
+
 			PortletCategory newPortletCategory = new PortletCategory(
 				categoryName);
 
-			if (newPortletCategory.getParentCategory() == null) {
-				PortletCategory rootPortletCategory = new PortletCategory();
-
-				rootPortletCategory.addCategory(newPortletCategory);
-			}
+			rootPortletCategory.addCategory(
+				newPortletCategory.getRootCategory());
 
 			Set<String> portletIds = newPortletCategory.getPortletIds();
 
 			portletIds.add(portlet.getPortletId());
 
-			portletCategory.merge(newPortletCategory.getRootCategory());
+			portletCategory.merge(rootPortletCategory);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -166,13 +166,9 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 			return;
 		}
 
-		PortletCategory rootPortletCategory = new PortletCategory();
-
 		PortletCategory newPortletCategory = new PortletCategory(categoryName);
 
-		rootPortletCategory.addCategory(newPortletCategory.getRootCategory());
-
-		portletCategory.merge(rootPortletCategory);
+		portletCategory.mergeCategory(newPortletCategory.getRootCategory());
 	}
 
 	@Override
@@ -2956,19 +2952,14 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 		portletCategory.separate(portlet.getPortletId());
 
 		for (String categoryName : portlet.getCategoryNames()) {
-			PortletCategory rootPortletCategory = new PortletCategory();
-
 			PortletCategory newPortletCategory = new PortletCategory(
 				categoryName);
-
-			rootPortletCategory.addCategory(
-				newPortletCategory.getRootCategory());
 
 			Set<String> portletIds = newPortletCategory.getPortletIds();
 
 			portletIds.add(portlet.getPortletId());
 
-			portletCategory.merge(rootPortletCategory);
+			portletCategory.mergeCategory(newPortletCategory.getRootCategory());
 		}
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/model/PortletCategory.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/PortletCategory.java
@@ -75,7 +75,21 @@ public class PortletCategory implements Serializable {
 	}
 
 	public PortletCategory getCategory(String name) {
-		return _portletCategories.get(name);
+		int index = name.indexOf(_DELIMITER);
+
+		if (index == -1) {
+			return _portletCategories.get(name);
+		}
+
+		PortletCategory portletCategory = _portletCategories.get(
+			name.substring(0, index));
+
+		if (portletCategory == null) {
+			return null;
+		}
+
+		return portletCategory.getCategory(
+			name.substring(index + _DELIMITER.length()));
 	}
 
 	public String getName() {

--- a/portal-kernel/src/com/liferay/portal/kernel/model/PortletCategory.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/PortletCategory.java
@@ -170,6 +170,12 @@ public class PortletCategory implements Serializable {
 
 	protected void setPath(String path) {
 		_path = path;
+
+		for (PortletCategory portletCategory : getCategories()) {
+			portletCategory.setPath(
+				StringBundler.concat(
+					_path, _DELIMITER, portletCategory.getName()));
+		}
 	}
 
 	private static final String _DELIMITER = StringPool.DOUBLE_SLASH;

--- a/portal-kernel/src/com/liferay/portal/kernel/model/PortletCategory.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/PortletCategory.java
@@ -124,6 +124,18 @@ public class PortletCategory implements Serializable {
 		merge(this, newPortletCategory);
 	}
 
+	public void mergeCategory(PortletCategory portletCategory) {
+		PortletCategory curPortletCategory = _portletCategories.get(
+			portletCategory.getName());
+
+		if (curPortletCategory != null) {
+			merge(curPortletCategory, portletCategory);
+		}
+		else {
+			addCategory(portletCategory);
+		}
+	}
+
 	public void separate(Set<String> portletIds) {
 		for (PortletCategory portletCategory : _portletCategories.values()) {
 			portletCategory.separate(portletIds);

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/model/PortletCategoryTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/model/PortletCategoryTest.java
@@ -1,0 +1,100 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.model;
+
+import com.liferay.portal.kernel.util.SetUtil;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Eric Yan
+ */
+public class PortletCategoryTest {
+
+	@Test
+	public void testGetCategory() {
+		PortletCategory childPortletCategory = new PortletCategory("child");
+		PortletCategory parentPortletCategory = new PortletCategory("parent");
+
+		parentPortletCategory.addCategory(childPortletCategory);
+
+		PortletCategory rootPortletCategory = new PortletCategory();
+
+		rootPortletCategory.addCategory(parentPortletCategory);
+
+		Assert.assertSame(
+			parentPortletCategory, rootPortletCategory.getCategory("parent"));
+		Assert.assertSame(
+			childPortletCategory,
+			rootPortletCategory.getCategory("parent//child"));
+
+		Assert.assertSame(
+			childPortletCategory, parentPortletCategory.getCategory("child"));
+
+		Assert.assertNull(rootPortletCategory.getCategory("root//parent"));
+		Assert.assertNull(
+			rootPortletCategory.getCategory("root//parent//child"));
+		Assert.assertNull(parentPortletCategory.getCategory("parent//child"));
+	}
+
+	@Test
+	public void testMergeCategory() {
+		PortletCategory rootPortletCategory = new PortletCategory();
+
+		PortletCategory portletCategory1 = new PortletCategory(
+			"parent", Collections.singleton("portletId1"));
+
+		Set<String> portletIds = portletCategory1.getPortletIds();
+
+		rootPortletCategory.mergeCategory(portletCategory1);
+
+		Assert.assertSame(
+			portletCategory1, rootPortletCategory.getCategory("parent"));
+
+		Assert.assertEquals(Collections.singleton("portletId1"), portletIds);
+
+		PortletCategory portletCategory2 = new PortletCategory(
+			"parent", Collections.singleton("portletId2"));
+
+		rootPortletCategory.mergeCategory(portletCategory2);
+
+		Assert.assertSame(
+			portletCategory1, rootPortletCategory.getCategory("parent"));
+		Assert.assertEquals(
+			SetUtil.fromArray("portletId1", "portletId2"), portletIds);
+	}
+
+	@Test
+	public void testPath() {
+		PortletCategory childPortletCategory = new PortletCategory("child");
+		PortletCategory parentPortletCategory = new PortletCategory("parent");
+
+		Assert.assertEquals("child", childPortletCategory.getPath());
+		Assert.assertEquals("parent", parentPortletCategory.getPath());
+
+		parentPortletCategory.addCategory(childPortletCategory);
+
+		Assert.assertEquals("parent", parentPortletCategory.getPath());
+		Assert.assertEquals("parent//child", childPortletCategory.getPath());
+
+		PortletCategory rootPortletCategory = new PortletCategory();
+
+		Assert.assertEquals("root", rootPortletCategory.getPath());
+
+		rootPortletCategory.addCategory(parentPortletCategory);
+
+		Assert.assertEquals("root", rootPortletCategory.getPath());
+
+		Assert.assertEquals("root//parent", parentPortletCategory.getPath());
+		Assert.assertEquals(
+			"root//parent//child", childPortletCategory.getPath());
+	}
+
+}


### PR DESCRIPTION
Previous PR: https://github.com/liferay-core-infra/liferay-portal/pull/9771
- As discussed, caller should not need to know PortletCategory's detailed implementation
  - `PortletCategory.getCategory` now resolves nested names. 
    - UpdateLayoutStrutsAction can now look up a portlet's category directly via its full   
name, instead of walking the tree and matching against getName() or getPath().                                                            
  - `PortletCategory.mergeCategory` merges the given category as a child of the receiver. 
    - Previously, callers had to wrap the category in a root PortletCategory first, because `PortletCategory.merge` iterates the argument's children rather than treating the argument itself as the category to merge. 

**Summary**
This PR fixes two issues: [LPD-84062](https://liferay.atlassian.net/browse/LPD-84062) and [LPD-84060](https://liferay.atlassian.net/browse/LPD-84060). 

The changes ensure that OSGi portlets (using the `com.liferay.portlet.display-category` property) and WAR portlets (categories declared in `liferay-display.xml`) now handle nested portlet category paths consistently and also fixes the permission check.

Note:  [LPD-84060](https://liferay.atlassian.net/browse/LPD-84060) is fixed by commit [LPD-84062 Wrap new PortletCategory with a root PortletCategory to prepare for merge](https://github.com/liferay-core-infra/liferay-portal/commit/662c18c2bc2d38dd544c845c27e0107eef3f594c)

**Additional Details**
When a portletCategory is created, it will be added to the default root category:
```
PortletCategory rootPortletCategory = (PortletCategory)WebAppPool.get(
	themeDisplay.getCompanyId(), WebKeys.PORTLET_CATEGORY);
```

And so for a nested portlet category (e.g. `category.sample//category.nested`) that is added to the default root category,  the expected path would be: `root//category.sample//category.nested`

However, this behavior is not consistent in certain use-cases, both with OSGi Portlet and WAR portlet, where the path may result as: `category.sample//category.nested`

These commits make the behavior consistent for both OSGi Portlet and WAR portlet
- [LPD-84062 When updating path, make sure to also update the paths for the nested categories](https://github.com/liferay-core-infra/liferay-portal/commit/8b1ff7e92a94d76ec2092d0d84ab80ae7184795d)
- [LPD-84062 Wrap new PortletCategory with a root PortletCategory to prepare for merge](https://github.com/liferay-core-infra/liferay-portal/commit/662c18c2bc2d38dd544c845c27e0107eef3f594c)

With the above commits, `UpdateLayoutStrutsActionTest` now fails and this exposes the same issue as the WAR portlet for the OSGi portlet. The permission issue is then fixed for both by commit:
- [LPD-84062 Use category name to find associated portletCategory](https://github.com/liferay-core-infra/liferay-portal/commit/cad11e5c57305161046e77515667c57391538d7a)

[LPD-84062]: https://liferay.atlassian.net/browse/LPD-84062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-84060]: https://liferay.atlassian.net/browse/LPD-84060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-84060]: https://liferay.atlassian.net/browse/LPD-84060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ