### PR TITLE
LPD-51826 ThemeDisplay could be null, fall back to JournalArticle for…

### DIFF
--- a/modules/apps/glowroot/glowroot-plugin-freemarker/src/main/java/com/liferay/glowroot/plugin/freemarker/TemplatesAspect.java
+++ b/modules/apps/glowroot/glowroot-plugin-freemarker/src/main/java/com/liferay/glowroot/plugin/freemarker/TemplatesAspect.java
@@ -134,10 +134,17 @@ public class TemplatesAspect {
 
 			ThemeDisplayShim themeDisplayShim = (ThemeDisplayShim)parameters[9];
 
-			sb.append(themeDisplayShim.getCompanyId());
+			if (themeDisplayShim != null) {
+				sb.append(themeDisplayShim.getCompanyId());
+				sb.append(", Site Group ID ");
+				sb.append(themeDisplayShim.getSiteGroupId());
+			}
+			else {
+				JournalArticleShim journalArticleShim =
+					(JournalArticleShim)parameters[0];
 
-			sb.append(", Site Group ID ");
-			sb.append(themeDisplayShim.getSiteGroupId());
+				sb.append(journalArticleShim.getCompanyId());
+			}
 
 			DDMTemplateShim dDMTemplateShim = (DDMTemplateShim)parameters[1];
 
@@ -301,6 +308,9 @@ public class TemplatesAspect {
 
 	@Shim("com.liferay.journal.model.JournalArticle")
 	public interface JournalArticleShim {
+
+		public long getCompanyId();
+
 	}
 
 	@Shim("com.liferay.portal.kernel.theme.ThemeDisplay")


### PR DESCRIPTION
**What is this trying to solve?**
  https://liferay.atlassian.net/browse/LPD-51826
                                              
  When Glowroot is enabled, a Kaleo workflow Groovy action that renders a `JournalArticle` (no request
  context, so no `ThemeDisplay`) hits `NullPointerException: Cannot invoke
  "ThemeDisplayShim.getCompanyId()" because "themeDisplayShim" is null` at `TemplatesAspect.java:137`,   
  blocking workflow execution. `JournalTransformer.transform` itself accepts a null `ThemeDisplay`       
  throughout — only the aspect's trace-message build dereferenced it without checking.                   
                                                                                                         
  **How am I fixing it?**                                       
  In `JournalTransformerAdvice.onBefore`, null-guard `themeDisplayShim`. When null, fall back to the
  article (`parameters[0]`) for `companyId` — matching what `JournalTransformer._transform:929` already
  does internally. `JournalArticleShim` gains `getCompanyId()`.
