### PR TITLE
LPD-74656 Redirect to home URL in VirtualHostFilter when site resolution fails

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/virtualhost/VirtualHostFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/virtualhost/VirtualHostFilter.java
@@ -290,6 +290,18 @@ public class VirtualHostFilter extends BasePortalFilter {
 				return;
 			}
 
+			if (friendlyURL.equals(StringPool.SLASH) &&
+				Validator.isNull(PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME)) {
+
+				String homeURL = PortalUtil.getHomeURL(httpServletRequest);
+
+				if (Validator.isNotNull(homeURL)) {
+					httpServletResponse.sendRedirect(homeURL);
+
+					return;
+				}
+			}
+
 			processFilter(
 				VirtualHostFilter.class.getName(), httpServletRequest,
 				httpServletResponse, filterChain);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-74656

## What is being fixed
When the portal property virtual.hosts.default.site.name is set to empty and site resolution fails, a client-side redirect was being triggered via index.jsp or error pages. In these forged request contexts, DefineObjectsTag fails to set the renderRequest attribute, leading to a NullPointerException in portlet_messages/page.jsp when it attempts to access the null request.

## How it is being fixed
An early server-side redirect is implemented in VirtualHostFilter. When layoutSet resolution fails and the requested path is root (/), the filter now immediately redirects to the portal's home URL if the default site name is empty. This prevents the request from reaching the JSP servlets that lack the necessary portlet context, avoiding the NPE and improving redirect efficiency.