### PR TITLE
LPD-91456 Fix O(L^2) fields-display rebuild in JournalConverterImpl.getDDMFields

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
@@ -29,7 +29,6 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -91,10 +90,11 @@ public class JournalConverterImpl implements JournalConverter {
 
 			Fields ddmFields = new Fields();
 
-			ddmFields.put(
-				new Field(
-					ddmStructure.getStructureId(), DDM.FIELDS_DISPLAY_NAME,
-					StringPool.BLANK));
+			Field fieldsDisplayField = new Field(
+				ddmStructure.getStructureId(), DDM.FIELDS_DISPLAY_NAME,
+				StringPool.BLANK);
+
+			ddmFields.put(fieldsDisplayField);
 
 			DDMForm ddmForm = ddmStructure.getDDMForm();
 
@@ -105,11 +105,15 @@ public class JournalConverterImpl implements JournalConverter {
 			String defaultLanguageId = rootElement.attributeValue(
 				"default-locale");
 
+			StringBundler sb = new StringBundler();
+
 			for (DDMFormField ddmFormField : ddmForm.getDDMFormFields()) {
 				_addDDMFields(
 					availableLanguageIds, defaultLanguageId, ddmFields,
-					ddmFormField, ddmStructure, rootElement, rootElement);
+					ddmFormField, ddmStructure, rootElement, rootElement, sb);
 			}
+
+			fieldsDisplayField.setValue(sb.toString());
 
 			return ddmFields;
 		}
@@ -156,7 +160,8 @@ public class JournalConverterImpl implements JournalConverter {
 	private void _addDDMFields(
 			String[] availableLanguageIds, String defaultLanguageId,
 			Fields ddmFields, DDMFormField ddmFormField,
-			DDMStructure ddmStructure, Element element, Element rootElement)
+			DDMStructure ddmStructure, Element element, Element rootElement,
+			StringBundler sb)
 		throws PortalException {
 
 		String ddmFormFieldName = ddmFormField.getName();
@@ -186,12 +191,12 @@ public class JournalConverterImpl implements JournalConverter {
 					DDMFormFieldTypeConstants.FIELDSET)) {
 
 				_updateFieldsDisplay(
-					ddmFields, ddmFormFieldName, StringUtil.randomString());
+					ddmFormFieldName, StringUtil.randomString(), sb);
 			}
 
 			_addNestedDDMFields(
 				availableLanguageIds, defaultLanguageId, ddmFields,
-				ddmFormField, ddmStructure, element, rootElement);
+				ddmFormField, ddmStructure, element, rootElement, sb);
 
 			return;
 		}
@@ -233,19 +238,21 @@ public class JournalConverterImpl implements JournalConverter {
 			}
 
 			_updateFieldsDisplay(
-				ddmFields, ddmFormFieldName,
-				dynamicElementElement.attributeValue("instance-id"));
+				ddmFormFieldName,
+				dynamicElementElement.attributeValue("instance-id"), sb);
 
 			_addNestedDDMFields(
 				availableLanguageIds, defaultLanguageId, ddmFields,
-				ddmFormField, ddmStructure, dynamicElementElement, rootElement);
+				ddmFormField, ddmStructure, dynamicElementElement, rootElement,
+				sb);
 		}
 	}
 
 	private void _addNestedDDMFields(
 			String[] availableLanguageIds, String defaultLanguageId,
 			Fields ddmFields, DDMFormField ddmFormField,
-			DDMStructure ddmStructure, Element element, Element rootElement)
+			DDMStructure ddmStructure, Element element, Element rootElement,
+			StringBundler sb)
 		throws PortalException {
 
 		for (DDMFormField nestedDDMFormField :
@@ -253,7 +260,7 @@ public class JournalConverterImpl implements JournalConverter {
 
 			_addDDMFields(
 				availableLanguageIds, defaultLanguageId, ddmFields,
-				nestedDDMFormField, ddmStructure, element, rootElement);
+				nestedDDMFormField, ddmStructure, element, rootElement, sb);
 		}
 	}
 
