### PR TITLE
LPD-80796 Fix upgrade step that updates the datatype of companyIds in configs to long

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	compileOnly group: "com.liferay", name: "org.apache.commons.fileupload", version: "1.5.JAKARTA-LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay", name: "org.apache.cxf.core", version: "3.6.9.JAKARTA-LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay", name: "org.apache.cxf.rt.frontend.jaxrs", version: "3.6.9.JAKARTA-LIFERAY-PATCHED-1"
+	compileOnly group: "com.liferay", name: "org.apache.felix.configadmin", version: "1.9.26.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay", name: "org.osgi.service.http.whiteboard", version: "1.1.1.JAKARTA-LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay", name: "org.osgi.service.jaxrs", version: "1.0.0.JAKARTA-LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay", name: "org.springframework.tx", version: "6.2.9.LIFERAY-PATCHED-1"

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/upgrade/registry/VulcanImplUpgradeStepRegistrator.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/upgrade/registry/VulcanImplUpgradeStepRegistrator.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.vulcan.internal.upgrade.registry;
 
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.portal.vulcan.internal.upgrade.v1_0_1.VulcanCompanyConfigurationUpgradeProcess;
 
@@ -23,6 +24,8 @@ public class VulcanImplUpgradeStepRegistrator
 	@Override
 	public void register(Registry registry) {
 		registry.registerInitialization();
+
+		registry.register("0.0.1", "1.0.0", new DummyUpgradeStep());
 
 		registry.register(
 			"1.0.0", "1.0.1",

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/upgrade/registry/VulcanImplUpgradeStepRegistrator.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/upgrade/registry/VulcanImplUpgradeStepRegistrator.java
@@ -5,14 +5,11 @@
 
 package com.liferay.portal.vulcan.internal.upgrade.registry;
 
-import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.portal.vulcan.internal.upgrade.v1_0_1.VulcanCompanyConfigurationUpgradeProcess;
 
-import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Vendel Toreki
@@ -28,15 +25,7 @@ public class VulcanImplUpgradeStepRegistrator
 		registry.register("0.0.1", "1.0.0", new DummyUpgradeStep());
 
 		registry.register(
-			"1.0.0", "1.0.1",
-			new VulcanCompanyConfigurationUpgradeProcess(
-				_companyLocalService, _configurationAdmin));
+			"1.0.0", "1.0.1", new VulcanCompanyConfigurationUpgradeProcess());
 	}
