### PR TITLE
LPD-88934 fix XML 1.0 forbidden character injection in LiferayXmlLayout 

### DIFF
--- a/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
+++ b/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
@@ -231,6 +231,36 @@ public class PortalLog4jTest {
 			"TestLogContext");
 	}
 
+	@Test
+	public void testXmlLogOutputWithForbiddenXml10Chars() throws Exception {
+		Logger logger = (Logger)LogManager.getLogger(PortalLog4jTest.class);
+
+		String forbiddenCharString = String.valueOf((char)1);
+
+		logger.info("message with forbidden char: " + forbiddenCharString);
+
+		try {
+			String xmlOutput = new String(Files.readAllBytes(_xmlLogFilePath));
+
+			Assert.assertTrue(
+				xmlOutput.contains("message with forbidden char"));
+
+			Assert.assertTrue(xmlOutput.contains("\uFFFD"));
+
+			Assert.assertFalse(xmlOutput.contains(forbiddenCharString));
+		}
+		finally {
+			_unsyncStringWriter.reset();
+
+			Files.write(
+				_textLogFilePath, new byte[0],
+				StandardOpenOption.TRUNCATE_EXISTING);
+			Files.write(
+				_xmlLogFilePath, new byte[0],
+				StandardOpenOption.TRUNCATE_EXISTING);
+		}
+	}
+
 	private static Path _initFileAppender(
 		Logger logger, Appender appender, String tempLogDir) {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/LiferayXmlLayout.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/LiferayXmlLayout.java
@@ -102,7 +102,9 @@ public final class LiferayXmlLayout extends AbstractStringLayout {
 		sb.append(
 			Transform.escapeHtmlTags(String.valueOf(logEvent.getLevel())));
 		sb.append("\" thread=\"");
-		sb.append(Transform.escapeHtmlTags(logEvent.getThreadName()));
+		sb.append(
+			Transform.escapeHtmlTags(
+				_stripForbiddenXML10Chars(logEvent.getThreadName())));
 		sb.append("\">");
 		sb.append(StringPool.RETURN_NEW_LINE);
 		sb.append("<log4j:message>");
@@ -110,7 +112,8 @@ public final class LiferayXmlLayout extends AbstractStringLayout {
 
 		Message message = logEvent.getMessage();
 
-		Transform.appendEscapingCData(sb, message.getFormattedMessage());
+		Transform.appendEscapingCData(
+			sb, _stripForbiddenXML10Chars(message.getFormattedMessage()));
 
 		sb.append(StringPool.CDATA_CLOSE);
 		sb.append("</log4j:message>");
@@ -125,7 +128,8 @@ public final class LiferayXmlLayout extends AbstractStringLayout {
 			sb.append(StringPool.CDATA_OPEN);
 
 			Transform.appendEscapingCData(
-				sb, Strings.join(ndc, CharPool.SPACE));
+				sb,
+				_stripForbiddenXML10Chars(Strings.join(ndc, CharPool.SPACE)));
 
 			sb.append(StringPool.CDATA_CLOSE);
 			sb.append("</log4j:NDC>");
@@ -142,7 +146,8 @@ public final class LiferayXmlLayout extends AbstractStringLayout {
 
 			throwable.printStackTrace(new PrintWriter(stringWriter));
 
-			Transform.appendEscapingCData(sb, stringWriter.toString());
+			Transform.appendEscapingCData(
+				sb, _stripForbiddenXML10Chars(stringWriter.toString()));
 
 			sb.append(StringPool.CDATA_CLOSE);
 			sb.append("</log4j:throwable>");
@@ -181,11 +186,14 @@ public final class LiferayXmlLayout extends AbstractStringLayout {
 					(key, value) -> {
 						if (value != null) {
 							sb.append("<log4j:data name=\"");
-							sb.append(Transform.escapeHtmlTags(key));
+							sb.append(
+								Transform.escapeHtmlTags(
+									_stripForbiddenXML10Chars(key)));
 							sb.append("\" value=\"");
 							sb.append(
 								Transform.escapeHtmlTags(
-									String.valueOf(value)));
+									_stripForbiddenXML10Chars(
+										String.valueOf(value))));
 							sb.append("\"/>");
 							sb.append(StringPool.RETURN_NEW_LINE);
 						}
@@ -200,6 +208,47 @@ public final class LiferayXmlLayout extends AbstractStringLayout {
 		sb.append(StringPool.RETURN_NEW_LINE);
 		sb.append(StringPool.RETURN_NEW_LINE);
 	}
+
+	private boolean _isForbiddenXML10Char(char c) {
+		if ((c < 0x20) && (c != CharPool.NEW_LINE) && (c != CharPool.RETURN) &&
+			(c != CharPool.TAB)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private String _stripForbiddenXML10Chars(String string) {
+		if (string == null) {
+			return null;
+		}
+
+		StringBuilder sb = null;
+
+		for (int i = 0; i < string.length(); i++) {
+			char c = string.charAt(i);
+
+			if (_isForbiddenXML10Char(c)) {
+				if (sb == null) {
+					sb = new StringBuilder(string.substring(0, i));
+				}
+
+				sb.append(_REPLACEMENT_CHARACTER);
+			}
+			else if (sb != null) {
+				sb.append(c);
+			}
+		}
+
+		if (sb != null) {
+			return sb.toString();
+		}
+
+		return string;
+	}
+
+	private static final char _REPLACEMENT_CHARACTER = '\uFFFD';
 
 	private final boolean _locationInfo;
 	private final boolean _properties;


### PR DESCRIPTION
This is for: https://liferay.atlassian.net/browse/LPD-88934

 `LiferayXmlLayout` shares the same vulnerability as CVE-2026-34480: XML 1.0
  forbidden characters (U+0000–U+0008, U+000B, U+000C, U+000E–U+001F) can be written
  directly to XML log output when logging through Log4j, producing malformed XML that
  can corrupt or crash XML log. This affects any caller that bypasses
  `SanitizerLogWrapper` such as third-party libraries logging directly via Log4j.

  The fix creates a helper and replaces forbidden characters with the Unicode replacement character (U+FFFD) in all user-controlled log fields: message, thread name, NDC, throwable stack trace, and MDC key/value pairs.