### PR TITLE
LPD-88242 Make dxp the default build.profile value

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -138,7 +138,7 @@
 		name="xmltask"
 	/>
 
-	<condition property="build.profile" value="portal">
+	<condition property="build.profile" value="dxp">
 		<not>
 			<isset property="build.profile" />
 		</not>

--- a/build.properties
+++ b/build.properties
@@ -348,7 +348,7 @@
     build.patcher.replace.release.info.tokens=false
     build.performance.logger.enabled=false
     build.portal.license.enterprise.app.module.version=1.0.18
-    build.profile=portal
+    build.profile=dxp
     build.repository.local.dir=${project.dir}/.m2
     build.repository.private.password=
     build.repository.private.url=

--- a/portal-impl/build.xml
+++ b/portal-impl/build.xml
@@ -178,7 +178,7 @@
 		<delete dir="${project.dir}/tmp/license-reports" quiet="true" />
 
 		<gradle-execute dir="${project.dir}/modules" task="generateLicenseReport">
-			<arg value="-Dbuild.profile=portal" />
+			<arg value="-Dbuild.profile=dxp" />
 			<arg value="-Dlicense.report.enabled=true" />
 			<arg value="-Dlicense.report.output.dir=${project.dir}/tmp/license-reports" />
 			<arg value="-Dlicense.report.override.properties.file=${project.dir}/lib/license-override.properties" />


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88242

## What is being fixed

Under epic LPD-84729 (Remove CE build profile), the source-build default
for `build.profile` is still `portal`. Since DXP is now the canonical
build profile and the `setup-profile-dxp` flow is being retired,
contributors who do not set the property explicitly still get the legacy
`portal` profile.

## How it is being fixed

Switch the default `build.profile` value from `portal` to `dxp` in the
three places it is declared: the Ant `<condition>` fallback in
`build-common.xml`, the documented default in `build.properties`, and
the `-Dbuild.profile` argument passed to the `generateLicenseReport`
Gradle task in `portal-impl/build.xml`. Profile switching itself is
preserved — callers can still pass `-Dbuild.profile=portal-pre` or any
other profile — only the implicit default changes.

## Why are there no tests?

Build-configuration-only change. There is no runtime code path to cover;
the change is exercised by the build itself.