### PR TITLE
LPD-90509

### DIFF
--- a/portal-test/src/com/liferay/portal/test/cluster/tomcat/dependencies/portal-ext.properties.tpl
+++ b/portal-test/src/com/liferay/portal/test/cluster/tomcat/dependencies/portal-ext.properties.tpl
@@ -1,3 +1,4 @@
+browser.launcher.url=
 cluster.link.channel.name.control=${CLUSTER_NAME}-channel-control
 cluster.link.channel.name.transport.0=${CLUSTER_NAME}-channel-transport-0
 cluster.link.enabled=true


### PR DESCRIPTION
Hi Tina,

This is for https://liferay.atlassian.net/browse/LPD-90508

Cluster sub-nodes spawned by `TomcatNode` open the Liferay home page in Chrome on every cluster integration test run, because `GlobalStartupAction` starts `BrowserLauncher` whenever `browser.launcher.url` is non-empty and the sub-node `portal-ext.properties` template (`dependencies/portal-ext.properties.tpl`) never carried the empty override that silences the main Tomcat. This PR adds `browser.launcher.url=` to that template, suppressing the popup in the 4 integration tests that use `TomcatCluster`/`TomcatNode` (`ClusterGeneralTest`, `ClusterCacheReplicationTest`, `ClusterLicenseTest`, `CacheReplicatorEntryTest`). All four are backend tests and CI behavior is unchanged.
