### PR TITLE
LPD-89877 Remove dead two-arg DynamicQuery#setProjection

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
@@ -226,7 +226,7 @@ public class KeywordResourceImpl
 		}
 
 		dynamicQuery.addOrder(OrderFactoryUtil.desc("assetCount"));
-		dynamicQuery.setProjection(_getProjectionList(), true);
+		dynamicQuery.setProjection(_getProjectionList());
 
 		return Page.of(
 			transform(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
@@ -205,7 +205,7 @@ public class TaxonomyCategoryResourceImpl
 		}
 
 		dynamicQuery.addOrder(OrderFactoryUtil.desc("assetCount"));
-		dynamicQuery.setProjection(_getProjectionList(), true);
+		dynamicQuery.setProjection(_getProjectionList());
 
 		return Page.of(
 			transform(

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/DynamicQueryImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/DynamicQueryImpl.java
@@ -9,7 +9,6 @@ import com.liferay.portal.kernel.dao.orm.Criterion;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Order;
 import com.liferay.portal.kernel.dao.orm.Projection;
-import com.liferay.portal.kernel.dao.orm.ProjectionFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -145,19 +144,6 @@ public class DynamicQueryImpl implements DynamicQuery {
 
 	@Override
 	public DynamicQuery setProjection(Projection projection) {
-		return setProjection(projection, true);
-	}
-
-	@Override
-	public DynamicQuery setProjection(
-		Projection projection, boolean useColumnAlias) {
-
-		if (!useColumnAlias) {
-			projection = ProjectionFactoryUtil.sqlProjection(
-				_detachedCriteria.getAlias() + "_." + projection.toString(),
-				null, null);
-		}
-
 		ProjectionImpl projectionImpl = (ProjectionImpl)projection;
 
 		_detachedCriteria.setProjection(projectionImpl.getWrappedProjection());

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/orm/DynamicQuery.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/orm/DynamicQuery.java
@@ -28,7 +28,4 @@ public interface DynamicQuery {
 
 	public DynamicQuery setProjection(Projection projection);
 
-	public DynamicQuery setProjection(
-		Projection projection, boolean useColumnAlias);
-
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89877

## What is being fixed

`DynamicQuery#setProjection(Projection, boolean useColumnAlias)` is a dead two-arg overload. The `useColumnAlias = false` branch wraps the projection in a `ProjectionFactoryUtil.sqlProjection(...)` call that prefixes the alias with the criteria alias — a workaround that no remaining caller exercises. The only two callers, in `headless-admin-taxonomy`, pass `useColumnAlias = true`, which is exactly what the single-arg `setProjection(Projection)` already does.

## How it is being fixed

The first commit drops the redundant `true` argument from the two `headless-admin-taxonomy` call sites so they invoke the single-arg overload directly. The second commit removes the now-unused two-arg overload from `DynamicQuery` and its implementation in `DynamicQueryImpl`, along with the unused `ProjectionFactoryUtil` import. Behavior is unchanged — every former caller continues to take the column-alias path.

## Why are there no tests?

These commits remove unused code paths and have no runtime behavior change, so they are covered by existing tests.