### PR TITLE
LPD-75296 Remove obsolete render attribute cleanup

### DIFF
--- a/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/RenderPortletActionTest.java
+++ b/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/RenderPortletActionTest.java
@@ -7,6 +7,7 @@ package com.liferay.portal.action.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.action.RenderPortletAction;
 import com.liferay.portal.kernel.model.Group;
@@ -36,12 +37,16 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import jakarta.portlet.HeaderRequest;
 import jakarta.portlet.HeaderResponse;
 import jakarta.portlet.Portlet;
+import jakarta.portlet.RenderRequest;
+import jakarta.portlet.RenderResponse;
 
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletContext;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+
+import java.util.Arrays;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -67,6 +72,199 @@ public class RenderPortletActionTest {
 	@Rule
 	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
 		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testOptionalRenderParameters() throws Exception {
+		Bundle bundle = FrameworkUtil.getBundle(RenderPortletActionTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		String portletId = RandomTestUtil.randomString();
+
+		ServiceRegistration<Portlet> serviceRegistration =
+			bundleContext.registerService(
+				Portlet.class,
+				new MVCPortlet() {
+
+					@Override
+					public void render(
+							RenderRequest renderRequest,
+							RenderResponse renderResponse)
+						throws IOException {
+
+						PrintWriter printWriter = renderResponse.getWriter();
+
+						printWriter.write(
+							String.valueOf(
+								Arrays.asList(
+									renderRequest.getAttribute(
+										WebKeys.PORTLET_DECORATE),
+									renderRequest.getAttribute(
+										WebKeys.RENDER_PATH),
+									renderRequest.getAttribute(
+										WebKeys.RENDER_PORTLET_BOUNDARY),
+									renderRequest.getAttribute(
+										WebKeys.RENDER_PORTLET_COLUMN_COUNT),
+									renderRequest.getAttribute(
+										WebKeys.RENDER_PORTLET_COLUMN_ID),
+									renderRequest.getAttribute(
+										WebKeys.RENDER_PORTLET_COLUMN_POS))));
+					}
+
+					@Override
+					public void renderHeaders(
+							HeaderRequest headerRequest,
+							HeaderResponse headerResponse)
+						throws IOException {
+
+						PrintWriter printWriter = headerResponse.getWriter();
+
+						printWriter.write(
+							StringBundler.concat(
+								"<link rel=\"stylesheet\" href=\"",
+								Arrays.asList(
+									headerRequest.getAttribute(
+										WebKeys.PORTLET_DECORATE),
+									headerRequest.getAttribute(
+										WebKeys.RENDER_PATH),
+									headerRequest.getAttribute(
+										WebKeys.RENDER_PORTLET_BOUNDARY),
+									headerRequest.getAttribute(
+										WebKeys.RENDER_PORTLET_COLUMN_COUNT),
+									headerRequest.getAttribute(
+										WebKeys.RENDER_PORTLET_COLUMN_ID),
+									headerRequest.getAttribute(
+										WebKeys.RENDER_PORTLET_COLUMN_POS)),
+								".css\">"));
+					}
+
+				},
+				HashMapDictionaryBuilder.<String, Object>put(
+					"com.liferay.portlet.deploy.parallel", "false"
+				).put(
+					"com.liferay.portlet.use-default-template", "false"
+				).put(
+					"jakarta.portlet.init-param.valid-paths", "/"
+				).put(
+					"jakarta.portlet.init-param.view-template", "/"
+				).put(
+					"jakarta.portlet.name", portletId
+				).put(
+					"jakarta.portlet.version", "3.0"
+				).build());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		RenderPortletAction renderPortletAction = new RenderPortletAction();
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest(HttpMethods.GET, StringPool.BLANK) {
+
+				@Override
+				public RequestDispatcher getRequestDispatcher(String path) {
+					ServletContext servletContext = ServletContextPool.get(
+						StringPool.BLANK);
+
+					return servletContext.getRequestDispatcher(path);
+				}
+
+			};
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.CURRENT_URL, "http://localhost:8080");
+
+		Group group = GroupTestUtil.addGroup();
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(group.getGroupId());
+
+		mockHttpServletRequest.setAttribute(WebKeys.LAYOUT, layout);
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.RENDER_PORTLET,
+			_portletLocalService.getPortletById(
+				TestPropsValues.getCompanyId(), portletId));
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(TestPropsValues.getCompanyId()));
+		themeDisplay.setLayout(layout);
+
+		LayoutSet layoutSet = group.getPublicLayoutSet();
+
+		themeDisplay.setLayoutSet(layoutSet);
+
+		themeDisplay.setLayoutTypePortlet(
+			(LayoutTypePortlet)layout.getLayoutType());
+		themeDisplay.setLocale(LocaleUtil.getDefault());
+		themeDisplay.setLookAndFeel(
+			layoutSet.getTheme(), layoutSet.getColorScheme());
+
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
+
+		themeDisplay.setPermissionChecker(
+			PermissionThreadLocal.getPermissionChecker());
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		String portletDecorate = String.valueOf(RandomTestUtil.randomBoolean());
+		String renderPortletBoundary = String.valueOf(
+			RandomTestUtil.randomBoolean());
+		String renderPortletColumnCount = String.valueOf(
+			RandomTestUtil.randomInt());
+		String renderPortletColumnId = RandomTestUtil.randomString();
+		String renderPortletColumnPos = String.valueOf(
+			RandomTestUtil.randomInt());
+
+		mockHttpServletRequest.setParameter(
+			"p_p_boundary", renderPortletBoundary);
+		mockHttpServletRequest.setParameter(
+			"p_p_col_count", renderPortletColumnCount);
+		mockHttpServletRequest.setParameter(
+			"p_p_col_id", renderPortletColumnId);
+		mockHttpServletRequest.setParameter(
+			"p_p_col_pos", renderPortletColumnPos);
+		mockHttpServletRequest.setParameter("p_p_decorate", portletDecorate);
+		mockHttpServletRequest.setParameter(
+			"p_p_id", LayoutTestUtil.addPortletToLayout(layout, portletId));
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		renderPortletAction.execute(
+			null, mockHttpServletRequest, mockHttpServletResponse);
+
+		OutputData outputData = (OutputData)mockHttpServletRequest.getAttribute(
+			WebKeys.OUTPUT_DATA);
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"\n<link rel=\"stylesheet\" href=\"",
+				Arrays.asList(
+					portletDecorate, null, renderPortletBoundary,
+					renderPortletColumnCount, renderPortletColumnId,
+					renderPortletColumnPos),
+				".css\">"),
+			String.valueOf(outputData.getMergedDataSB(WebKeys.PAGE_TOP)));
+
+		String content = mockHttpServletResponse.getContentAsString();
+
+		Assert.assertTrue(
+			content,
+			content.contains(
+				String.valueOf(
+					Arrays.asList(
+						null, null, renderPortletBoundary,
+						renderPortletColumnCount, renderPortletColumnId,
+						renderPortletColumnPos))));
+
+		PermissionThreadLocal.setPermissionChecker(permissionChecker);
+
+		serviceRegistration.unregister();
+	}
 
 	@Test
 	public void testRenderHeaders() throws Exception {

--- a/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/RenderPortletActionTest.java
+++ b/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/RenderPortletActionTest.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
-import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.servlet.HttpMethods;
 import com.liferay.portal.kernel.servlet.ServletContextPool;
@@ -388,8 +387,5 @@ public class RenderPortletActionTest {
 
 	@Inject
 	private CompanyLocalService _companyLocalService;
-
-	@Inject
-	private LayoutLocalService _layoutLocalService;
 
 }

--- a/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/RenderPortletActionTest.java
+++ b/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/RenderPortletActionTest.java
@@ -15,14 +15,13 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
-import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.servlet.HttpMethods;
 import com.liferay.portal.kernel.servlet.ServletContextPool;
 import com.liferay.portal.kernel.servlet.taglib.util.OutputData;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -32,6 +31,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import jakarta.portlet.HeaderRequest;
 import jakarta.portlet.HeaderResponse;
@@ -47,6 +47,7 @@ import java.io.PrintWriter;
 
 import java.util.Arrays;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -69,91 +70,74 @@ public class RenderPortletActionTest {
 
 	@ClassRule
 	@Rule
-	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
-		new LiferayIntegrationTestRule();
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@After
+	public void tearDown() {
+		if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+		}
+	}
 
 	@Test
 	public void testOptionalRenderParameters() throws Exception {
-		Bundle bundle = FrameworkUtil.getBundle(RenderPortletActionTest.class);
+		String portletId = _registerPortlet(
+			new MVCPortlet() {
 
-		BundleContext bundleContext = bundle.getBundleContext();
+				@Override
+				public void render(
+						RenderRequest renderRequest,
+						RenderResponse renderResponse)
+					throws IOException {
 
-		String portletId = RandomTestUtil.randomString();
+					PrintWriter printWriter = renderResponse.getWriter();
 
-		ServiceRegistration<Portlet> serviceRegistration =
-			bundleContext.registerService(
-				Portlet.class,
-				new MVCPortlet() {
+					printWriter.write(
+						String.valueOf(
+							Arrays.asList(
+								renderRequest.getAttribute(
+									WebKeys.PORTLET_DECORATE),
+								renderRequest.getAttribute(WebKeys.RENDER_PATH),
+								renderRequest.getAttribute(
+									WebKeys.RENDER_PORTLET_BOUNDARY),
+								renderRequest.getAttribute(
+									WebKeys.RENDER_PORTLET_COLUMN_COUNT),
+								renderRequest.getAttribute(
+									WebKeys.RENDER_PORTLET_COLUMN_ID),
+								renderRequest.getAttribute(
+									WebKeys.RENDER_PORTLET_COLUMN_POS))));
+				}
 
-					@Override
-					public void render(
-							RenderRequest renderRequest,
-							RenderResponse renderResponse)
-						throws IOException {
+				@Override
+				public void renderHeaders(
+						HeaderRequest headerRequest,
+						HeaderResponse headerResponse)
+					throws IOException {
 
-						PrintWriter printWriter = renderResponse.getWriter();
+					PrintWriter printWriter = headerResponse.getWriter();
 
-						printWriter.write(
-							String.valueOf(
-								Arrays.asList(
-									renderRequest.getAttribute(
-										WebKeys.PORTLET_DECORATE),
-									renderRequest.getAttribute(
-										WebKeys.RENDER_PATH),
-									renderRequest.getAttribute(
-										WebKeys.RENDER_PORTLET_BOUNDARY),
-									renderRequest.getAttribute(
-										WebKeys.RENDER_PORTLET_COLUMN_COUNT),
-									renderRequest.getAttribute(
-										WebKeys.RENDER_PORTLET_COLUMN_ID),
-									renderRequest.getAttribute(
-										WebKeys.RENDER_PORTLET_COLUMN_POS))));
-					}
+					printWriter.write(
+						StringBundler.concat(
+							"<link rel=\"stylesheet\" href=\"",
+							Arrays.asList(
+								headerRequest.getAttribute(
+									WebKeys.PORTLET_DECORATE),
+								headerRequest.getAttribute(WebKeys.RENDER_PATH),
+								headerRequest.getAttribute(
+									WebKeys.RENDER_PORTLET_BOUNDARY),
+								headerRequest.getAttribute(
+									WebKeys.RENDER_PORTLET_COLUMN_COUNT),
+								headerRequest.getAttribute(
+									WebKeys.RENDER_PORTLET_COLUMN_ID),
+								headerRequest.getAttribute(
+									WebKeys.RENDER_PORTLET_COLUMN_POS)),
+							".css\">"));
+				}
 
-					@Override
-					public void renderHeaders(
-							HeaderRequest headerRequest,
-							HeaderResponse headerResponse)
-						throws IOException {
-
-						PrintWriter printWriter = headerResponse.getWriter();
-
-						printWriter.write(
-							StringBundler.concat(
-								"<link rel=\"stylesheet\" href=\"",
-								Arrays.asList(
-									headerRequest.getAttribute(
-										WebKeys.PORTLET_DECORATE),
-									headerRequest.getAttribute(
-										WebKeys.RENDER_PATH),
-									headerRequest.getAttribute(
-										WebKeys.RENDER_PORTLET_BOUNDARY),
-									headerRequest.getAttribute(
-										WebKeys.RENDER_PORTLET_COLUMN_COUNT),
-									headerRequest.getAttribute(
-										WebKeys.RENDER_PORTLET_COLUMN_ID),
-									headerRequest.getAttribute(
-										WebKeys.RENDER_PORTLET_COLUMN_POS)),
-								".css\">"));
-					}
-
-				},
-				HashMapDictionaryBuilder.<String, Object>put(
-					"com.liferay.portlet.deploy.parallel", "false"
-				).put(
-					"com.liferay.portlet.use-default-template", "false"
-				).put(
-					"jakarta.portlet.init-param.valid-paths", "/"
-				).put(
-					"jakarta.portlet.init-param.view-template", "/"
-				).put(
-					"jakarta.portlet.name", portletId
-				).put(
-					"jakarta.portlet.version", "3.0"
-				).build());
-
-		PermissionChecker permissionChecker =
-			PermissionThreadLocal.getPermissionChecker();
+			});
 
 		RenderPortletAction renderPortletAction = new RenderPortletAction();
 
@@ -184,30 +168,8 @@ public class RenderPortletActionTest {
 			_portletLocalService.getPortletById(
 				TestPropsValues.getCompanyId(), portletId));
 
-		ThemeDisplay themeDisplay = new ThemeDisplay();
-
-		themeDisplay.setCompany(
-			_companyLocalService.getCompany(TestPropsValues.getCompanyId()));
-		themeDisplay.setLayout(layout);
-
-		LayoutSet layoutSet = group.getPublicLayoutSet();
-
-		themeDisplay.setLayoutSet(layoutSet);
-
-		themeDisplay.setLayoutTypePortlet(
-			(LayoutTypePortlet)layout.getLayoutType());
-		themeDisplay.setLocale(LocaleUtil.getDefault());
-		themeDisplay.setLookAndFeel(
-			layoutSet.getTheme(), layoutSet.getColorScheme());
-
-		PermissionThreadLocal.setPermissionChecker(
-			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
-
-		themeDisplay.setPermissionChecker(
-			PermissionThreadLocal.getPermissionChecker());
-
 		mockHttpServletRequest.setAttribute(
-			WebKeys.THEME_DISPLAY, themeDisplay);
+			WebKeys.THEME_DISPLAY, _getThemeDisplay(layout, group));
 
 		String portletDecorate = String.valueOf(RandomTestUtil.randomBoolean());
 		String renderPortletBoundary = String.valueOf(
@@ -259,56 +221,29 @@ public class RenderPortletActionTest {
 						null, null, renderPortletBoundary,
 						renderPortletColumnCount, renderPortletColumnId,
 						renderPortletColumnPos))));