@@ -755,24 +762,19 @@ public class JournalConverterImpl implements JournalConverter {
 	}
 
 	private void _updateFieldsDisplay(
-		Fields ddmFields, String fieldName, String instanceId) {
+		String fieldName, String instanceId, StringBundler sb) {
 
 		if (Validator.isNull(instanceId)) {
 			instanceId = StringUtil.randomString();
 		}
 
-		String fieldsDisplayValue = StringBundler.concat(
-			fieldName, DDM.INSTANCE_SEPARATOR, instanceId);
+		if (sb.length() > 0) {
+			sb.append(StringPool.COMMA);
+		}
 
-		Field fieldsDisplayField = ddmFields.get(DDM.FIELDS_DISPLAY_NAME);
-
-		String[] fieldsDisplayValues = StringUtil.split(
-			(String)fieldsDisplayField.getValue());
-
-		fieldsDisplayValues = ArrayUtil.append(
-			fieldsDisplayValues, fieldsDisplayValue);
-
-		fieldsDisplayField.setValue(StringUtil.merge(fieldsDisplayValues));
+		sb.append(fieldName);
+		sb.append(DDM.INSTANCE_SEPARATOR);
+		sb.append(instanceId);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/journal/journal-service/src/test/java/com/liferay/journal/internal/util/JournalConverterImplTest.java
+++ b/modules/apps/journal/journal-service/src/test/java/com/liferay/journal/internal/util/JournalConverterImplTest.java
@@ -5,12 +5,21 @@
 
 package com.liferay.journal.internal.util;
 
+import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.model.DDMFormFieldOptions;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalServiceUtil;
 import com.liferay.dynamic.data.mapping.storage.Field;
+import com.liferay.dynamic.data.mapping.storage.Fields;
+import com.liferay.dynamic.data.mapping.util.DDM;
+import com.liferay.journal.util.JournalConverter;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.json.JSONFactoryImpl;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -18,6 +27,8 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.kernel.xml.SAXReaderUtil;
+import com.liferay.portal.kernel.xml.UnsecureSAXReaderUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.xml.SAXReaderImpl;
 
@@ -26,11 +37,17 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 /**
  * @author Jürgen Kappler
@@ -41,6 +58,123 @@ public class JournalConverterImplTest {
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+		Language language = Mockito.mock(Language.class);
+
+		Mockito.when(
+			language.isAvailableLanguageCode(Mockito.anyString())
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			language.isAvailableLocale(Mockito.any(Locale.class))
+		).thenReturn(
+			true
+		);
+
+		LanguageUtil languageUtil = new LanguageUtil();
+
+		languageUtil.setLanguage(language);
+
+		SAXReaderUtil saxReaderUtil = new SAXReaderUtil();
+
+		SAXReaderImpl secureSAXReaderImpl = new SAXReaderImpl();
+
+		secureSAXReaderImpl.setSecure(true);
+
+		saxReaderUtil.setSAXReader(secureSAXReaderImpl);
+
+		UnsecureSAXReaderUtil unsecureSAXReaderUtil =
+			new UnsecureSAXReaderUtil();
+
+		unsecureSAXReaderUtil.setSAXReader(new SAXReaderImpl());
+
+		_mockedStatic = Mockito.mockStatic(DDMStructureLocalServiceUtil.class);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_mockedStatic.close();
+	}
+
+	@Test
+	public void testGetDDMFields() throws Exception {
+		JournalConverter journalConverter = new JournalConverterImpl();
+
+		DDMStructure ddmStructure = Mockito.mock(DDMStructure.class);
+
+		Mockito.when(
+			ddmStructure.getStructureId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Mockito.when(
+			DDMStructureLocalServiceUtil.fetchDDMStructure(Mockito.anyLong())
+		).thenReturn(
+			ddmStructure
+		);
+
+		DDMForm ddmForm = new DDMForm();
+
+		Mockito.when(
+			ddmStructure.getDDMForm()
+		).thenReturn(
+			ddmForm
+		);
+
+		int leafCount = 50;
+
+		StringBundler contentSB = new StringBundler(3 + (leafCount * 7));
+
+		contentSB.append("<?xml version=\"1.0\"?><root available-locales=");
+		contentSB.append("\"en_US\" default-locale=\"en_US\">");
+
+		StringBundler expectedSB = new StringBundler((leafCount * 4) - 1);
+
+		for (int i = 0; i < leafCount; i++) {
+			String name = "text" + i;
+			String instanceId = "instance" + i;
+
+			DDMFormField ddmFormField = _createDDMFormField(
+				"string", true, name, "text");
+
+			ddmForm.addDDMFormField(ddmFormField);
+
+			Mockito.when(
+				ddmStructure.getDDMFormField(name)
+			).thenReturn(
+				ddmFormField
+			);
+
+			contentSB.append("<dynamic-element instance-id=\"");
+			contentSB.append(instanceId);
+			contentSB.append("\" name=\"");
+			contentSB.append(name);
+			contentSB.append("\" type=\"text\"><dynamic-content language-id=");
+			contentSB.append("\"en_US\"><![CDATA[v]]></dynamic-content>");
+			contentSB.append("</dynamic-element>");
+
+			if (i > 0) {
+				expectedSB.append(StringPool.COMMA);
+			}
+
+			expectedSB.append(name);
+			expectedSB.append(DDM.INSTANCE_SEPARATOR);
+			expectedSB.append(instanceId);
+		}
+
+		contentSB.append("</root>");
+
+		Assert.assertEquals(
+			expectedSB.toString(),
+			_getFieldsDisplayValue(
+				journalConverter.getDDMFields(
+					ddmStructure, contentSB.toString())));
+	}
 
 	@Test
 	public void testUpdateContentDynamicElement() {
@@ -97,6 +231,15 @@ public class JournalConverterImplTest {
 		Document document = saxReaderImpl.createDocument();
 
 		return document.addElement("root");
+	}
+
+	private String _getFieldsDisplayValue(Fields ddmFields) {
+		Field fieldsDisplayField = ddmFields.get(DDM.FIELDS_DISPLAY_NAME);
+
+		List<Serializable> values = fieldsDisplayField.getValues(
+			LocaleUtil.getSiteDefault());
+
+		return (String)values.get(0);
 	}
 
 	private void _testUpdateContentDynamicElement(
@@ -290,5 +433,7 @@ public class JournalConverterImplTest {
 			},
 			0, ddmFormField, rootElement, field);
 	}
+
+	private static MockedStatic<DDMStructureLocalServiceUtil> _mockedStatic;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91456

The change roughly improves adding and updating by 1 second, see the ticket comment vs https://liferay.atlassian.net/browse/LPD-91455

## What is being fixed

`JournalConverterImpl#getDDMFields` rebuilds the cumulative fields-display string once per leaf field while parsing an article's XML content. Each call splits the current value, appends a single entry, and merges it back, so for an article with L leaves the parser does L^2 / 2 string splits, array copies, and merges on strings that grow without bound.

## How it is being fixed

Thread a `StringBundler` through `getDDMFields`, `_addDDMFields`, and `_addNestedDDMFields`, append the new entry once per leaf, and materialize the fields-display value only at the end of `getDDMFields`. `_updateFieldsDisplay` becomes amortized O(1) per call and the overall pass drops from O(L^2) to O(L).