### PR TITLE
LPD-82451 Consolidate friendly URL group resolution across the filter chain

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -138,11 +138,13 @@ public class FriendlyURLServlet extends HttpServlet {
 				companyId, path);
 		}
 
-		Group group = (friendlyURLGroupObjectValuePair == null) ? null :
-			friendlyURLGroupObjectValuePair.getValue();
-		String groupFriendlyURL =
-			(friendlyURLGroupObjectValuePair == null) ? path :
-				friendlyURLGroupObjectValuePair.getKey();
+		Group group = null;
+		String groupFriendlyURL = path;
+
+		if (friendlyURLGroupObjectValuePair != null) {
+			group = friendlyURLGroupObjectValuePair.getValue();
+			groupFriendlyURL = friendlyURLGroupObjectValuePair.getKey();
+		}
 
 		if ((group == null) ||
 			(!group.isActive() && !groupLocalService.isMaintenanceMode(group) &&

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -129,18 +129,20 @@ public class FriendlyURLServlet extends HttpServlet {
 
 		long companyId = PortalInstances.getCompanyId(httpServletRequest);
 
-		ObjectValuePair<Group, String> friendlyURLGroup =
-			(ObjectValuePair<Group, String>)httpServletRequest.getAttribute(
+		ObjectValuePair<String, Group> friendlyURLGroupObjectValuePair =
+			(ObjectValuePair<String, Group>)httpServletRequest.getAttribute(
 				WebKeys.FRIENDLY_URL_GROUP);
 
-		if (friendlyURLGroup == null) {
-			friendlyURLGroup = portal.fetchFriendlyURLGroup(companyId, path);
+		if (friendlyURLGroupObjectValuePair == null) {
+			friendlyURLGroupObjectValuePair = portal.fetchFriendlyURLGroup(
+				companyId, path);
 		}
 
-		Group group =
-			(friendlyURLGroup == null) ? null : friendlyURLGroup.getKey();
+		Group group = (friendlyURLGroupObjectValuePair == null) ? null :
+			friendlyURLGroupObjectValuePair.getValue();
 		String groupFriendlyURL =
-			(friendlyURLGroup == null) ? path : friendlyURLGroup.getValue();
+			(friendlyURLGroupObjectValuePair == null) ? path :
+				friendlyURLGroupObjectValuePair.getKey();
 
 		if ((group == null) ||
 			(!group.isActive() && !groupLocalService.isMaintenanceMode(group) &&

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -73,6 +73,7 @@ import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PrefsPropsUtil;
@@ -83,7 +84,6 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.util.PortalInstances;
 import com.liferay.portlet.AsyncPortletServletRequest;
-import com.liferay.portlet.documentlibrary.constants.DLFriendlyURLConstants;
 import com.liferay.redirect.provider.RedirectProvider;
 import com.liferay.redirect.tracker.RedirectNotFoundTracker;
 import com.liferay.site.model.SiteFriendlyURL;
@@ -127,34 +127,20 @@ public class FriendlyURLServlet extends HttpServlet {
 			return new Redirect();
 		}
 
-		String groupFriendlyURL = path;
-
-		int pos = path.indexOf(CharPool.SLASH, 1);
-
-		if (pos != -1) {
-			String friendlyURL = path.substring(pos);
-
-			if (friendlyURL.startsWith(
-					DLFriendlyURLConstants.PATH_PREFIX_DOCUMENT)) {
-
-				String fileEntryFriendlyURL = friendlyURL.substring(
-					DLFriendlyURLConstants.PATH_PREFIX_DOCUMENT.length() - 1);
-
-				groupFriendlyURL = fileEntryFriendlyURL.substring(
-					0, fileEntryFriendlyURL.indexOf(CharPool.SLASH, 1));
-			}
-			else {
-				groupFriendlyURL = path.substring(0, pos);
-			}
-		}
-
 		long companyId = PortalInstances.getCompanyId(httpServletRequest);
 
-		Group group = (Group)httpServletRequest.getAttribute(WebKeys.GROUP);
+		ObjectValuePair<Group, String> friendlyURLGroup =
+			(ObjectValuePair<Group, String>)httpServletRequest.getAttribute(
+				WebKeys.FRIENDLY_URL_GROUP);
 
-		if (group == null) {
-			group = portal.fetchFriendlyURLGroup(companyId, path);
+		if (friendlyURLGroup == null) {
+			friendlyURLGroup = portal.fetchFriendlyURLGroup(companyId, path);
 		}
+
+		Group group =
+			(friendlyURLGroup == null) ? null : friendlyURLGroup.getKey();
+		String groupFriendlyURL =
+			(friendlyURLGroup == null) ? path : friendlyURLGroup.getValue();
 
 		if ((group == null) ||
 			(!group.isActive() && !groupLocalService.isMaintenanceMode(group) &&
@@ -193,6 +179,8 @@ public class FriendlyURLServlet extends HttpServlet {
 
 		String layoutFriendlyURL = null;
 		Redirect redirectProviderRedirect = null;
+
+		int pos = path.indexOf(CharPool.SLASH, 1);
 
 		if ((pos != -1) && ((pos + 1) != path.length())) {
 			layoutFriendlyURL = path.substring(pos);

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -150,7 +150,25 @@ public class FriendlyURLServlet extends HttpServlet {
 
 		long companyId = PortalInstances.getCompanyId(httpServletRequest);
 
-		Group group = _getGroup(path, groupFriendlyURL, companyId);
+		Group group = (Group)httpServletRequest.getAttribute(WebKeys.GROUP);
+
+		if (group == null) {
+			group = portal.fetchFriendlyURLGroup(companyId, path);
+		}
+
+		if ((group == null) ||
+			(!group.isActive() && !groupLocalService.isMaintenanceMode(group) &&
+			 !inactiveRequestHandler.isShowInactiveRequestMessage() &&
+			 !path.startsWith(GroupConstants.CONTROL_PANEL_FRIENDLY_URL) &&
+			 !path.startsWith(
+				 groupFriendlyURL +
+					 VirtualLayoutConstants.CANONICAL_URL_SEPARATOR))) {
+
+			throw new NoSuchGroupException(
+				StringBundler.concat(
+					"{companyId=", companyId, ", friendlyURL=",
+					groupFriendlyURL, "}"));
+		}
 
 		if (!group.isActive() && groupLocalService.isMaintenanceMode(group)) {
 			User user = _getUser(httpServletRequest);
@@ -967,43 +985,6 @@ public class FriendlyURLServlet extends HttpServlet {
 					getCompanyFriendlyURLRedirectionConfiguration(companyId);
 
 		return friendlyURLRedirectionConfiguration.redirectionType();
-	}
-
-	private Group _getGroup(String path, String friendlyURL, long companyId)
-		throws NoSuchGroupException {
-
-		Group group = groupLocalService.fetchFriendlyURLGroup(
-			companyId, friendlyURL);
-
-		if (group == null) {
-			String screenName = friendlyURL.substring(1);
-
-			User user = userLocalService.fetchUserByScreenName(
-				companyId, screenName);
-
-			if (user != null) {
-				group = user.getGroup();
-			}
-			else if (_log.isWarnEnabled()) {
-				_log.warn("No user exists with friendly URL " + screenName);
-			}
-		}
-
-		if ((group == null) ||
-			(!group.isActive() && !groupLocalService.isMaintenanceMode(group) &&
-			 !inactiveRequestHandler.isShowInactiveRequestMessage() &&
-			 !path.startsWith(GroupConstants.CONTROL_PANEL_FRIENDLY_URL) &&
-			 !path.startsWith(
-				 friendlyURL +
-					 VirtualLayoutConstants.CANONICAL_URL_SEPARATOR))) {
-
-			throw new NoSuchGroupException(
-				StringBundler.concat(
-					"{companyId=", companyId, ", friendlyURL=", friendlyURL,
-					"}"));
-		}
-
-		return group;
 	}
 
 	private LastPath _getLastPath(

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/servlet/test/FriendlyURLServletTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/servlet/test/FriendlyURLServletTest.java
@@ -61,6 +61,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
@@ -483,7 +484,9 @@ public class FriendlyURLServletTest {
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest();
 
-		mockHttpServletRequest.setAttribute(WebKeys.GROUP, _group);
+		mockHttpServletRequest.setAttribute(
+			WebKeys.FRIENDLY_URL_GROUP,
+			new ObjectValuePair<>(_group, _group.getFriendlyURL()));
 		mockHttpServletRequest.setPathInfo(StringPool.SLASH);
 
 		testGetRedirect(

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/servlet/test/FriendlyURLServletTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/servlet/test/FriendlyURLServletTest.java
@@ -477,6 +477,22 @@ public class FriendlyURLServletTest {
 	}
 
 	@Test
+	public void testGetRedirectReusesGroupFromRequestAttribute()
+		throws Throwable {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(WebKeys.GROUP, _group);
+		mockHttpServletRequest.setPathInfo(StringPool.SLASH);
+
+		testGetRedirect(
+			mockHttpServletRequest,
+			"/lpd82451-no-such-group" + _layout.getFriendlyURL(),
+			_redirectConstructor1.newInstance(getURL(_layout)));
+	}
+
+	@Test
 	public void testGetRedirectWithExistentSite() throws Throwable {
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest();

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/servlet/test/FriendlyURLServletTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/servlet/test/FriendlyURLServletTest.java
@@ -486,12 +486,13 @@ public class FriendlyURLServletTest {
 
 		mockHttpServletRequest.setAttribute(
 			WebKeys.FRIENDLY_URL_GROUP,
-			new ObjectValuePair<>(_group, _group.getFriendlyURL()));
+			new ObjectValuePair<>(_group.getFriendlyURL(), _group));
 		mockHttpServletRequest.setPathInfo(StringPool.SLASH);
 
 		testGetRedirect(
 			mockHttpServletRequest,
-			"/lpd82451-no-such-group" + _layout.getFriendlyURL(),
+			StringPool.SLASH + RandomTestUtil.randomString() +
+				_layout.getFriendlyURL(),
 			_redirectConstructor1.newInstance(getURL(_layout)));
 	}
 

--- a/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/virtualhost/test/VirtualHostFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/virtualhost/test/VirtualHostFilterTest.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.struts.LastPath;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ObjectValuePair;
@@ -97,7 +98,7 @@ public class VirtualHostFilterTest {
 					false)) {
 
 			MockHttpServletRequest mockHttpServletRequest = _processFilter(
-				null, "/lpd82451-no-such-group");
+				null, StringPool.SLASH + RandomTestUtil.randomString());
 
 			Assert.assertNull(
 				mockHttpServletRequest.getAttribute(
@@ -240,21 +241,23 @@ public class VirtualHostFilterTest {
 		String groupFriendlyURL = _getGroupFriendlyURL(_publicLayoutSet);
 
 		MockHttpServletRequest mockHttpServletRequest = _processFilter(
-			_publicLayoutSet, groupFriendlyURL + "/home");
+			_publicLayoutSet,
+			groupFriendlyURL + StringPool.SLASH +
+				RandomTestUtil.randomString());
 
-		ObjectValuePair<Group, String> stashedFriendlyURLGroup =
-			(ObjectValuePair<Group, String>)mockHttpServletRequest.getAttribute(
+		ObjectValuePair<String, Group> friendlyURLGroupObjectValuePair =
+			(ObjectValuePair<String, Group>)mockHttpServletRequest.getAttribute(
 				WebKeys.FRIENDLY_URL_GROUP);
 
-		Assert.assertNotNull(stashedFriendlyURLGroup);
+		Assert.assertNotNull(friendlyURLGroupObjectValuePair);
 
-		Group stashedGroup = stashedFriendlyURLGroup.getKey();
+		Group stashedGroup = friendlyURLGroupObjectValuePair.getValue();
 
 		Assert.assertEquals(
 			_publicLayoutSet.getGroupId(), stashedGroup.getGroupId());
 
 		Assert.assertEquals(
-			groupFriendlyURL, stashedFriendlyURLGroup.getValue());
+			groupFriendlyURL, friendlyURLGroupObjectValuePair.getKey());
 	}
 
 	@Test
@@ -269,22 +272,24 @@ public class VirtualHostFilterTest {
 			String groupFriendlyURL = _getGroupFriendlyURL(_publicLayoutSet);
 
 			MockHttpServletRequest mockHttpServletRequest = _processFilter(
-				null, groupFriendlyURL + "/home");
+				null,
+				groupFriendlyURL + StringPool.SLASH +
+					RandomTestUtil.randomString());
 
-			ObjectValuePair<Group, String> stashedFriendlyURLGroup =
-				(ObjectValuePair<Group, String>)
+			ObjectValuePair<String, Group> friendlyURLGroupObjectValuePair =
+				(ObjectValuePair<String, Group>)
 					mockHttpServletRequest.getAttribute(
 						WebKeys.FRIENDLY_URL_GROUP);
 
-			Assert.assertNotNull(stashedFriendlyURLGroup);
+			Assert.assertNotNull(friendlyURLGroupObjectValuePair);
 
-			Group stashedGroup = stashedFriendlyURLGroup.getKey();
+			Group stashedGroup = friendlyURLGroupObjectValuePair.getValue();
 
 			Assert.assertEquals(
 				_publicLayoutSet.getGroupId(), stashedGroup.getGroupId());
 
 			Assert.assertEquals(
-				groupFriendlyURL, stashedFriendlyURLGroup.getValue());
+				groupFriendlyURL, friendlyURLGroupObjectValuePair.getKey());
 		}
 	}
 

--- a/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/virtualhost/test/VirtualHostFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/virtualhost/test/VirtualHostFilterTest.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -99,7 +100,8 @@ public class VirtualHostFilterTest {
 				null, "/lpd82451-no-such-group");
 
 			Assert.assertNull(
-				mockHttpServletRequest.getAttribute(WebKeys.GROUP));
+				mockHttpServletRequest.getAttribute(
+					WebKeys.FRIENDLY_URL_GROUP));
 		}
 	}
 
@@ -240,12 +242,19 @@ public class VirtualHostFilterTest {
 		MockHttpServletRequest mockHttpServletRequest = _processFilter(
 			_publicLayoutSet, groupFriendlyURL + "/home");
 
-		Group stashedGroup = (Group)mockHttpServletRequest.getAttribute(
-			WebKeys.GROUP);
+		ObjectValuePair<Group, String> stashedFriendlyURLGroup =
+			(ObjectValuePair<Group, String>)mockHttpServletRequest.getAttribute(
+				WebKeys.FRIENDLY_URL_GROUP);
 
-		Assert.assertNotNull(stashedGroup);
+		Assert.assertNotNull(stashedFriendlyURLGroup);
+
+		Group stashedGroup = stashedFriendlyURLGroup.getKey();
+
 		Assert.assertEquals(
 			_publicLayoutSet.getGroupId(), stashedGroup.getGroupId());
+
+		Assert.assertEquals(
+			groupFriendlyURL, stashedFriendlyURLGroup.getValue());
 	}
 
 	@Test
@@ -262,12 +271,20 @@ public class VirtualHostFilterTest {
 			MockHttpServletRequest mockHttpServletRequest = _processFilter(
 				null, groupFriendlyURL + "/home");
 
-			Group stashedGroup = (Group)mockHttpServletRequest.getAttribute(
-				WebKeys.GROUP);
+			ObjectValuePair<Group, String> stashedFriendlyURLGroup =
+				(ObjectValuePair<Group, String>)
+					mockHttpServletRequest.getAttribute(
+						WebKeys.FRIENDLY_URL_GROUP);
 
-			Assert.assertNotNull(stashedGroup);
+			Assert.assertNotNull(stashedFriendlyURLGroup);
+
+			Group stashedGroup = stashedFriendlyURLGroup.getKey();
+
 			Assert.assertEquals(
 				_publicLayoutSet.getGroupId(), stashedGroup.getGroupId());
+
+			Assert.assertEquals(
+				groupFriendlyURL, stashedFriendlyURLGroup.getValue());
 		}
 	}
 

--- a/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/virtualhost/test/VirtualHostFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/virtualhost/test/VirtualHostFilterTest.java
@@ -251,10 +251,9 @@ public class VirtualHostFilterTest {
 
 		Assert.assertNotNull(friendlyURLGroupObjectValuePair);
 
-		Group stashedGroup = friendlyURLGroupObjectValuePair.getValue();
+		Group group = friendlyURLGroupObjectValuePair.getValue();
 
-		Assert.assertEquals(
-			_publicLayoutSet.getGroupId(), stashedGroup.getGroupId());
+		Assert.assertEquals(_publicLayoutSet.getGroupId(), group.getGroupId());
 
 		Assert.assertEquals(
 			groupFriendlyURL, friendlyURLGroupObjectValuePair.getKey());
@@ -283,10 +282,10 @@ public class VirtualHostFilterTest {
 
 			Assert.assertNotNull(friendlyURLGroupObjectValuePair);
 
-			Group stashedGroup = friendlyURLGroupObjectValuePair.getValue();
+			Group group = friendlyURLGroupObjectValuePair.getValue();
 
 			Assert.assertEquals(
-				_publicLayoutSet.getGroupId(), stashedGroup.getGroupId());
+				_publicLayoutSet.getGroupId(), group.getGroupId());
 
 			Assert.assertEquals(
 				groupFriendlyURL, friendlyURLGroupObjectValuePair.getKey());

--- a/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/virtualhost/test/VirtualHostFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/virtualhost/test/VirtualHostFilterTest.java
@@ -89,6 +89,21 @@ public class VirtualHostFilterTest {
 	}
 
 	@Test
+	public void testProcessFilterDoesNotStashGroupOnRequestForUnknownPath() {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED",
+					false)) {
+
+			MockHttpServletRequest mockHttpServletRequest = _processFilter(
+				null, "/lpd82451-no-such-group");
+
+			Assert.assertNull(
+				mockHttpServletRequest.getAttribute(WebKeys.GROUP));
+		}
+	}
+
+	@Test
 	public void testProcessFilterForwardedURL() {
 		try (SafeCloseable safeCloseable =
 				PropsValuesTestUtil.swapWithSafeCloseable(
@@ -216,6 +231,46 @@ public class VirtualHostFilterTest {
 		}
 	}
 
+	@Test
+	public void testProcessFilterStashesGroupOnRequestWhenLayoutSetMatches()
+		throws Exception {
+
+		String groupFriendlyURL = _getGroupFriendlyURL(_publicLayoutSet);
+
+		MockHttpServletRequest mockHttpServletRequest = _processFilter(
+			_publicLayoutSet, groupFriendlyURL + "/home");
+
+		Group stashedGroup = (Group)mockHttpServletRequest.getAttribute(
+			WebKeys.GROUP);
+
+		Assert.assertNotNull(stashedGroup);
+		Assert.assertEquals(
+			_publicLayoutSet.getGroupId(), stashedGroup.getGroupId());
+	}
+
+	@Test
+	public void testProcessFilterStashesGroupOnRequestWhenPathForwards()
+		throws Exception {
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED",
+					false)) {
+
+			String groupFriendlyURL = _getGroupFriendlyURL(_publicLayoutSet);
+
+			MockHttpServletRequest mockHttpServletRequest = _processFilter(
+				null, groupFriendlyURL + "/home");
+
+			Group stashedGroup = (Group)mockHttpServletRequest.getAttribute(
+				WebKeys.GROUP);
+
+			Assert.assertNotNull(stashedGroup);
+			Assert.assertEquals(
+				_publicLayoutSet.getGroupId(), stashedGroup.getGroupId());
+		}
+	}
+
 	private String _getForwardedURL(LayoutSet layoutSet, String requestURI) {
 		MockHttpServletRequest mockHttpServletRequest =
 			_getMockHttpServletRequest(layoutSet, requestURI);
@@ -308,6 +363,26 @@ public class VirtualHostFilterTest {
 		String requestURI) {
 
 		return _getMockHttpServletRequest(_publicLayoutSet, requestURI);
+	}
+
+	private MockHttpServletRequest _processFilter(
+		LayoutSet layoutSet, String requestURI) {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			_getMockHttpServletRequest(layoutSet, requestURI);
+
+		_virtualHostFilter.init(new MockFilterConfig());
+
+		ReflectionTestUtil.invoke(
+			_virtualHostFilter, "processFilter",
+			new Class<?>[] {
+				HttpServletRequest.class, HttpServletResponse.class,
+				FilterChain.class
+			},
+			mockHttpServletRequest, new MockHttpServletResponse(),
+			new MockFilterChain());
+
+		return mockHttpServletRequest;
 	}
 
 	private void _testProcessFilterLastPath(

--- a/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/virtualhost/test/VirtualHostFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/virtualhost/test/VirtualHostFilterTest.java
@@ -222,10 +222,9 @@ public class VirtualHostFilterTest {
 
 		Assert.assertNotNull(friendlyURLGroupObjectValuePair);
 
-		Group stashedGroup = friendlyURLGroupObjectValuePair.getValue();
+		Group group = friendlyURLGroupObjectValuePair.getValue();
 
-		Assert.assertEquals(
-			_publicLayoutSet.getGroupId(), stashedGroup.getGroupId());
+		Assert.assertEquals(_publicLayoutSet.getGroupId(), group.getGroupId());
 
 		Assert.assertEquals(
 			groupFriendlyURL, friendlyURLGroupObjectValuePair.getKey());
@@ -254,10 +253,10 @@ public class VirtualHostFilterTest {
 
 			Assert.assertNotNull(friendlyURLGroupObjectValuePair);
 
-			Group stashedGroup = friendlyURLGroupObjectValuePair.getValue();
+			Group group = friendlyURLGroupObjectValuePair.getValue();
 
 			Assert.assertEquals(
-				_publicLayoutSet.getGroupId(), stashedGroup.getGroupId());
+				_publicLayoutSet.getGroupId(), group.getGroupId());
 
 			Assert.assertEquals(
 				groupFriendlyURL, friendlyURLGroupObjectValuePair.getKey());

--- a/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/virtualhost/test/VirtualHostFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/virtualhost/test/VirtualHostFilterTest.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.struts.LastPath;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ObjectValuePair;
@@ -97,7 +98,7 @@ public class VirtualHostFilterTest {
 					false)) {
 
 			MockHttpServletRequest mockHttpServletRequest = _processFilter(
-				null, "/lpd82451-no-such-group");
+				null, StringPool.SLASH + RandomTestUtil.randomString());
 
 			Assert.assertNull(
 				mockHttpServletRequest.getAttribute(
@@ -211,21 +212,23 @@ public class VirtualHostFilterTest {
 		String groupFriendlyURL = _getGroupFriendlyURL(_publicLayoutSet);
 
 		MockHttpServletRequest mockHttpServletRequest = _processFilter(
-			_publicLayoutSet, groupFriendlyURL + "/home");
+			_publicLayoutSet,
+			groupFriendlyURL + StringPool.SLASH +
+				RandomTestUtil.randomString());
 
-		ObjectValuePair<Group, String> stashedFriendlyURLGroup =
-			(ObjectValuePair<Group, String>)mockHttpServletRequest.getAttribute(
+		ObjectValuePair<String, Group> friendlyURLGroupObjectValuePair =
+			(ObjectValuePair<String, Group>)mockHttpServletRequest.getAttribute(
 				WebKeys.FRIENDLY_URL_GROUP);
 
-		Assert.assertNotNull(stashedFriendlyURLGroup);
+		Assert.assertNotNull(friendlyURLGroupObjectValuePair);
 
-		Group stashedGroup = stashedFriendlyURLGroup.getKey();
+		Group stashedGroup = friendlyURLGroupObjectValuePair.getValue();
 
 		Assert.assertEquals(
 			_publicLayoutSet.getGroupId(), stashedGroup.getGroupId());
 
 		Assert.assertEquals(
-			groupFriendlyURL, stashedFriendlyURLGroup.getValue());
+			groupFriendlyURL, friendlyURLGroupObjectValuePair.getKey());
 	}
 
 	@Test
@@ -240,22 +243,24 @@ public class VirtualHostFilterTest {
 			String groupFriendlyURL = _getGroupFriendlyURL(_publicLayoutSet);
 
 			MockHttpServletRequest mockHttpServletRequest = _processFilter(
-				null, groupFriendlyURL + "/home");
+				null,
+				groupFriendlyURL + StringPool.SLASH +
+					RandomTestUtil.randomString());
 
-			ObjectValuePair<Group, String> stashedFriendlyURLGroup =
-				(ObjectValuePair<Group, String>)
+			ObjectValuePair<String, Group> friendlyURLGroupObjectValuePair =
+				(ObjectValuePair<String, Group>)
 					mockHttpServletRequest.getAttribute(
 						WebKeys.FRIENDLY_URL_GROUP);
 
-			Assert.assertNotNull(stashedFriendlyURLGroup);
+			Assert.assertNotNull(friendlyURLGroupObjectValuePair);
 
-			Group stashedGroup = stashedFriendlyURLGroup.getKey();
+			Group stashedGroup = friendlyURLGroupObjectValuePair.getValue();
 
 			Assert.assertEquals(
 				_publicLayoutSet.getGroupId(), stashedGroup.getGroupId());
 
 			Assert.assertEquals(
-				groupFriendlyURL, stashedFriendlyURLGroup.getValue());
+				groupFriendlyURL, friendlyURLGroupObjectValuePair.getKey());
 		}
 	}
 

--- a/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/virtualhost/test/VirtualHostFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/virtualhost/test/VirtualHostFilterTest.java
@@ -89,6 +89,21 @@ public class VirtualHostFilterTest {
 	}
 
 	@Test
+	public void testProcessFilterDoesNotStashGroupOnRequestForUnknownPath() {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED",
+					false)) {
+
+			MockHttpServletRequest mockHttpServletRequest = _processFilter(
+				null, "/lpd82451-no-such-group");
+
+			Assert.assertNull(
+				mockHttpServletRequest.getAttribute(WebKeys.GROUP));
+		}
+	}
+
+	@Test
 	public void testProcessFilterForwardedURL() {
 		try (SafeCloseable safeCloseable =
 				PropsValuesTestUtil.swapWithSafeCloseable(
@@ -187,6 +202,46 @@ public class VirtualHostFilterTest {
 		_testProcessFilterLastPath(_PATH_PROXY, _PATH_PROXY, _LAST_PATH);
 	}
 
+	@Test
+	public void testProcessFilterStashesGroupOnRequestWhenLayoutSetMatches()
+		throws Exception {
+
+		String groupFriendlyURL = _getGroupFriendlyURL(_publicLayoutSet);
+
+		MockHttpServletRequest mockHttpServletRequest = _processFilter(
+			_publicLayoutSet, groupFriendlyURL + "/home");
+
+		Group stashedGroup = (Group)mockHttpServletRequest.getAttribute(
+			WebKeys.GROUP);
+
+		Assert.assertNotNull(stashedGroup);
+		Assert.assertEquals(
+			_publicLayoutSet.getGroupId(), stashedGroup.getGroupId());
+	}
+
+	@Test
+	public void testProcessFilterStashesGroupOnRequestWhenPathForwards()
+		throws Exception {
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED",
+					false)) {
+
+			String groupFriendlyURL = _getGroupFriendlyURL(_publicLayoutSet);
+
+			MockHttpServletRequest mockHttpServletRequest = _processFilter(
+				null, groupFriendlyURL + "/home");
+
+			Group stashedGroup = (Group)mockHttpServletRequest.getAttribute(
+				WebKeys.GROUP);
+
+			Assert.assertNotNull(stashedGroup);
+			Assert.assertEquals(
+				_publicLayoutSet.getGroupId(), stashedGroup.getGroupId());
+		}
+	}
+
 	private String _getForwardedURL(LayoutSet layoutSet, String requestURI) {
 		MockHttpServletRequest mockHttpServletRequest =
 			_getMockHttpServletRequest(layoutSet, requestURI);
@@ -279,6 +334,26 @@ public class VirtualHostFilterTest {
 		String requestURI) {
 
 		return _getMockHttpServletRequest(_publicLayoutSet, requestURI);
+	}
+
+	private MockHttpServletRequest _processFilter(
+		LayoutSet layoutSet, String requestURI) {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			_getMockHttpServletRequest(layoutSet, requestURI);
+
+		_virtualHostFilter.init(new MockFilterConfig());
+
+		ReflectionTestUtil.invoke(
+			_virtualHostFilter, "processFilter",
+			new Class<?>[] {
+				HttpServletRequest.class, HttpServletResponse.class,
+				FilterChain.class
+			},
+			mockHttpServletRequest, new MockHttpServletResponse(),
+			new MockFilterChain());
+
+		return mockHttpServletRequest;
 	}
 
 	private void _testProcessFilterLastPath(

--- a/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/virtualhost/test/VirtualHostFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/virtualhost/test/VirtualHostFilterTest.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -99,7 +100,8 @@ public class VirtualHostFilterTest {
 				null, "/lpd82451-no-such-group");
 
 			Assert.assertNull(
-				mockHttpServletRequest.getAttribute(WebKeys.GROUP));
+				mockHttpServletRequest.getAttribute(
+					WebKeys.FRIENDLY_URL_GROUP));
 		}
 	}
 
@@ -211,12 +213,19 @@ public class VirtualHostFilterTest {
 		MockHttpServletRequest mockHttpServletRequest = _processFilter(
 			_publicLayoutSet, groupFriendlyURL + "/home");
 
-		Group stashedGroup = (Group)mockHttpServletRequest.getAttribute(
-			WebKeys.GROUP);
+		ObjectValuePair<Group, String> stashedFriendlyURLGroup =
+			(ObjectValuePair<Group, String>)mockHttpServletRequest.getAttribute(
+				WebKeys.FRIENDLY_URL_GROUP);
 
-		Assert.assertNotNull(stashedGroup);
+		Assert.assertNotNull(stashedFriendlyURLGroup);
+
+		Group stashedGroup = stashedFriendlyURLGroup.getKey();
+
 		Assert.assertEquals(
 			_publicLayoutSet.getGroupId(), stashedGroup.getGroupId());
+
+		Assert.assertEquals(
+			groupFriendlyURL, stashedFriendlyURLGroup.getValue());
 	}
 
 	@Test
@@ -233,12 +242,20 @@ public class VirtualHostFilterTest {
 			MockHttpServletRequest mockHttpServletRequest = _processFilter(
 				null, groupFriendlyURL + "/home");
 
-			Group stashedGroup = (Group)mockHttpServletRequest.getAttribute(
-				WebKeys.GROUP);
+			ObjectValuePair<Group, String> stashedFriendlyURLGroup =
+				(ObjectValuePair<Group, String>)
+					mockHttpServletRequest.getAttribute(
+						WebKeys.FRIENDLY_URL_GROUP);
 
-			Assert.assertNotNull(stashedGroup);
+			Assert.assertNotNull(stashedFriendlyURLGroup);
+
+			Group stashedGroup = stashedFriendlyURLGroup.getKey();
+
 			Assert.assertEquals(
 				_publicLayoutSet.getGroupId(), stashedGroup.getGroupId());
+
+			Assert.assertEquals(
+				groupFriendlyURL, stashedFriendlyURLGroup.getValue());
 		}
 	}
 

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplTest.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadServletRequest;
 import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.TreeMapBuilder;
@@ -79,11 +80,18 @@ public class PortalImplTest {
 			userGroup.getGroupId(),
 			StringPool.SLASH + RandomTestUtil.randomString());
 
-		Group group = _portal.fetchFriendlyURLGroup(
-			TestPropsValues.getCompanyId(),
-			StringPool.SLASH + _user.getScreenName());
+		ObjectValuePair<Group, String> friendlyURLGroup =
+			_portal.fetchFriendlyURLGroup(
+				TestPropsValues.getCompanyId(),
+				StringPool.SLASH + _user.getScreenName());
+
+		Group group = friendlyURLGroup.getKey();
 
 		Assert.assertEquals(userGroup.getGroupId(), group.getGroupId());
+
+		Assert.assertEquals(
+			StringPool.SLASH + _user.getScreenName(),
+			friendlyURLGroup.getValue());
 	}
 
 	@Test
@@ -92,11 +100,17 @@ public class PortalImplTest {
 
 		_group = GroupTestUtil.addGroup();
 
-		Group group = _portal.fetchFriendlyURLGroup(
-			TestPropsValues.getCompanyId(),
-			_group.getFriendlyURL() + "/some-layout");
+		ObjectValuePair<Group, String> friendlyURLGroup =
+			_portal.fetchFriendlyURLGroup(
+				TestPropsValues.getCompanyId(),
+				_group.getFriendlyURL() + "/some-layout");
+
+		Group group = friendlyURLGroup.getKey();
 
 		Assert.assertEquals(_group.getGroupId(), group.getGroupId());
+
+		Assert.assertEquals(
+			_group.getFriendlyURL(), friendlyURLGroup.getValue());
 	}
 
 	@Test
@@ -105,10 +119,16 @@ public class PortalImplTest {
 
 		_group = GroupTestUtil.addGroup();
 
-		Group group = _portal.fetchFriendlyURLGroup(
-			TestPropsValues.getCompanyId(), _group.getFriendlyURL());
+		ObjectValuePair<Group, String> friendlyURLGroup =
+			_portal.fetchFriendlyURLGroup(
+				TestPropsValues.getCompanyId(), _group.getFriendlyURL());
+
+		Group group = friendlyURLGroup.getKey();
 
 		Assert.assertEquals(_group.getGroupId(), group.getGroupId());
+
+		Assert.assertEquals(
+			_group.getFriendlyURL(), friendlyURLGroup.getValue());
 	}
 
 	@Test
@@ -118,13 +138,19 @@ public class PortalImplTest {
 		_group = GroupTestUtil.addGroup();
 		_otherGroup = GroupTestUtil.addGroup();
 
-		Group group = _portal.fetchFriendlyURLGroup(
-			TestPropsValues.getCompanyId(),
-			StringBundler.concat(
-				_group.getFriendlyURL(), "/documents/d",
-				_otherGroup.getFriendlyURL(), "/abc"));
+		ObjectValuePair<Group, String> friendlyURLGroup =
+			_portal.fetchFriendlyURLGroup(
+				TestPropsValues.getCompanyId(),
+				StringBundler.concat(
+					_group.getFriendlyURL(), "/documents/d",
+					_otherGroup.getFriendlyURL(), "/abc"));
+
+		Group group = friendlyURLGroup.getKey();
 
 		Assert.assertEquals(_otherGroup.getGroupId(), group.getGroupId());
+
+		Assert.assertEquals(
+			_otherGroup.getFriendlyURL(), friendlyURLGroup.getValue());
 	}
 
 	@Test

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplTest.java
@@ -80,18 +80,18 @@ public class PortalImplTest {
 			userGroup.getGroupId(),
 			StringPool.SLASH + RandomTestUtil.randomString());
 
-		ObjectValuePair<Group, String> friendlyURLGroup =
+		ObjectValuePair<String, Group> friendlyURLGroupObjectValuePair =
 			_portal.fetchFriendlyURLGroup(
 				TestPropsValues.getCompanyId(),
 				StringPool.SLASH + _user.getScreenName());
 
-		Group group = friendlyURLGroup.getKey();
+		Group group = friendlyURLGroupObjectValuePair.getValue();
 
 		Assert.assertEquals(userGroup.getGroupId(), group.getGroupId());
 
 		Assert.assertEquals(
 			StringPool.SLASH + _user.getScreenName(),
-			friendlyURLGroup.getValue());
+			friendlyURLGroupObjectValuePair.getKey());
 	}
 
 	@Test
@@ -100,17 +100,18 @@ public class PortalImplTest {
 
 		_group = GroupTestUtil.addGroup();
 
-		ObjectValuePair<Group, String> friendlyURLGroup =
+		ObjectValuePair<String, Group> friendlyURLGroupObjectValuePair =
 			_portal.fetchFriendlyURLGroup(
 				TestPropsValues.getCompanyId(),
-				_group.getFriendlyURL() + "/some-layout");
+				_group.getFriendlyURL() + StringPool.SLASH +
+					RandomTestUtil.randomString());
 
-		Group group = friendlyURLGroup.getKey();
+		Group group = friendlyURLGroupObjectValuePair.getValue();
 
 		Assert.assertEquals(_group.getGroupId(), group.getGroupId());
 
 		Assert.assertEquals(
-			_group.getFriendlyURL(), friendlyURLGroup.getValue());
+			_group.getFriendlyURL(), friendlyURLGroupObjectValuePair.getKey());
 	}
 
 	@Test
@@ -119,16 +120,16 @@ public class PortalImplTest {
 
 		_group = GroupTestUtil.addGroup();
 
-		ObjectValuePair<Group, String> friendlyURLGroup =
+		ObjectValuePair<String, Group> friendlyURLGroupObjectValuePair =
 			_portal.fetchFriendlyURLGroup(
 				TestPropsValues.getCompanyId(), _group.getFriendlyURL());
 
-		Group group = friendlyURLGroup.getKey();
+		Group group = friendlyURLGroupObjectValuePair.getValue();
 
 		Assert.assertEquals(_group.getGroupId(), group.getGroupId());
 
 		Assert.assertEquals(
-			_group.getFriendlyURL(), friendlyURLGroup.getValue());
+			_group.getFriendlyURL(), friendlyURLGroupObjectValuePair.getKey());
 	}
 
 	@Test
