### PR TITLE
LPD-88934 

### DIFF
--- a/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
+++ b/modules/apps/portal/portal-log4j-test/src/testIntegration/java/com/liferay/portal/log4j/test/PortalLog4jTest.java
@@ -231,6 +231,128 @@ public class PortalLog4jTest {
 			"TestLogContext");
 	}
 
+	@Test
+	public void testXMLLogOutputWithCDATAClosingSequence() throws Exception {
+		Logger logger = (Logger)LogManager.getLogger(PortalLog4jTest.class);
+
+		Files.write(
+			_xmlLogFilePath, new byte[0], StandardOpenOption.TRUNCATE_EXISTING);
+
+		logger.info("before]]>after");
+
+		try {
+			String xmlOutput = new String(Files.readAllBytes(_xmlLogFilePath));
+
+			Assert.assertTrue(xmlOutput.contains("before"));
+			Assert.assertTrue(xmlOutput.contains("after"));
+			Assert.assertTrue(xmlOutput.contains("]]>]]&gt;<![CDATA["));
+		}
+		finally {
+			_clearLogFiles();
+		}
+	}
+
+	@Test
+	public void testXMLLogOutputWithForbiddenXML10Chars() throws Exception {
+		Logger logger = (Logger)LogManager.getLogger(PortalLog4jTest.class);
+
+		Files.write(
+			_xmlLogFilePath, new byte[0], StandardOpenOption.TRUNCATE_EXISTING);
+
+		String forbiddenCharString = String.valueOf((char)1);
+
+		String originalThreadNameString = Thread.currentThread(
+		).getName();
+
+		Thread.currentThread(
+		).setName(
+			"thread:" + forbiddenCharString
+		);
+
+		ThreadContext.push("ndc:" + forbiddenCharString);
+		ThreadContext.put(
+			"key:" + forbiddenCharString, "value:" + forbiddenCharString);
+
+		logger.error(
+			"tab:\there newline:\nhere return:\rhere forbidden:" +
+				forbiddenCharString,
+			new RuntimeException(
+				"exception with forbidden char: " + forbiddenCharString));
+
+		try {
+			String xmlOutput = new String(Files.readAllBytes(_xmlLogFilePath));
+
+			Assert.assertFalse(xmlOutput.contains(forbiddenCharString));
+			Assert.assertTrue(xmlOutput.contains("thread=\"thread: \""));
+
+			Matcher messageMatcher = _xmlMessagePattern.matcher(xmlOutput);
+
+			Assert.assertTrue(messageMatcher.find());
+			Assert.assertEquals(
+				"tab:\there newline:\nhere return:\rhere forbidden:",
+				messageMatcher.group(1));
+
+			Matcher ndcMatcher = _xmlNdcPattern.matcher(xmlOutput);
+
+			Assert.assertTrue(ndcMatcher.find());
+			Assert.assertEquals("ndc:", ndcMatcher.group(1));
+
+			Matcher throwableMatcher = _xmlThrowablePattern.matcher(xmlOutput);
+
+			Assert.assertTrue(throwableMatcher.find());
+			Assert.assertTrue(
+				throwableMatcher.group(
+					1
+				).contains(
+					"exception with forbidden char: "
+				));
+		}
+		finally {
+			Thread.currentThread(
+			).setName(
+				originalThreadNameString
+			);
+
+			ThreadContext.pop();
+			ThreadContext.remove("key:" + forbiddenCharString);
+
+			_clearLogFiles();
+		}
+	}
+
+	@Test
+	public void testXMLLogOutputWithHTMLSpecialChars() throws Exception {
+		Logger logger = (Logger)LogManager.getLogger(PortalLog4jTest.class);
+
+		Files.write(
+			_xmlLogFilePath, new byte[0], StandardOpenOption.TRUNCATE_EXISTING);
+
+		String originalThreadNameString = Thread.currentThread(
+		).getName();
+
+		Thread.currentThread(
+		).setName(
+			"thread:<>&\""
+		);
+
+		logger.info("message");
+
+		try {
+			String xmlOutput = new String(Files.readAllBytes(_xmlLogFilePath));
+
+			Assert.assertFalse(xmlOutput.contains("thread:<>&\""));
+			Assert.assertTrue(xmlOutput.contains("thread:&lt;&gt;&amp;&quot;"));
+		}
+		finally {
+			Thread.currentThread(
+			).setName(
+				originalThreadNameString
+			);
+
+			_clearLogFiles();
+		}
+	}
+
 	private static Path _initFileAppender(
 		Logger logger, Appender appender, String tempLogDir) {
 
@@ -476,6 +598,16 @@ public class PortalLog4jTest {
 				0, expectedLog4JLocationInfoFile.length()));
 	}
 
