### PR TITLE
LPD-90197 Wrap arrayable args in filter scalar finder overloads

### DIFF
--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl_finder_count.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl_finder_count.ftl
@@ -522,7 +522,11 @@ public int countBy${entityFinder.name}(
 				${finderCacheInstance},
 				new Object[] {
 					<#list entityColumns as entityColumn>
-						${entityColumn.name}
+						<#if entityColumn.hasArrayableOperator()>
+							new ${entityColumn.type}[] {${entityColumn.name}}
+						<#else>
+							${entityColumn.name}
+						</#if>
 
 						<#if entityColumn_has_next>
 							,

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl_finder_find.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl_finder_find.ftl
@@ -745,7 +745,11 @@ that may or may not be enforced with a unique index at the database level. Case
 					${finderCacheInstance},
 					new Object[] {
 						<#list entityColumns as entityColumn>
-							${entityColumn.name}
+							<#if entityColumn.hasArrayableOperator()>
+								new ${entityColumn.type}[] {${entityColumn.name}}
+							<#else>
+								${entityColumn.name}
+							</#if>
 
 							<#if entityColumn_has_next>
 								,

--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetCategoryPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetCategoryPersistenceImpl.java
@@ -1435,8 +1435,8 @@ public class AssetCategoryPersistenceImpl
 
 		return _collectionPersistenceFinderByG_V.filterFind(
 			FinderCacheUtil.getFinderCache(),
-			new Object[] {groupId, vocabularyId}, start, end, orderByComparator,
-			groupId);
+			new Object[] {new long[] {groupId}, new long[] {vocabularyId}},
+			start, end, orderByComparator, groupId);
 	}
 
 	/**
@@ -1650,7 +1650,8 @@ public class AssetCategoryPersistenceImpl
 	public int filterCountByG_V(long groupId, long vocabularyId) {
 		return _collectionPersistenceFinderByG_V.filterCount(
 			FinderCacheUtil.getFinderCache(),
-			new Object[] {groupId, vocabularyId}, groupId);
+			new Object[] {new long[] {groupId}, new long[] {vocabularyId}},
+			groupId);
 	}
 
 	/**
@@ -2903,8 +2904,10 @@ public class AssetCategoryPersistenceImpl
 
 		return _collectionPersistenceFinderByG_LikeN_V.filterFind(
 			FinderCacheUtil.getFinderCache(),
-			new Object[] {groupId, name, vocabularyId}, start, end,
-			orderByComparator, groupId);
+			new Object[] {
+				new long[] {groupId}, name, new long[] {vocabularyId}
+			},
+			start, end, orderByComparator, groupId);
 	}
 
 	/**
@@ -3144,7 +3147,10 @@ public class AssetCategoryPersistenceImpl
 
 		return _collectionPersistenceFinderByG_LikeN_V.filterCount(
 			FinderCacheUtil.getFinderCache(),
-			new Object[] {groupId, name, vocabularyId}, groupId);
+			new Object[] {
+				new long[] {groupId}, name, new long[] {vocabularyId}
+			},
+			groupId);
 	}
 
 	/**


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90197

## Failing Test

`export-import-web/main/site.import.spec.ts > Can import a folder with document type restrictions and workflow`

`modules/test/playwright/tests/export-import-web/main/site.import.spec.ts:294`

```
Test timeout of 90000ms exceeded.
Error: locator.click: Test timeout of 90000ms exceeded.
Call log:
  - waiting for locator('.card-body:has-text(\'LPS-205933\')').getByLabel('More actions')
     at ../pages/document-library-web/DocumentLibraryPage.ts:221
```

## Root Cause

Commit `646373c7d6cb` ("LPD-89869 Service Builder 7.4+ enables filter finder delegation") rewrote the `filterCount` and `filterFind` scalar overloads to delegate to `FilterCollectionPersistenceFinder` but forgot to wrap arguments backing an `ArrayableFinderColumn` in a one-element array, the way the sibling `count` / `find` scalar overloads already do. Once regenerated, `AssetCategoryPersistenceImpl.filterCountByG_V(long, long)` (called from the Document Library admin toolbar via `AssetCategoryServiceUtil.getVocabularyCategoriesCount`) passes scalar `Long`s where `ArrayableFinderColumn.normalizeValue` expects a `long[]`, so the column throws `IllegalStateException: Unsupported arrayable value: <groupId>` and the Document Library page never renders, leaving the imported `LPS-205933` folder card off-screen for the test to click.

## Fix

Restore the arrayable wrap that the regular `count` / `find` templates already use: when an entity column has an arrayable operator, emit `new <type>[] {<name>}` instead of the bare name. Apply the same shape to the regenerated `AssetCategoryPersistenceImpl.java` so the four affected filter scalar overloads pass `new long[] {groupId}` and `new long[] {vocabularyId}` into the arrayable columns, matching what the corrected templates would now produce on a fresh regeneration.

- `modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl_finder_count.ftl`
- `modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl_finder_find.ftl`
- `portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetCategoryPersistenceImpl.java`