### PR TITLE
LPD-89993 restrict propsUtil access on template engines context

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/com/liferay/document/library/web/portlet/display/template/dependencies/portlet_display_template_carousel.ftl
+++ b/modules/apps/document-library/document-library-web/src/main/resources/com/liferay/document/library/web/portlet/display/template/dependencies/portlet_display_template_carousel.ftl
@@ -15,10 +15,8 @@
 	</style>
 
 	<div id="<@portlet.namespace />carousel">
-		<#assign imageMimeTypes = propsUtil.getArray("dl.file.entry.preview.image.mime.types") />
-
 		<#list entries as entry>
-			<#if imageMimeTypes?seq_contains(entry.getMimeType())>
+			<#if entry.getMimeType()?starts_with("image/")>
 				<div class="carousel-item image-viewer-base-image">
 					<img alt="${htmlUtil.escapeAttribute(entry.getDescription())}" src="${dlUtil.getPreviewURL(entry, entry.getFileVersion(), themeDisplay, "")}" />
 				</div>

--- a/modules/apps/document-library/document-library-web/src/main/resources/com/liferay/document/library/web/template/dependencies/portlet_display_template_carousel.ftl
+++ b/modules/apps/document-library/document-library-web/src/main/resources/com/liferay/document/library/web/template/dependencies/portlet_display_template_carousel.ftl
@@ -15,10 +15,8 @@
 	</style>
 
 	<div id="<@portlet.namespace />carousel">
-		<#assign imageMimeTypes = propsUtil.getArray("dl.file.entry.preview.image.mime.types") />
-
 		<#list entries as entry>
-			<#if imageMimeTypes?seq_contains(entry.getMimeType())>
+			<#if entry.getMimeType()?starts_with("image/")>
 				<div class="carousel-item image-viewer-base-image">
 					<img src="${dlUtil.getPreviewURL(entry, entry.getFileVersion(), themeDisplay, "")}" />
 				</div>

--- a/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/configuration/FreeMarkerEngineConfiguration.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/configuration/FreeMarkerEngineConfiguration.java
@@ -79,7 +79,7 @@ public interface FreeMarkerEngineConfiguration {
 	public String[] restrictedMethods();
 
 	@Meta.AD(
-		deflt = "httpUtil|httpUtilUnsafe|objectUtil|serviceLocator|staticFieldGetter|staticUtil",
+		deflt = "httpUtil|httpUtilUnsafe|objectUtil|propsUtil|serviceLocator|staticFieldGetter|staticUtil",
 		name = "restricted-variables", required = false
 	)
 	public String[] restrictedVariables();

--- a/modules/apps/portal-template/portal-template-test/src/testIntegration/java/com/liferay/portal/template/test/TemplateContextHelperTest.java
+++ b/modules/apps/portal-template/portal-template-test/src/testIntegration/java/com/liferay/portal/template/test/TemplateContextHelperTest.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 
 import java.net.URL;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -36,6 +37,11 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
 
 import org.springframework.mock.web.MockHttpServletRequest;
 
@@ -201,6 +207,39 @@ public class TemplateContextHelperTest {
 
 		Assert.assertEquals(
 			" nonce=\"TEST_NONCE\"", contextObjects.get("nonceAttribute"));
+	}
+
+	@Test
+	public void testPropsUtilNotAccessibleInRestrictedTemplateContext()
+		throws Exception {
+
+		Bundle bundle = FrameworkUtil.getBundle(
+			TemplateContextHelperTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		Collection<ServiceReference<TemplateContextHelper>> serviceReferences =
+			bundleContext.getServiceReferences(
+				TemplateContextHelper.class, null);
+
+		Assert.assertFalse(serviceReferences.isEmpty());
+
+		for (ServiceReference<TemplateContextHelper> serviceReference :
+				serviceReferences) {
+
+			TemplateContextHelper templateContextHelper =
+				bundleContext.getService(serviceReference);
+
+			try {
+				Map<String, Object> helperUtilities =
+					templateContextHelper.getHelperUtilities(true);
+
+				Assert.assertFalse(helperUtilities.containsKey("propsUtil"));
+			}
+			finally {
+				bundleContext.ungetService(serviceReference);
+			}
+		}
 	}
 
 }

--- a/modules/apps/portal-template/portal-template-velocity/src/main/java/com/liferay/portal/template/velocity/configuration/VelocityEngineConfiguration.java
+++ b/modules/apps/portal-template/portal-template-velocity/src/main/java/com/liferay/portal/template/velocity/configuration/VelocityEngineConfiguration.java
@@ -63,7 +63,7 @@ public interface VelocityEngineConfiguration {
 	public String[] restrictedPackages();
 
 	@Meta.AD(
-		deflt = "httpUtil|httpUtilUnsafe|serviceLocator|staticFieldGetter",
+		deflt = "httpUtil|httpUtilUnsafe|propsUtil|serviceLocator|staticFieldGetter",
 		name = "restricted-variables", required = false
 	)
 	public String[] restrictedVariables();

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/dependencies/adt_media_gallery_carousel.ftl
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/dependencies/adt_media_gallery_carousel.ftl
@@ -15,10 +15,8 @@
 	</style>
 
 	<div id="<@portlet.namespace />carousel">
-		<#assign imageMimeTypes = propsUtil.getArray("dl.file.entry.preview.image.mime.types") />
-
 		<#list entries as entry>
-			<#if imageMimeTypes?seq_contains(entry.getMimeType())>
+			<#if entry.getMimeType()?starts_with("image/")>
 				<div class="carousel-item image-viewer-base-image">
 					<img src="${dlUtil.getPreviewURL(entry, entry.getFileVersion(), themeDisplay, "")}" />
 				</div>


### PR DESCRIPTION
this is for https://liferay.atlassian.net/browse/LPD-89993

`propsUtil` in FreeMarker and Velocity templates allows template authors to read any portal configuration property, including sensitive ones such as database credentials. Web Content and Widget templates run in a restricted context, but `propsUtil` was not in the default restricted-variables list for either engine.
This PR adds `propsUti` to the default restricted-variables in the FreeMarker and Velocity engine configuration files, restricting it by default in Liferay. This is a breaking change as any existing template relying on `propsUtil` will stop working. Administrators can re-enable it via `System Settings > Template Engines`, but should be aware of the security risks involved.
The carousel ADT in document-library-web used `propsUtil.getArray("dl.file.entry.preview.image.mime.types"`) to filter image entries. Since `propsUtil` is now blocked, that template would break without an update. On this PR, i replaced the check with `entry.getMimeType()?starts_with("image/")`.