@@ -138,19 +139,21 @@ public class PortalImplTest {
 		_group = GroupTestUtil.addGroup();
 		_otherGroup = GroupTestUtil.addGroup();
 
-		ObjectValuePair<Group, String> friendlyURLGroup =
+		ObjectValuePair<String, Group> friendlyURLGroupObjectValuePair =
 			_portal.fetchFriendlyURLGroup(
 				TestPropsValues.getCompanyId(),
 				StringBundler.concat(
 					_group.getFriendlyURL(), "/documents/d",
-					_otherGroup.getFriendlyURL(), "/abc"));
+					_otherGroup.getFriendlyURL(), StringPool.SLASH,
+					RandomTestUtil.randomString()));
 
-		Group group = friendlyURLGroup.getKey();
+		Group group = friendlyURLGroupObjectValuePair.getValue();
 
 		Assert.assertEquals(_otherGroup.getGroupId(), group.getGroupId());
 
 		Assert.assertEquals(
-			_otherGroup.getFriendlyURL(), friendlyURLGroup.getValue());
+			_otherGroup.getFriendlyURL(),
+			friendlyURLGroupObjectValuePair.getKey());
 	}
 
 	@Test

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplTest.java
@@ -8,6 +8,7 @@ package com.liferay.portal.util.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Company;
@@ -15,6 +16,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
@@ -27,6 +29,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadServletRequest;
 import com.liferay.portal.kernel.util.File;