+	private void _clearLogFiles() throws IOException {
+		_unsyncStringWriter.reset();
+
+		Files.write(
+			_textLogFilePath, new byte[0],
+			StandardOpenOption.TRUNCATE_EXISTING);
+		Files.write(
+			_xmlLogFilePath, new byte[0], StandardOpenOption.TRUNCATE_EXISTING);
+	}
+
 	private void _outputLog(String level, String message, Throwable throwable) {
 		if (level.equals("DEBUG")) {
 			if ((message == null) && (throwable != null)) {
@@ -687,6 +819,14 @@ public class PortalLog4jTest {
 	private static final UnsyncStringWriter _unsyncStringWriter =
 		new UnsyncStringWriter();
 	private static Path _xmlLogFilePath;
+	private static final Pattern _xmlMessagePattern = Pattern.compile(
+		"<log4j:message><!\\[CDATA\\[(.*?)\\]\\]></log4j:message>",
+		Pattern.DOTALL);
+	private static final Pattern _xmlNdcPattern = Pattern.compile(
+		"<log4j:NDC><!\\[CDATA\\[(.*?)\\]\\]></log4j:NDC>", Pattern.DOTALL);
+	private static final Pattern _xmlThrowablePattern = Pattern.compile(
+		"<log4j:throwable><!\\[CDATA\\[(.*?)\\]\\]></log4j:throwable>",
+		Pattern.DOTALL);
 
 	private static class TestOutputStream extends CloseShieldOutputStream {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/LiferayXmlLayout.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/LiferayXmlLayout.java
@@ -7,6 +7,8 @@ package com.liferay.portal.kernel.internal.log4j;
 
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.xml.XMLUtil;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -95,14 +97,14 @@ public final class LiferayXmlLayout extends AbstractStringLayout {
 
 	private void _generateXMLLog(LogEvent logEvent, StringBuilder sb) {
 		sb.append("<log4j:event logger=\"");
-		sb.append(Transform.escapeHtmlTags(logEvent.getLoggerName()));
+		sb.append(HtmlUtil.escapeAttribute(logEvent.getLoggerName()));
 		sb.append("\" timestamp=\"");
 		sb.append(logEvent.getTimeMillis());
 		sb.append("\" level=\"");
 		sb.append(
-			Transform.escapeHtmlTags(String.valueOf(logEvent.getLevel())));
+			HtmlUtil.escapeAttribute(String.valueOf(logEvent.getLevel())));
 		sb.append("\" thread=\"");
-		sb.append(Transform.escapeHtmlTags(logEvent.getThreadName()));
+		sb.append(HtmlUtil.escapeAttribute(logEvent.getThreadName()));
 		sb.append("\">");
 		sb.append(StringPool.RETURN_NEW_LINE);
 		sb.append("<log4j:message>");
@@ -110,7 +112,8 @@ public final class LiferayXmlLayout extends AbstractStringLayout {
 
 		Message message = logEvent.getMessage();
 
-		Transform.appendEscapingCData(sb, message.getFormattedMessage());
+		Transform.appendEscapingCData(
+			sb, XMLUtil.stripInvalidChars(message.getFormattedMessage()));
 
 		sb.append(StringPool.CDATA_CLOSE);
 		sb.append("</log4j:message>");
@@ -125,7 +128,8 @@ public final class LiferayXmlLayout extends AbstractStringLayout {
 			sb.append(StringPool.CDATA_OPEN);
 
 			Transform.appendEscapingCData(
-				sb, Strings.join(ndc, CharPool.SPACE));
+				sb,
+				XMLUtil.stripInvalidChars(Strings.join(ndc, CharPool.SPACE)));
 
 			sb.append(StringPool.CDATA_CLOSE);
 			sb.append("</log4j:NDC>");
@@ -142,7 +146,8 @@ public final class LiferayXmlLayout extends AbstractStringLayout {
 
 			throwable.printStackTrace(new PrintWriter(stringWriter));
 
-			Transform.appendEscapingCData(sb, stringWriter.toString());
+			Transform.appendEscapingCData(
+				sb, XMLUtil.stripInvalidChars(stringWriter.toString()));
 
 			sb.append(StringPool.CDATA_CLOSE);
 			sb.append("</log4j:throwable>");
@@ -155,14 +160,14 @@ public final class LiferayXmlLayout extends AbstractStringLayout {
 			if (stackTraceElement != null) {
 				sb.append("<log4j:locationInfo class=\"");
 				sb.append(
-					Transform.escapeHtmlTags(stackTraceElement.getClassName()));
+					HtmlUtil.escapeAttribute(stackTraceElement.getClassName()));
 				sb.append("\" method=\"");
 				sb.append(
-					Transform.escapeHtmlTags(
+					HtmlUtil.escapeAttribute(
 						stackTraceElement.getMethodName()));
 				sb.append("\" file=\"");
 				sb.append(
-					Transform.escapeHtmlTags(stackTraceElement.getFileName()));
+					HtmlUtil.escapeAttribute(stackTraceElement.getFileName()));
 				sb.append("\" line=\"");
 				sb.append(stackTraceElement.getLineNumber());
 				sb.append("\"/>");
@@ -181,10 +186,10 @@ public final class LiferayXmlLayout extends AbstractStringLayout {
 					(key, value) -> {
 						if (value != null) {
 							sb.append("<log4j:data name=\"");
-							sb.append(Transform.escapeHtmlTags(key));
+							sb.append(HtmlUtil.escapeAttribute(key));
 							sb.append("\" value=\"");
 							sb.append(
-								Transform.escapeHtmlTags(
+								HtmlUtil.escapeAttribute(
 									String.valueOf(value)));
 							sb.append("\"/>");
 							sb.append(StringPool.RETURN_NEW_LINE);


### PR DESCRIPTION
this is for: https://liferay.atlassian.net/browse/LPD-88934

LiferayXmlLayout shares the same class of issue as Apache Log4j Core XmlLayout: XML 1.0 forbidden characters can be written directly to XML log output when logging through Log4j, producing malformed XML that can corrupt or crash XML log parsers. This affects any caller that bypasses SanitizerLogWrapper, such as third-party libraries logging directly via Log4j.

The fix sanitizes all user-controlled log fields before they reach the XML output. Attribute-context fields are processed with `HtmlUtil.escapeAttribute`, which strips invalid XML characters and HTML-escapes special characters in a single pass. CDATA-context fields are processed with `stripInvalidChars`.

This PR also adds tests covering the full security contract of LiferayXmlLayout to PortalLog4jTest, verifying that forbidden XML 1.0 characters are stripped, HTML special characters in attributes are properly escaped, and CDATA injection via` ]]>` is prevented.