-
-	@Reference
-	private CompanyLocalService _companyLocalService;
-
-	@Reference
-	private ConfigurationAdmin _configurationAdmin;
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/upgrade/v1_0_1/VulcanCompanyConfigurationUpgradeProcess.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/upgrade/v1_0_1/VulcanCompanyConfigurationUpgradeProcess.java
@@ -59,7 +59,7 @@ public class VulcanCompanyConfigurationUpgradeProcess extends UpgradeProcess {
 
 				Object value = dictionary.get("companyId");
 
-				if (value instanceof Long) {
+				if ((value == null) || (value instanceof Long)) {
 					continue;
 				}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/upgrade/v1_0_1/VulcanCompanyConfigurationUpgradeProcess.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/upgrade/v1_0_1/VulcanCompanyConfigurationUpgradeProcess.java
@@ -5,79 +5,83 @@
 
 package com.liferay.portal.vulcan.internal.upgrade.v1_0_1;
 
+import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
+import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
-import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.vulcan.internal.configuration.VulcanCompanyConfiguration;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
 
 import java.util.Dictionary;
 
-import org.osgi.service.cm.Configuration;
-import org.osgi.service.cm.ConfigurationAdmin;
+import org.apache.felix.cm.file.ConfigurationHandler;
 
 /**
  * @author Vendel Toreki
  */
 public class VulcanCompanyConfigurationUpgradeProcess extends UpgradeProcess {
 
-	public VulcanCompanyConfigurationUpgradeProcess(
-		CompanyLocalService companyLocalService,
-		ConfigurationAdmin configurationAdmin) {
-
-		_companyLocalService = companyLocalService;
-		_configurationAdmin = configurationAdmin;
-	}
-
 	@Override
 	protected void doUpgrade() throws Exception {
-		_companyLocalService.forEachCompany(
-			company -> _upgradeVulcanCompanyConfigurations(
-				company.getCompanyId()));
-	}
-
-	private void _upgradeVulcanCompanyConfigurations(long companyId)
-		throws Exception {
-
-		String factoryPid =
-			"com.liferay.portal.vulcan.internal.configuration." +
-				"VulcanCompanyConfiguration";
-
-		Configuration[] configurations = _configurationAdmin.listConfigurations(
-			StringBundler.concat(
-				"(&(",
-				ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
-				"=", companyId, ")(path=*)(service.factoryPid=", factoryPid,
-				"))"));
-
-		if (configurations == null) {
+		if (!hasTable("Configuration_")) {
 			return;
 		}
 
-		for (Configuration configuration : configurations) {
-			Dictionary<String, Object> dictionary =
-				configuration.getProperties();
+		try (Statement statement = connection.createStatement();
+			ResultSet resultSet = statement.executeQuery(
+				StringBundler.concat(
+					"select * from Configuration_ where configurationId LIKE ",
+					"'%", VulcanCompanyConfiguration.class.getName(), "%'"));
+			PreparedStatement preparedStatement =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection,
+					"update Configuration_ set dictionary = ? where " +
+						"configurationId = ?")) {
 
-			if ((dictionary == null) || dictionary.isEmpty()) {
-				continue;
+			while (resultSet.next()) {
+				String dictionaryString = resultSet.getString("dictionary");
+
+				if (Validator.isNull(dictionaryString)) {
+					continue;
+				}
+
+				Dictionary<String, Object> dictionary =
+					ConfigurationHandler.read(
+						new UnsyncByteArrayInputStream(
+							dictionaryString.getBytes(StringPool.UTF8)));
+
+				Object value = dictionary.get("companyId");
+
+				if (value instanceof Long) {
+					continue;
+				}
+
+				dictionary.put("companyId", GetterUtil.getLong(value));
+
+				UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
+					new UnsyncByteArrayOutputStream();
+
+				ConfigurationHandler.write(
+					unsyncByteArrayOutputStream, dictionary);
+
+				preparedStatement.setString(
+					1, unsyncByteArrayOutputStream.toString());
+
+				preparedStatement.setString(
+					2, resultSet.getString("configurationId"));
+
+				preparedStatement.addBatch();
 			}
 
-			Object value = dictionary.get(
-				ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey());
-
-			if ((value == null) || (value instanceof Long)) {
-				continue;
-			}
-
-			dictionary.put(
-				ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
-				GetterUtil.getLong(value));
-
-			configuration.update(dictionary);
+			preparedStatement.executeBatch();
 		}
 	}
-
-	private final CompanyLocalService _companyLocalService;
-	private final ConfigurationAdmin _configurationAdmin;
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/upgrade/v1_0_1/VulcanCompanyConfigurationUpgradeProcess.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/upgrade/v1_0_1/VulcanCompanyConfigurationUpgradeProcess.java
@@ -35,10 +35,12 @@ public class VulcanCompanyConfigurationUpgradeProcess extends UpgradeProcess {
 		}
 
 		try (Statement statement = connection.createStatement();
+
 			ResultSet resultSet = statement.executeQuery(
 				StringBundler.concat(
 					"select * from Configuration_ where configurationId LIKE ",
 					"'%", VulcanCompanyConfiguration.class.getName(), "%'"));
+
 			PreparedStatement preparedStatement =
 				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
 					connection,

--- a/modules/apps/portal-vulcan/portal-vulcan-test/build.gradle
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	testIntegrationImplementation group: "com.liferay", name: "jakarta.ws.rs", version: "3.1.0.LIFERAY-PATCHED-1"
 	testIntegrationImplementation group: "com.liferay", name: "org.apache.cxf.core", version: "3.6.9.JAKARTA-LIFERAY-PATCHED-1"
 	testIntegrationImplementation group: "com.liferay", name: "org.apache.cxf.rt.frontend.jaxrs", version: "3.6.9.JAKARTA-LIFERAY-PATCHED-1"
+	testIntegrationImplementation group: "com.liferay", name: "org.apache.felix.configadmin", version: "1.9.26.LIFERAY-PATCHED-1"
 	testIntegrationImplementation group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
 	testIntegrationImplementation group: "org.skyscreamer", name: "jsonassert", version: "1.2.3"
 	testIntegrationImplementation group: "org.springframework", name: "spring-test", version: "6.2.9"

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/upgrade/v1_0_1/test/VulcanCompanyConfigurationUpgradeProcessTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/upgrade/v1_0_1/test/VulcanCompanyConfigurationUpgradeProcessTest.java
@@ -72,6 +72,7 @@ public class VulcanCompanyConfigurationUpgradeProcessTest {
 			).build());
 
 		try (Connection connection = DataAccess.getConnection();
+
 			PreparedStatement preparedStatement = connection.prepareStatement(
 				"insert into Configuration_ (configurationId, dictionary) " +
 					"values(?, ?)")) {
@@ -98,7 +99,9 @@ public class VulcanCompanyConfigurationUpgradeProcessTest {
 		_runUpgrade();
 
 		try (Connection connection = DataAccess.getConnection();
+
 			Statement statement = connection.createStatement();
+
 			ResultSet resultSet = statement.executeQuery(
 				StringBundler.concat(
 					"select dictionary from Configuration_ where ",

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/upgrade/v1_0_1/test/VulcanCompanyConfigurationUpgradeProcessTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/upgrade/v1_0_1/test/VulcanCompanyConfigurationUpgradeProcessTest.java
@@ -6,10 +6,15 @@
 package com.liferay.portal.vulcan.internal.upgrade.v1_0_1.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
+import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.kernel.cache.CacheRegistryUtil;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -22,17 +27,22 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
 
-import java.util.Arrays;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
 import java.util.Dictionary;
 
+import org.apache.felix.cm.file.ConfigurationHandler;
+
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.osgi.service.cm.Configuration;
-import org.osgi.service.cm.ConfigurationAdmin;
 
 /**
  * @author Vendel Toreki
@@ -47,49 +57,70 @@ public class VulcanCompanyConfigurationUpgradeProcessTest {
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
 
-	@Test
-	public void testUpgradeConfigurationCompanyIds() throws Exception {
-		String factoryPid =
-			"com.liferay.portal.vulcan.internal.configuration." +
-				"VulcanCompanyConfiguration";
+	@Before
+	public void setUp() throws Exception {
+		UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
+			new UnsyncByteArrayOutputStream();
 
-		Configuration configuration =
-			_configurationAdmin.createFactoryConfiguration(
-				factoryPid, StringPool.QUESTION);
-
-		long companyId = TestPropsValues.getCompanyId();
-		String path = RandomTestUtil.randomString();
-
-		configuration.update(
+		ConfigurationHandler.write(
+			unsyncByteArrayOutputStream,
 			HashMapDictionaryBuilder.<String, Object>put(
 				ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
-				String.valueOf(companyId)
+				String.valueOf(TestPropsValues.getCompanyId())
 			).put(
-				"path", path
+				"path", RandomTestUtil.randomString()
 			).build());
 
+		try (Connection connection = DataAccess.getConnection();
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"insert into Configuration_ (configurationId, dictionary) " +
+					"values(?, ?)")) {
+
+			preparedStatement.setString(1, _CONFIGURATION_ID);
+			preparedStatement.setString(
+				2, unsyncByteArrayOutputStream.toString());
+
+			preparedStatement.execute();
+		}
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		DB db = DBManagerUtil.getDB();
+
+		db.runSQL(
+			"delete from Configuration_ where configurationId ='" +
+				_CONFIGURATION_ID + "'");
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
 		_runUpgrade();
 
-		Configuration[] configurations = _configurationAdmin.listConfigurations(
-			StringBundler.concat(
-				"(&(",
-				ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
-				"=", companyId, ")(path=", path, ")(service.factoryPid=",
-				factoryPid, "))"));
+		try (Connection connection = DataAccess.getConnection();
+			Statement statement = connection.createStatement();
+			ResultSet resultSet = statement.executeQuery(
+				StringBundler.concat(
+					"select dictionary from Configuration_ where ",
+					"configurationId = '", _CONFIGURATION_ID, "'"))) {
 
-		Assert.assertEquals(
-			Arrays.toString(configurations), 1, configurations.length);
+			if (resultSet.next()) {
+				String dictionaryString = resultSet.getString("dictionary");
 
-		configuration = configurations[0];
+				Dictionary<String, Object> dictionary =
+					ConfigurationHandler.read(
+						new UnsyncByteArrayInputStream(
+							dictionaryString.getBytes(StringPool.UTF8)));
 
-		Dictionary<String, Object> dictionary = configuration.getProperties();
+				Object value = dictionary.get(
+					ExtendedObjectClassDefinition.Scope.COMPANY.
+						getPropertyKey());
 
-		Object value = dictionary.get(
-			ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey());
+				Assert.assertTrue(value instanceof Long);
 
-		Assert.assertTrue(value instanceof Long);
-
-		Assert.assertEquals(companyId, value);
+				Assert.assertEquals(TestPropsValues.getCompanyId(), value);
+			}
+		}
 	}
 
 	private void _runUpgrade() throws Exception {
@@ -103,12 +134,14 @@ public class VulcanCompanyConfigurationUpgradeProcessTest {
 		CacheRegistryUtil.clear();
 	}
 
-	@Inject
-	private ConfigurationAdmin _configurationAdmin;
+	private static final String _CONFIGURATION_ID =
+		"com.liferay.portal.vulcan.internal.configuration." +
+			"VulcanCompanyConfiguration.scoped~" +
+				RandomTestUtil.randomString();
 
 	@Inject(
 		filter = "(&(component.name=com.liferay.portal.vulcan.internal.upgrade.registry.VulcanImplUpgradeStepRegistrator))"
 	)
-	private UpgradeStepRegistrator _upgradeStepRegistrator;
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -766,6 +766,11 @@ public class PortalUpgradeProcessRegistryImpl
 		upgradeVersionTreeMap.put(
 			new Version(38, 4, 1),
 			new RegionExternalReferenceCodeUpgradeProcess());
+
+		upgradeVersionTreeMap.put(
+			new Version(38, 4, 2),
+			UpgradeModulesFactory.create(
+				new String[] {"com.liferay.portal.vulcan.impl"}, null));
 	}
 
 }


### PR DESCRIPTION
[LPD-80796](https://liferay.atlassian.net/browse/LPD-80796)

The commits of the original fix have been reverted because of unexpected warnings in the test case mentioned in the ticket.
These were handled by [LPD-84627](https://liferay.atlassian.net/browse/LPD-84627) and [LPD-89408](https://liferay.atlassian.net/browse/LPD-89408).

I've run the test case locally (including the currently in-review changes of https://github.com/liferay-core-infra/liferay-portal/pull/9828 ) and I did not get any warnings.

cc:  @victorhcunha, @shuyangzhou 

[LPD-80796]: https://liferay.atlassian.net/browse/LPD-80796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-84627]: https://liferay.atlassian.net/browse/LPD-84627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-89408]: https://liferay.atlassian.net/browse/LPD-89408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