@@ -63,6 +66,83 @@ public class PortalImplTest {
 	@Rule
 	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
 		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testFetchFriendlyURLGroupFallsBackToUserScreenName()
+		throws Exception {
+
+		_user = UserTestUtil.addUser();
+
+		Group userGroup = _user.getGroup();
+
+		_groupLocalService.updateFriendlyURL(
+			userGroup.getGroupId(),
+			StringPool.SLASH + RandomTestUtil.randomString());
+
+		Group group = _portal.fetchFriendlyURLGroup(
+			TestPropsValues.getCompanyId(),
+			StringPool.SLASH + _user.getScreenName());
+
+		Assert.assertEquals(userGroup.getGroupId(), group.getGroupId());
+	}
+
+	@Test
+	public void testFetchFriendlyURLGroupResolvesGroupWithLayoutSuffix()
+		throws Exception {
+
+		_group = GroupTestUtil.addGroup();
+
+		Group group = _portal.fetchFriendlyURLGroup(
+			TestPropsValues.getCompanyId(),
+			_group.getFriendlyURL() + "/some-layout");
+
+		Assert.assertEquals(_group.getGroupId(), group.getGroupId());
+	}
+
+	@Test
+	public void testFetchFriendlyURLGroupResolvesGroupWithoutSuffix()
+		throws Exception {
+
+		_group = GroupTestUtil.addGroup();
+
+		Group group = _portal.fetchFriendlyURLGroup(
+			TestPropsValues.getCompanyId(), _group.getFriendlyURL());
+
+		Assert.assertEquals(_group.getGroupId(), group.getGroupId());
+	}
+
+	@Test
+	public void testFetchFriendlyURLGroupResolvesInnerGroupForDocumentPathPrefix()
+		throws Exception {
+
+		_group = GroupTestUtil.addGroup();
+		_otherGroup = GroupTestUtil.addGroup();
+
+		Group group = _portal.fetchFriendlyURLGroup(
+			TestPropsValues.getCompanyId(),
+			StringBundler.concat(
+				_group.getFriendlyURL(), "/documents/d",
+				_otherGroup.getFriendlyURL(), "/abc"));
+
+		Assert.assertEquals(_otherGroup.getGroupId(), group.getGroupId());
+	}
+
+	@Test
+	public void testFetchFriendlyURLGroupReturnsNullForRoot() throws Exception {
+		Assert.assertNull(
+			_portal.fetchFriendlyURLGroup(
+				TestPropsValues.getCompanyId(), StringPool.SLASH));
+	}
+
+	@Test
+	public void testFetchFriendlyURLGroupReturnsNullWhenGroupAndUserAreMissing()
+		throws Exception {
+
+		Assert.assertNull(
+			_portal.fetchFriendlyURLGroup(
+				TestPropsValues.getCompanyId(),
+				StringPool.SLASH + RandomTestUtil.randomString()));
+	}
 
 	@Test
 	public void testGetLayoutFriendlyURLWithPublicServletMappingDisabled()
@@ -317,8 +397,14 @@ public class PortalImplTest {
 	@Inject
 	private LayoutLocalService _layoutLocalService;
 
+	@DeleteAfterTestRun
+	private Group _otherGroup;
+
 	@Inject
 	private Portal _portal;
+
+	@DeleteAfterTestRun
+	private User _user;
 
 	@Inject
 	private VirtualHostLocalService _virtualHostLocalService;

--- a/portal-impl/src/com/liferay/portal/servlet/filters/virtualhost/VirtualHostFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/virtualhost/VirtualHostFilter.java
@@ -15,7 +15,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.struts.LastPath;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
@@ -261,7 +260,7 @@ public class VirtualHostFilter extends BasePortalFilter {
 		}
 
 		if (layoutSet == null) {
-			Group group = _fetchGroupByFriendlyURLPrefix(
+			Group group = PortalUtil.fetchFriendlyURLGroup(
 				CompanyThreadLocal.getCompanyId(), friendlyURL);
 
 			if (!PropsValues.
@@ -280,6 +279,8 @@ public class VirtualHostFilter extends BasePortalFilter {
 				if (_log.isDebugEnabled()) {
 					_log.debug("Forward to " + sb.toString());
 				}
+
+				httpServletRequest.setAttribute(WebKeys.GROUP, group);
 
 				RequestDispatcher requestDispatcher =
 					_servletContext.getRequestDispatcher(sb.toString());
@@ -346,8 +347,12 @@ public class VirtualHostFilter extends BasePortalFilter {
 					StringPool.BLANK);
 			}
 
-			Group group = _fetchGroupByFriendlyURLPrefix(
+			Group group = PortalUtil.fetchFriendlyURLGroup(
 				companyId, friendlyURL);
+
+			if (group != null) {
+				httpServletRequest.setAttribute(WebKeys.GROUP, group);
+			}
 
 			if (!PropsValues.
 					LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED &&
@@ -445,28 +450,6 @@ public class VirtualHostFilter extends BasePortalFilter {
 				VirtualHostFilter.class.getName(), httpServletRequest,
 				httpServletResponse, filterChain);
 		}
-	}
-
-	private Group _fetchGroupByFriendlyURLPrefix(
-		long companyId, String friendlyURL) {
-
-		if (friendlyURL.equals(StringPool.SLASH)) {
-			return null;
-		}
-
-		int index = friendlyURL.indexOf(CharPool.SLASH, 1);
-
-		String groupFriendlyURL;
-
-		if (index != -1) {
-			groupFriendlyURL = friendlyURL.substring(0, index);
-		}
-		else {
-			groupFriendlyURL = friendlyURL;
-		}
-
-		return GroupLocalServiceUtil.fetchFriendlyURLGroup(
-			companyId, groupFriendlyURL);
 	}
 
 	private String _findLanguageId(String friendlyURL) {

--- a/portal-impl/src/com/liferay/portal/servlet/filters/virtualhost/VirtualHostFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/virtualhost/VirtualHostFilter.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.struts.LastPath;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
+import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
@@ -260,12 +261,13 @@ public class VirtualHostFilter extends BasePortalFilter {
 		}
 
 		if (layoutSet == null) {
-			Group group = PortalUtil.fetchFriendlyURLGroup(
-				CompanyThreadLocal.getCompanyId(), friendlyURL);
+			ObjectValuePair<Group, String> friendlyURLGroup =
+				PortalUtil.fetchFriendlyURLGroup(
+					CompanyThreadLocal.getCompanyId(), friendlyURL);
 
 			if (!PropsValues.
 					LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED &&
-				(group != null)) {
+				(friendlyURLGroup != null)) {
 
 				StringBundler sb = new StringBundler(3);
 
@@ -280,7 +282,8 @@ public class VirtualHostFilter extends BasePortalFilter {
 					_log.debug("Forward to " + sb.toString());
 				}
 
-				httpServletRequest.setAttribute(WebKeys.GROUP, group);
+				httpServletRequest.setAttribute(
+					WebKeys.FRIENDLY_URL_GROUP, friendlyURLGroup);
 
 				RequestDispatcher requestDispatcher =
 					_servletContext.getRequestDispatcher(sb.toString());
@@ -347,16 +350,17 @@ public class VirtualHostFilter extends BasePortalFilter {
 					StringPool.BLANK);
 			}
 
-			Group group = PortalUtil.fetchFriendlyURLGroup(
-				companyId, friendlyURL);
+			ObjectValuePair<Group, String> friendlyURLGroup =
+				PortalUtil.fetchFriendlyURLGroup(companyId, friendlyURL);
 
-			if (group != null) {
-				httpServletRequest.setAttribute(WebKeys.GROUP, group);
+			if (friendlyURLGroup != null) {
+				httpServletRequest.setAttribute(
+					WebKeys.FRIENDLY_URL_GROUP, friendlyURLGroup);
 			}
 
 			if (!PropsValues.
 					LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED &&
-				!layoutSet.isPrivateLayout() && (group != null)) {
+				!layoutSet.isPrivateLayout() && (friendlyURLGroup != null)) {
 
 				sb.append(_PUBLIC_GROUP_SERVLET_MAPPING);
 			}

--- a/portal-impl/src/com/liferay/portal/servlet/filters/virtualhost/VirtualHostFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/virtualhost/VirtualHostFilter.java
@@ -261,13 +261,13 @@ public class VirtualHostFilter extends BasePortalFilter {
 		}
 
 		if (layoutSet == null) {
-			ObjectValuePair<Group, String> friendlyURLGroup =
+			ObjectValuePair<String, Group> friendlyURLGroupObjectValuePair =
 				PortalUtil.fetchFriendlyURLGroup(
 					CompanyThreadLocal.getCompanyId(), friendlyURL);
 
 			if (!PropsValues.
 					LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED &&
-				(friendlyURLGroup != null)) {
+				(friendlyURLGroupObjectValuePair != null)) {
 
 				StringBundler sb = new StringBundler(3);
 
@@ -283,7 +283,8 @@ public class VirtualHostFilter extends BasePortalFilter {
 				}
 
 				httpServletRequest.setAttribute(
-					WebKeys.FRIENDLY_URL_GROUP, friendlyURLGroup);
+					WebKeys.FRIENDLY_URL_GROUP,
+					friendlyURLGroupObjectValuePair);
 
 				RequestDispatcher requestDispatcher =
 					_servletContext.getRequestDispatcher(sb.toString());
@@ -350,17 +351,19 @@ public class VirtualHostFilter extends BasePortalFilter {
 					StringPool.BLANK);
 			}
 
-			ObjectValuePair<Group, String> friendlyURLGroup =
+			ObjectValuePair<String, Group> friendlyURLGroupObjectValuePair =
 				PortalUtil.fetchFriendlyURLGroup(companyId, friendlyURL);
 
-			if (friendlyURLGroup != null) {
+			if (friendlyURLGroupObjectValuePair != null) {
 				httpServletRequest.setAttribute(
-					WebKeys.FRIENDLY_URL_GROUP, friendlyURLGroup);
+					WebKeys.FRIENDLY_URL_GROUP,
+					friendlyURLGroupObjectValuePair);
 			}
 
 			if (!PropsValues.
 					LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED &&
-				!layoutSet.isPrivateLayout() && (friendlyURLGroup != null)) {
+				!layoutSet.isPrivateLayout() &&
+				(friendlyURLGroupObjectValuePair != null)) {
 
 				sb.append(_PUBLIC_GROUP_SERVLET_MAPPING);
 			}

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1028,7 +1028,7 @@ public class PortalImpl implements Portal {
 	}
 
 	@Override
-	public ObjectValuePair<Group, String> fetchFriendlyURLGroup(
+	public ObjectValuePair<String, Group> fetchFriendlyURLGroup(
 		long companyId, String path) {
 
 		if ((path == null) || path.equals(StringPool.SLASH)) {
@@ -1066,14 +1066,14 @@ public class PortalImpl implements Portal {
 			companyId, groupFriendlyURL);
 
 		if (group != null) {
-			return new ObjectValuePair<>(group, groupFriendlyURL);
+			return new ObjectValuePair<>(groupFriendlyURL, group);
 		}
 
 		User user = UserLocalServiceUtil.fetchUserByScreenName(
 			companyId, groupFriendlyURL.substring(1));
 
 		if (user != null) {
-			return new ObjectValuePair<>(user.getGroup(), groupFriendlyURL);
+			return new ObjectValuePair<>(groupFriendlyURL, user.getGroup());
 		}
 
 		return null;

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -174,6 +174,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.MethodHandler;
 import com.liferay.portal.kernel.util.MethodKey;
+import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalInetSocketAddressEventListener;
@@ -1027,7 +1028,9 @@ public class PortalImpl implements Portal {
 	}
 
 	@Override
-	public Group fetchFriendlyURLGroup(long companyId, String path) {
+	public ObjectValuePair<Group, String> fetchFriendlyURLGroup(
+		long companyId, String path) {
+
 		if ((path == null) || path.equals(StringPool.SLASH)) {
 			return null;
 		}
@@ -1063,14 +1066,14 @@ public class PortalImpl implements Portal {
 			companyId, groupFriendlyURL);
 
 		if (group != null) {
-			return group;
+			return new ObjectValuePair<>(group, groupFriendlyURL);
 		}
 
 		User user = UserLocalServiceUtil.fetchUserByScreenName(
 			companyId, groupFriendlyURL.substring(1));
 
 		if (user != null) {
-			return user.getGroup();
+			return new ObjectValuePair<>(user.getGroup(), groupFriendlyURL);
 		}
 
 		return null;

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -211,6 +211,7 @@ import com.liferay.portal.webserver.WebServerServlet;
 import com.liferay.portlet.LiferayPortletUtil;
 import com.liferay.portlet.PortletPreferencesWrapper;
 import com.liferay.portlet.admin.util.OmniadminUtil;
+import com.liferay.portlet.documentlibrary.constants.DLFriendlyURLConstants;
 import com.liferay.sites.kernel.util.Sites;
 import com.liferay.social.kernel.model.SocialRelationConstants;
 import com.liferay.util.JS;
@@ -1023,6 +1024,56 @@ public class PortalImpl implements Portal {
 		}
 
 		return className.getValue();
+	}
+
+	@Override
+	public Group fetchFriendlyURLGroup(long companyId, String path) {
+		if ((path == null) || path.equals(StringPool.SLASH)) {
+			return null;
+		}
+
+		String groupFriendlyURL = path;
+
+		int index = path.indexOf(CharPool.SLASH, 1);
+
+		if (index != -1) {
+			String pathSuffix = path.substring(index);
+
+			if (pathSuffix.startsWith(
+					DLFriendlyURLConstants.PATH_PREFIX_DOCUMENT)) {
+
+				String documentFriendlyURL = pathSuffix.substring(
+					DLFriendlyURLConstants.PATH_PREFIX_DOCUMENT.length() - 1);
+
+				index = documentFriendlyURL.indexOf(CharPool.SLASH, 1);
+
+				if (index == -1) {
+					groupFriendlyURL = documentFriendlyURL;
+				}
+				else {
+					groupFriendlyURL = documentFriendlyURL.substring(0, index);
+				}
+			}
+			else {
+				groupFriendlyURL = path.substring(0, index);
+			}
+		}
+
+		Group group = GroupLocalServiceUtil.fetchFriendlyURLGroup(
+			companyId, groupFriendlyURL);
+
+		if (group != null) {
+			return group;
+		}
+
+		User user = UserLocalServiceUtil.fetchUserByScreenName(
+			companyId, groupFriendlyURL.substring(1));
+
+		if (user != null) {
+			return user.getGroup();
+		}
+
+		return null;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 78.0.0
+version 78.1.0

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 79.0.0
+version 79.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
@@ -245,11 +245,11 @@ public interface Portal {
 	 *
 	 * @param  companyId the primary key of the company
 	 * @param  path the request path beginning with a slash
-	 * @return a pair of the matching group (key) and the path-typed group
-	 *         friendly URL prefix (value), or <code>null</code> if the path is
-	 *         just a slash or no group nor user matches
+	 * @return a pair of the path-typed group friendly URL prefix (key) and the
+	 *         matching group (value), or <code>null</code> if the path is just
+	 *         a slash or no group nor user matches
 	 */
-	public ObjectValuePair<Group, String> fetchFriendlyURLGroup(
+	public ObjectValuePair<String, Group> fetchFriendlyURLGroup(
 		long companyId, String path);
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
@@ -231,6 +231,25 @@ public interface Portal {
 	public String fetchClassName(long classNameId);
 
 	/**
+	 * Resolves the friendly URL group implied by the given path.
+	 *
+	 * <p>
+	 * Splits the path on the first slash and uses the first segment as the
+	 * candidate group friendly URL. If the remainder begins with the document
+	 * library path prefix (<code>/documents/d/</code>), the segment immediately
+	 * after that prefix is used instead. When no matching group is found, the
+	 * candidate is treated as a user screen name and the user's personal site
+	 * group is returned.
+	 * </p>
+	 *
+	 * @param  companyId the primary key of the company
+	 * @param  path the request path beginning with a slash
+	 * @return the matching group, or <code>null</code> if the path is just a
+	 *         slash or no group nor user matches
+	 */
+	public Group fetchFriendlyURLGroup(long companyId, String path);
+
+	/**
 	 * Generates a random key to identify the request based on the input string.
 	 *
 	 * @param  httpServletRequest the servlet request for the page

--- a/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
@@ -231,7 +231,8 @@ public interface Portal {
 	public String fetchClassName(long classNameId);
 
 	/**
-	 * Resolves the friendly URL group implied by the given path.
+	 * Resolves the friendly URL group implied by the given path together with
+	 * the path-typed group friendly URL prefix that drove the resolution.
 	 *
 	 * <p>
 	 * Splits the path on the first slash and uses the first segment as the
@@ -244,10 +245,12 @@ public interface Portal {
 	 *
 	 * @param  companyId the primary key of the company
 	 * @param  path the request path beginning with a slash
-	 * @return the matching group, or <code>null</code> if the path is just a
-	 *         slash or no group nor user matches
+	 * @return a pair of the matching group (key) and the path-typed group
+	 *         friendly URL prefix (value), or <code>null</code> if the path is
+	 *         just a slash or no group nor user matches
 	 */
-	public Group fetchFriendlyURLGroup(long companyId, String path);
+	public ObjectValuePair<Group, String> fetchFriendlyURLGroup(
+		long companyId, String path);
 
 	/**
 	 * Generates a random key to identify the request based on the input string.

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
@@ -274,11 +274,11 @@ public class PortalUtil {
 	 *
 	 * @param  companyId the primary key of the company
 	 * @param  path the request path beginning with a slash
-	 * @return a pair of the matching group (key) and the path-typed group
-	 *         friendly URL prefix (value), or <code>null</code> if the path is
-	 *         just a slash or no group nor user matches
+	 * @return a pair of the path-typed group friendly URL prefix (key) and the
+	 *         matching group (value), or <code>null</code> if the path is just
+	 *         a slash or no group nor user matches
 	 */
-	public static ObjectValuePair<Group, String> fetchFriendlyURLGroup(
+	public static ObjectValuePair<String, Group> fetchFriendlyURLGroup(
 		long companyId, String path) {
 
 		return _portal.fetchFriendlyURLGroup(companyId, path);

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
@@ -260,7 +260,8 @@ public class PortalUtil {
 	}
 
 	/**
-	 * Resolves the friendly URL group implied by the given path.
+	 * Resolves the friendly URL group implied by the given path together with
+	 * the path-typed group friendly URL prefix that drove the resolution.
 	 *
 	 * <p>
 	 * Splits the path on the first slash and uses the first segment as the
@@ -273,10 +274,13 @@ public class PortalUtil {
 	 *
 	 * @param  companyId the primary key of the company
 	 * @param  path the request path beginning with a slash
-	 * @return the matching group, or <code>null</code> if the path is just a
-	 *         slash or no group nor user matches
+	 * @return a pair of the matching group (key) and the path-typed group
+	 *         friendly URL prefix (value), or <code>null</code> if the path is
+	 *         just a slash or no group nor user matches
 	 */
-	public static Group fetchFriendlyURLGroup(long companyId, String path) {
+	public static ObjectValuePair<Group, String> fetchFriendlyURLGroup(
+		long companyId, String path) {
+
 		return _portal.fetchFriendlyURLGroup(companyId, path);
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
@@ -260,6 +260,27 @@ public class PortalUtil {
 	}
 
 	/**
+	 * Resolves the friendly URL group implied by the given path.
+	 *
+	 * <p>
+	 * Splits the path on the first slash and uses the first segment as the
+	 * candidate group friendly URL. If the remainder begins with the document
+	 * library path prefix (<code>/documents/d/</code>), the segment immediately
+	 * after that prefix is used instead. When no matching group is found, the
+	 * candidate is treated as a user screen name and the user's personal site
+	 * group is returned.
+	 * </p>
+	 *
+	 * @param  companyId the primary key of the company
+	 * @param  path the request path beginning with a slash
+	 * @return the matching group, or <code>null</code> if the path is just a
+	 *         slash or no group nor user matches
+	 */
+	public static Group fetchFriendlyURLGroup(long companyId, String path) {
+		return _portal.fetchFriendlyURLGroup(companyId, path);
+	}
+
+	/**
 	 * Generates a random key to identify the request based on the input string.
 	 *
 	 * @param  httpServletRequest the servlet request for the page

--- a/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java
@@ -188,6 +188,8 @@ public interface WebKeys {
 
 	public static final String FORWARD_URL = "FORWARD_URL";
 
+	public static final String FRIENDLY_URL_GROUP = "FRIENDLY_URL_GROUP";
+
 	public static final String FTL_VARIABLES = "FTL_VARIABLES";
 
 	public static final String GOOGLE_GADGET = "GOOGLE_GADGET";

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 98.0.0
+version 98.1.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-82451

## What is being fixed

The (companyId, path) → Group lookup was duplicated across `VirtualHostFilter` and `FriendlyURLServlet`, each carrying its own inline branch for the document-library `/documents/d/` path prefix and its own user-screen-name fallback. Every site URL forwarded by the filter then refetched the same group from `FriendlyURLServlet.getRedirect`, and the path-typed group friendly URL prefix used downstream had to be recomputed in both places.

## How it is being fixed

A single resolver, `Portal.fetchFriendlyURLGroup(long companyId, String path)`, now centralizes the group-by-friendly-URL lookup, the document library prefix branch, and the user-screen-name fallback. It returns an `ObjectValuePair<String, Group>` so both the matched group and the path-typed prefix that drove the resolution travel together. `VirtualHostFilter` stashes the pair under `WebKeys.FRIENDLY_URL_GROUP` at every forward site, and `FriendlyURLServlet.getRedirect` reads the attribute first, falling back to the resolver only when the request did not pass through the filter. The pair's key is the prefix and the value is the group — matching the constant name — which lets the servlet drop its 18-line path extraction block entirely.