### PR TITLE
LPD-89408 Use STANDARD cookie spec on OIDC HTTP calls

### DIFF
--- a/modules/apps/oauth-client/oauth-client-persistence-service/src/main/java/com/liferay/oauth/client/persistence/service/impl/OAuthClientEntryLocalServiceImpl.java
+++ b/modules/apps/oauth-client/oauth-client-persistence-service/src/main/java/com/liferay/oauth/client/persistence/service/impl/OAuthClientEntryLocalServiceImpl.java
@@ -347,6 +347,7 @@ public class OAuthClientEntryLocalServiceImpl
 
 			Http.Options httpOptions = new Http.Options();
 
+			httpOptions.setCookieSpec(Http.CookieSpec.STANDARD);
 			httpOptions.setLocation(authServerWellKnownURI);
 
 			_http.URLtoString(httpOptions);

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectHttpUtil.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectHttpUtil.java
@@ -51,6 +51,8 @@ public class OpenIdConnectHttpUtil {
 	private static Http.Options _toHttpOptions(HTTPRequest httpRequest) {
 		Http.Options httpOptions = new Http.Options();
 
+		httpOptions.setCookieSpec(Http.CookieSpec.STANDARD);
+
 		Map<String, List<String>> headerMap = httpRequest.getHeaderMap();
 
 		if (headerMap != null) {

--- a/modules/apps/portal/portal-http-impl/src/test/java/com/liferay/portal/http/internal/HttpImplTest.java
+++ b/modules/apps/portal/portal-http-impl/src/test/java/com/liferay/portal/http/internal/HttpImplTest.java
@@ -10,14 +10,27 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Tuple;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.util.PortalImpl;
 
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.OutputStream;
+
+import java.net.InetSocketAddress;
 import java.net.URI;
 
+import java.nio.charset.StandardCharsets;
+
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.http.ConnectionReuseStrategy;
@@ -218,6 +231,77 @@ public class HttpImplTest {
 			Collections.singletonMap("tcpKeepAliveEnabled", true));
 
 		_testTCPKeepAlive(true);
+	}
+
+	@Test
+	public void testURLtoStringWithCookieSpec() throws Exception {
+		HttpServer httpServer = HttpServer.create(
+			new InetSocketAddress("127.0.0.1", 0), 0);
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"org.apache.http.client.protocol.ResponseProcessCookies",
+				LoggerTestUtil.WARN)) {
+
+			String cookie =
+				RandomTestUtil.randomString() +
+					"=1; expires=Fri, 15 May 2027 18:46:54 GMT; path=/; " +
+						"secure; SameSite=None; HttpOnly";
+
+			httpServer.createContext(
+				"/",
+				httpExchange -> {
+					Headers responseHeaders = httpExchange.getResponseHeaders();
+
+					responseHeaders.add("Content-Type", "application/json");
+					responseHeaders.add("Set-Cookie", cookie);
+
+					String responseBody = "{}";
+
+					byte[] bodyBytes = responseBody.getBytes(
+						StandardCharsets.UTF_8);
+
+					httpExchange.sendResponseHeaders(200, bodyBytes.length);
+
+					try (OutputStream outputStream =
+							httpExchange.getResponseBody()) {
+
+						outputStream.write(bodyBytes);
+					}
+				});
+
+			httpServer.start();
+
+			InetSocketAddress address = httpServer.getAddress();
+
+			int port = address.getPort();
+
+			Http.Options options = new Http.Options();
+
+			options.setLocation("http://127.0.0.1:" + port + "/");
+
+			_httpImpl.URLtoString(options);
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			String message = logEntry.getMessage();
+
+			Assert.assertTrue(message.contains("Invalid 'expires' attribute"));
+
+			options.setCookieSpec(Http.CookieSpec.STANDARD);
+
+			_httpImpl.URLtoString(options);
+
+			logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+		}
+		finally {
+			httpServer.stop(0);
+		}
 	}
 
 	private Tuple _getTuple() {


### PR DESCRIPTION
Forwarded from https://github.com/liferay-appsec/liferay-portal/pull/2851 for core-infra review.

The fix itself is in appsec-owned OIDC code, but the regression test `HttpImplTest.testURLtoStringWithCookieSpec` lives in `portal-impl`, which is owned by core infra — that is the reason this PR needs your review.

---

https://liferay.atlassian.net/browse/LPD-89408

## What is being fixed

During portal startup, Apache HttpClient emits "Invalid cookie header" WARN entries when an Identity Provider returns a `Set-Cookie` header containing an RFC 1123 `Expires` attribute (the standard "Expires=Fri, 15 May 2026 18:46:54 GMT" form). The default Apache HttpClient cookie policy is strict about cookie date formats and rejects RFC 1123 as malformed, even though the rest of the world treats it as valid. The OIDC code paths in `OAuthClientEntryLocalServiceImpl` (discovery endpoint fetch) and `OpenIdConnectHttpUtil` (token and userinfo calls) inherit that strict default and surface the warning.

## How it is being fixed

Both OIDC HTTP code paths opt into `Http.CookieSpec.STANDARD`, which parses RFC 1123 `Expires` attributes silently. The fix is a one-line `setCookieSpec` call at the two call sites.

Coverage is consolidated into a single unit test at the Http layer: `HttpImplTest.testURLtoStringWithCookieSpec` drives `HttpImpl.URLtoString` against an embedded `com.sun.net.httpserver.HttpServer` returning a tracer cookie with an RFC 1123 `Expires`. It exercises the mechanism in two phases against the same `LogCapture` on `org.apache.http.client.protocol.ResponseProcessCookies`:

- **Baseline (broken state):** with no cookie spec set, `HttpImpl` falls back to `CookieSpecs.DEFAULT`. `logCapture` captures exactly 1 entry whose message contains `Invalid 'expires' attribute` — the specific warning the fix targets.
- **Fix:** `setCookieSpec(Http.CookieSpec.STANDARD)` on the same options, then re-issue the request. The entry count stays at 1, confirming `STANDARD` adds no new warning.

Testing at the Http layer covers the mechanism once for both OIDC callers; each caller's `setCookieSpec(STANDARD)` wiring is verified by diff review.