-
-		PermissionThreadLocal.setPermissionChecker(permissionChecker);
-
-		serviceRegistration.unregister();
 	}
 
 	@Test
 	public void testRenderHeaders() throws Exception {
-		Bundle bundle = FrameworkUtil.getBundle(RenderPortletActionTest.class);
-
-		BundleContext bundleContext = bundle.getBundleContext();
-
 		String html =
 			"<link rel=\"stylesheet\" href=\"" + RandomTestUtil.randomString() +
 				".css\">";
-		String portletId = RandomTestUtil.randomString();
 
-		ServiceRegistration<Portlet> serviceRegistration =
-			bundleContext.registerService(
-				Portlet.class,
-				new MVCPortlet() {
+		String portletId = _registerPortlet(
+			new MVCPortlet() {
 
-					@Override
-					public void renderHeaders(
-							HeaderRequest headerRequest,
-							HeaderResponse headerResponse)
-						throws IOException {
+				@Override
+				public void renderHeaders(
+						HeaderRequest headerRequest,
+						HeaderResponse headerResponse)
+					throws IOException {
 
-						PrintWriter printWriter = headerResponse.getWriter();
+					PrintWriter printWriter = headerResponse.getWriter();
 
-						printWriter.write(html);
-					}
+					printWriter.write(html);
+				}
 
-				},
-				HashMapDictionaryBuilder.put(
-					"com.liferay.portlet.deploy.parallel", "false"
-				).put(
-					"com.liferay.portlet.use-default-template", "false"
-				).put(
-					"jakarta.portlet.init-param.valid-paths", "/"
-				).put(
-					"jakarta.portlet.init-param.view-template", "/"
-				).put(
-					"jakarta.portlet.name", portletId
-				).put(
-					"jakarta.portlet.version", "3.0"
-				).build());
-
-		PermissionChecker permissionChecker =
-			PermissionThreadLocal.getPermissionChecker();
+			});
 
 		RenderPortletAction renderPortletAction = new RenderPortletAction();
 
@@ -339,6 +274,26 @@ public class RenderPortletActionTest {
 			_portletLocalService.getPortletById(
 				TestPropsValues.getCompanyId(), portletId));
 
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay(layout, group));
+
+		mockHttpServletRequest.setParameter(
+			"p_p_id", LayoutTestUtil.addPortletToLayout(layout, portletId));
+
+		renderPortletAction.execute(
+			null, mockHttpServletRequest, new MockHttpServletResponse());
+
+		OutputData outputData = (OutputData)mockHttpServletRequest.getAttribute(
+			WebKeys.OUTPUT_DATA);
+
+		Assert.assertEquals(
+			StringPool.NEW_LINE + html,
+			String.valueOf(outputData.getMergedDataSB(WebKeys.PAGE_TOP)));
+	}
+
+	private ThemeDisplay _getThemeDisplay(Layout layout, Group group)
+		throws Exception {
+
 		ThemeDisplay themeDisplay = new ThemeDisplay();
 
 		themeDisplay.setCompany(
@@ -354,32 +309,36 @@ public class RenderPortletActionTest {
 		themeDisplay.setLocale(LocaleUtil.getDefault());
 		themeDisplay.setLookAndFeel(
 			layoutSet.getTheme(), layoutSet.getColorScheme());
-
-		PermissionThreadLocal.setPermissionChecker(
-			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
-
 		themeDisplay.setPermissionChecker(
 			PermissionThreadLocal.getPermissionChecker());
 
-		mockHttpServletRequest.setAttribute(
-			WebKeys.THEME_DISPLAY, themeDisplay);
+		return themeDisplay;
+	}
 
-		mockHttpServletRequest.setParameter(
-			"p_p_id", LayoutTestUtil.addPortletToLayout(layout, portletId));
+	private String _registerPortlet(Portlet portlet) {
+		Bundle bundle = FrameworkUtil.getBundle(RenderPortletActionTest.class);
 
-		renderPortletAction.execute(
-			null, mockHttpServletRequest, new MockHttpServletResponse());
+		BundleContext bundleContext = bundle.getBundleContext();
 
-		OutputData outputData = (OutputData)mockHttpServletRequest.getAttribute(
-			WebKeys.OUTPUT_DATA);
+		String portletId = RandomTestUtil.randomString();
 
-		Assert.assertEquals(
-			StringPool.NEW_LINE + html,
-			String.valueOf(outputData.getMergedDataSB(WebKeys.PAGE_TOP)));
+		_serviceRegistration = bundleContext.registerService(
+			Portlet.class, portlet,
+			HashMapDictionaryBuilder.put(
+				"com.liferay.portlet.deploy.parallel", "false"
+			).put(
+				"com.liferay.portlet.use-default-template", "false"
+			).put(
+				"jakarta.portlet.init-param.valid-paths", "/"
+			).put(
+				"jakarta.portlet.init-param.view-template", "/"
+			).put(
+				"jakarta.portlet.name", portletId
+			).put(
+				"jakarta.portlet.version", "3.0"
+			).build());
 
-		PermissionThreadLocal.setPermissionChecker(permissionChecker);
-
-		serviceRegistration.unregister();
+		return portletId;
 	}
 
 	@Inject
@@ -387,5 +346,7 @@ public class RenderPortletActionTest {
 
 	@Inject
 	private CompanyLocalService _companyLocalService;
+
+	private ServiceRegistration<?> _serviceRegistration;
 
 }

--- a/portal-impl/src/com/liferay/portlet/RestrictPortletContainerWrapper.java
+++ b/portal-impl/src/com/liferay/portlet/RestrictPortletContainerWrapper.java
@@ -169,14 +169,6 @@ public class RestrictPortletContainerWrapper implements PortletContainer {
 			renderable.render();
 		}
 		finally {
-			restrictPortletServletRequest.removeAttribute(WebKeys.RENDER_PATH);
-			restrictPortletServletRequest.removeAttribute(
-				WebKeys.RENDER_PORTLET_COLUMN_COUNT);
-			restrictPortletServletRequest.removeAttribute(
-				WebKeys.RENDER_PORTLET_COLUMN_ID);
-			restrictPortletServletRequest.removeAttribute(
-				WebKeys.RENDER_PORTLET_COLUMN_POS);
-
 			restrictPortletServletRequest.mergeSharedAttributes();
 		}
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-75296

## What is being fixed

Customizable widget pages were missing "Delete" and other kebab menu options due to attribute leakage cleanup clearing necessary attributes between Portlet 3.0 phases. Portlet 3.0 expects the header phase and render phase to be invoked in sequence. Since `RestrictPortletContainerWrapper` handles both phases, `RENDER_PORTLET_COLUMN_*` attributes were cleared after `renderHeaders`. The subsequent render ran without these attributes, resulting in unexpected behavior.

## How it is being fixed

Removed the manual attribute cleanup in `RestrictPortletContainerWrapper.java` as it is no longer necessary. The cleanup originally defended against attribute leakage when a wrapper was reused across multiple portlet renders, but no caller exhibits this pattern now (parallel rendering was removed in LPS-110359).