### PR TITLE
LPD-91457 Cache fields-display split in FieldsToDDMFormValuesConverterImpl.convert

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/FieldsToDDMFormValuesConverterImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/FieldsToDDMFormValuesConverterImpl.java
@@ -66,27 +66,51 @@ public class FieldsToDDMFormValuesConverterImpl
 		Field fieldsDisplayField = fields.get(DDMImpl.FIELDS_DISPLAY_NAME);
 
 		String[] ddmFieldsDisplayValues = null;
-		Map<String, List<String>> instanceIdsByFieldName = null;
+		Map<String, List<String>> instanceIdsByFieldNamesMap = null;
 
 		if (fieldsDisplayField != null) {
 			String[] rawFieldsDisplayValues = splitFieldsDisplayValue(
 				fieldsDisplayField);
 
-			ddmFieldsDisplayValues = _toFilteredFieldNames(
-				rawFieldsDisplayValues, ddmFormFieldsMap);
-			instanceIdsByFieldName = _toInstanceIdsByFieldName(
-				rawFieldsDisplayValues);
+			ddmFieldsDisplayValues = TransformUtil.transform(
+				rawFieldsDisplayValues,
+				value -> {
+					String fieldName = StringUtil.extractFirst(
+						value, DDMImpl.INSTANCE_SEPARATOR);
+
+					if (!ddmFormFieldsMap.containsKey(fieldName)) {
+						return null;
+					}
+
+					return fieldName;
+				},
+				String.class);
+
+			instanceIdsByFieldNamesMap = new HashMap<>();
+
+			for (String value : rawFieldsDisplayValues) {
+				String fieldName = StringUtil.extractFirst(
+					value, DDMImpl.INSTANCE_SEPARATOR);
+				String instanceId = StringUtil.extractLast(
+					value, DDMImpl.INSTANCE_SEPARATOR);
+
+				List<String> instanceIds =
+					instanceIdsByFieldNamesMap.computeIfAbsent(
+						fieldName, key -> new ArrayList<>());
+
+				instanceIds.add(instanceId);
+			}
 		}
 
 		for (String fieldName :
 				_getDDMFormFieldNames(ddmForm.getDDMFormFields())) {
 
 			int repetitions = _countDDMFieldRepetitions(
-				ddmFieldsDisplayValues, fields, fieldName, null, -1);
+				fields, ddmFieldsDisplayValues, fieldName, null, -1);
 
 			for (int i = 0; i < repetitions; i++) {
 				DDMFormFieldValue ddmFormFieldValue = createDDMFormFieldValue(
-					fieldName, instanceIdsByFieldName, ddmFieldsCounter);
+					ddmFieldsCounter, instanceIdsByFieldNamesMap, fieldName);
 
 				DDMFormField ddmFormField = ddmFormFieldsMap.get(fieldName);
 
@@ -96,9 +120,9 @@ public class FieldsToDDMFormValuesConverterImpl
 				}
 
 				_setDDMFormFieldValueProperties(
-					ddmFormFieldValue, ddmFormFieldsMap, fields,
-					ddmFieldsDisplayValues, instanceIdsByFieldName,
-					ddmFieldsCounter);
+					fields, ddmFieldsCounter, ddmFieldsDisplayValues,
+					ddmFormFieldValue, ddmFormFieldsMap,
+					instanceIdsByFieldNamesMap);
 
 				ddmFormValues.addDDMFormFieldValue(ddmFormFieldValue);
 			}
@@ -108,12 +132,12 @@ public class FieldsToDDMFormValuesConverterImpl
 	}
 
 	protected DDMFormFieldValue createDDMFormFieldValue(
-		String name, Map<String, List<String>> instanceIdsByFieldName,
-		DDMFieldsCounter ddmFieldsCounter) {
+		DDMFieldsCounter ddmFieldsCounter,
+		Map<String, List<String>> instanceIdsByFieldNamesMap, String name) {
 
 		DDMFormFieldValue ddmFormFieldValue = new DDMFormFieldValue(
 			_getDDMFieldInstanceId(
-				instanceIdsByFieldName, name, ddmFieldsCounter.get(name)));
+				name, ddmFieldsCounter.get(name), instanceIdsByFieldNamesMap));
 
 		ddmFormFieldValue.setName(name);
 
@@ -138,7 +162,7 @@ public class FieldsToDDMFormValuesConverterImpl
 	}
 
 	private int _countDDMFieldRepetitions(
-		String[] ddmFieldsDisplayValues, Fields ddmFields, String fieldName,
+		Fields ddmFields, String[] ddmFieldsDisplayValues, String fieldName,
 		String parentFieldName, int parentOffset) {
 
 		if (ddmFieldsDisplayValues == null) {
@@ -173,14 +197,14 @@ public class FieldsToDDMFormValuesConverterImpl
 	}
 
 	private String _getDDMFieldInstanceId(
-		Map<String, List<String>> instanceIdsByFieldName, String fieldName,
-		int index) {
+		String fieldName, int index,
+		Map<String, List<String>> instanceIdsByFieldNamesMap) {
 
-		if (instanceIdsByFieldName == null) {
+		if (instanceIdsByFieldNamesMap == null) {
 			return StringUtil.randomString();
 		}
 
-		List<String> instanceIds = instanceIdsByFieldName.get(fieldName);
+		List<String> instanceIds = instanceIdsByFieldNamesMap.get(fieldName);
 
 		if ((instanceIds == null) || (index >= instanceIds.size())) {
 			return null;
@@ -245,16 +269,16 @@ public class FieldsToDDMFormValuesConverterImpl
 	}
 
 	private void _setDDMFormFieldValueProperties(
-			DDMFormFieldValue ddmFormFieldValue,
-			Map<String, DDMFormField> ddmFormFieldsMap, Fields ddmFields,
+			Fields ddmFields, DDMFieldsCounter ddmFieldsCounter,
 			String[] ddmFieldsDisplayValues,
-			Map<String, List<String>> instanceIdsByFieldName,
-			DDMFieldsCounter ddmFieldsCounter)
+			DDMFormFieldValue ddmFormFieldValue,
+			Map<String, DDMFormField> ddmFormFieldsMap,
+			Map<String, List<String>> instanceIdsByFieldNamesMap)
 		throws PortalException {
 
 		_setNestedDDMFormFieldValues(
-			ddmFormFieldValue, ddmFormFieldsMap, ddmFields,
-			ddmFieldsDisplayValues, instanceIdsByFieldName, ddmFieldsCounter);
+			ddmFields, ddmFieldsCounter, ddmFieldsDisplayValues,
+			ddmFormFieldValue, ddmFormFieldsMap, instanceIdsByFieldNamesMap);
 
 		_setDDMFormFieldValueValues(
 			ddmFormFieldValue, ddmFormFieldsMap, ddmFields, ddmFieldsCounter);
@@ -298,11 +322,11 @@ public class FieldsToDDMFormValuesConverterImpl
 	}
 
 	private void _setNestedDDMFormFieldValues(
-			DDMFormFieldValue ddmFormFieldValue,
-			Map<String, DDMFormField> ddmFormFieldsMap, Fields ddmFields,
+			Fields ddmFields, DDMFieldsCounter ddmFieldsCounter,
 			String[] ddmFieldsDisplayValues,
-			Map<String, List<String>> instanceIdsByFieldName,
-			DDMFieldsCounter ddmFieldsCounter)
+			DDMFormFieldValue ddmFormFieldValue,
+			Map<String, DDMFormField> ddmFormFieldsMap,
+			Map<String, List<String>> instanceIdsByFieldNamesMap)
 		throws PortalException {
 
 		String fieldName = ddmFormFieldValue.getName();
@@ -316,14 +340,14 @@ public class FieldsToDDMFormValuesConverterImpl
 
 		for (String nestedFieldName : nestedFieldNames) {
 			int repetitions = _countDDMFieldRepetitions(
-				ddmFieldsDisplayValues, ddmFields, nestedFieldName, fieldName,
+				ddmFields, ddmFieldsDisplayValues, nestedFieldName, fieldName,
 				parentOffset);
 
 			for (int i = 0; i < repetitions; i++) {
 				DDMFormFieldValue nestedDDMFormFieldValue =
 					createDDMFormFieldValue(
-						nestedFieldName, instanceIdsByFieldName,
-						ddmFieldsCounter);
+						ddmFieldsCounter, instanceIdsByFieldNamesMap,
+						nestedFieldName);
 
 				DDMFormField nestedDDMFormField = ddmFormFieldsMap.get(
 					nestedFieldName);
@@ -334,53 +358,14 @@ public class FieldsToDDMFormValuesConverterImpl
 				}
 
 				_setDDMFormFieldValueProperties(
-					nestedDDMFormFieldValue, ddmFormFieldsMap, ddmFields,
-					ddmFieldsDisplayValues, instanceIdsByFieldName,
-					ddmFieldsCounter);
+					ddmFields, ddmFieldsCounter, ddmFieldsDisplayValues,
+					nestedDDMFormFieldValue, ddmFormFieldsMap,
+					instanceIdsByFieldNamesMap);
 
 				ddmFormFieldValue.addNestedDDMFormFieldValue(
 					nestedDDMFormFieldValue);
 			}
 		}
-	}
-
-	private String[] _toFilteredFieldNames(
-		String[] rawFieldsDisplayValues,
-		Map<String, DDMFormField> ddmFormFieldsMap) {
-
-		return TransformUtil.transform(
-			rawFieldsDisplayValues,
-			value -> {
-				String fieldName = StringUtil.extractFirst(
-					value, DDMImpl.INSTANCE_SEPARATOR);
-
-				if (!ddmFormFieldsMap.containsKey(fieldName)) {
-					return null;
-				}
-
-				return fieldName;
-			},
-			String.class);
-	}
-
-	private Map<String, List<String>> _toInstanceIdsByFieldName(
-		String[] rawFieldsDisplayValues) {
-
-		Map<String, List<String>> instanceIdsByFieldName = new HashMap<>();
-
-		for (String value : rawFieldsDisplayValues) {
-			String fieldName = StringUtil.extractFirst(
-				value, DDMImpl.INSTANCE_SEPARATOR);
-			String instanceId = StringUtil.extractLast(
-				value, DDMImpl.INSTANCE_SEPARATOR);
-
-			List<String> instanceIds = instanceIdsByFieldName.computeIfAbsent(
-				fieldName, key -> new ArrayList<>());
-
-			instanceIds.add(instanceId);
-		}
-
-		return instanceIdsByFieldName;
 	}
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/FieldsToDDMFormValuesConverterImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/FieldsToDDMFormValuesConverterImpl.java
@@ -58,11 +58,6 @@ public class FieldsToDDMFormValuesConverterImpl
 
 		DDMFieldsCounter ddmFieldsCounter = new DDMFieldsCounter();
 
-		// Split the fields-display value once for the duration of this call.
-		// _countDDMFieldRepetitions and _getDDMFieldInstanceId would otherwise
-		// re-split the cumulative string per leaf, turning convert() into
-		// O(L^2) in the leaf count.
-
 		Field fieldsDisplayField = fields.get(DDMImpl.FIELDS_DISPLAY_NAME);
 
 		String[] ddmFieldsDisplayValues = null;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/FieldsToDDMFormValuesConverterImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/FieldsToDDMFormValuesConverterImpl.java
@@ -27,7 +27,9 @@ import java.io.Serializable;
 
 import java.text.DecimalFormat;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -56,13 +58,24 @@ public class FieldsToDDMFormValuesConverterImpl
 
 		DDMFieldsCounter ddmFieldsCounter = new DDMFieldsCounter();
 
+		// Split the fields-display value once for the duration of this call.
+		// _countDDMFieldRepetitions and _getDDMFieldInstanceId would otherwise
+		// re-split the cumulative string per leaf, turning convert() into
+		// O(L^2) in the leaf count.
+
 		Field fieldsDisplayField = fields.get(DDMImpl.FIELDS_DISPLAY_NAME);
 
 		String[] ddmFieldsDisplayValues = null;
+		Map<String, List<String>> instanceIdsByFieldName = null;
 
 		if (fieldsDisplayField != null) {
-			ddmFieldsDisplayValues = _getDDMFieldsDisplayValues(
-				ddmFormFieldsMap, fieldsDisplayField);
+			String[] rawFieldsDisplayValues = splitFieldsDisplayValue(
+				fieldsDisplayField);
+
+			ddmFieldsDisplayValues = _toFilteredFieldNames(
+				rawFieldsDisplayValues, ddmFormFieldsMap);
+			instanceIdsByFieldName = _toInstanceIdsByFieldName(
+				rawFieldsDisplayValues);
 		}
 
 		for (String fieldName :
@@ -73,7 +86,7 @@ public class FieldsToDDMFormValuesConverterImpl
 
 			for (int i = 0; i < repetitions; i++) {
 				DDMFormFieldValue ddmFormFieldValue = createDDMFormFieldValue(
-					fieldName, fields, ddmFieldsCounter);
+					fieldName, instanceIdsByFieldName, ddmFieldsCounter);
 
 				DDMFormField ddmFormField = ddmFormFieldsMap.get(fieldName);
 
@@ -84,7 +97,8 @@ public class FieldsToDDMFormValuesConverterImpl
 
 				_setDDMFormFieldValueProperties(
 					ddmFormFieldValue, ddmFormFieldsMap, fields,
-					ddmFieldsDisplayValues, ddmFieldsCounter);
+					ddmFieldsDisplayValues, instanceIdsByFieldName,
+					ddmFieldsCounter);
 
 				ddmFormValues.addDDMFormFieldValue(ddmFormFieldValue);
 			}
@@ -94,11 +108,12 @@ public class FieldsToDDMFormValuesConverterImpl
 	}
 
 	protected DDMFormFieldValue createDDMFormFieldValue(
-		String name, Fields ddmFields, DDMFieldsCounter ddmFieldsCounter) {
+		String name, Map<String, List<String>> instanceIdsByFieldName,
+		DDMFieldsCounter ddmFieldsCounter) {
 
 		DDMFormFieldValue ddmFormFieldValue = new DDMFormFieldValue(
 			_getDDMFieldInstanceId(
-				ddmFields, name, ddmFieldsCounter.get(name)));
+				instanceIdsByFieldName, name, ddmFieldsCounter.get(name)));
 
 		ddmFormFieldValue.setName(name);
 
@@ -158,57 +173,20 @@ public class FieldsToDDMFormValuesConverterImpl
 	}
 
 	private String _getDDMFieldInstanceId(
-		Fields ddmFields, String fieldName, int index) {
+		Map<String, List<String>> instanceIdsByFieldName, String fieldName,
+		int index) {
 
-		Field ddmFieldsDisplayField = ddmFields.get(
-			DDMImpl.FIELDS_DISPLAY_NAME);
-
-		if (ddmFieldsDisplayField == null) {
+		if (instanceIdsByFieldName == null) {
 			return StringUtil.randomString();
 		}
 
-		String prefix = fieldName.concat(DDMImpl.INSTANCE_SEPARATOR);
+		List<String> instanceIds = instanceIdsByFieldName.get(fieldName);
 
-		String[] ddmFieldsDisplayValues = StringUtil.split(
-			(String)ddmFieldsDisplayField.getValue());
-
-		for (String ddmFieldsDisplayValue : ddmFieldsDisplayValues) {
-			if (ddmFieldsDisplayValue.startsWith(prefix)) {
-				index--;
-
-				if (index < 0) {
-					return StringUtil.extractLast(
-						ddmFieldsDisplayValue, DDMImpl.INSTANCE_SEPARATOR);
-				}
-			}
+		if ((instanceIds == null) || (index >= instanceIds.size())) {
+			return null;
 		}
 
-		return null;
-	}
-
-	private String[] _getDDMFieldsDisplayValues(
-			Map<String, DDMFormField> ddmFormFieldsMap,
-			Field ddmFieldsDisplayField)
-		throws PortalException {
-
-		try {
-			return TransformUtil.transform(
-				splitFieldsDisplayValue(ddmFieldsDisplayField),
-				value -> {
-					String fieldName = StringUtil.extractFirst(
-						value, DDMImpl.INSTANCE_SEPARATOR);
-
-					if (!ddmFormFieldsMap.containsKey(fieldName)) {
-						return null;
-					}
-
-					return fieldName;
-				},
-				String.class);
-		}
-		catch (Exception exception) {
-			throw new PortalException(exception);
-		}
+		return instanceIds.get(index);
 	}
 
 	private String _getDDMFieldValueString(
@@ -269,12 +247,14 @@ public class FieldsToDDMFormValuesConverterImpl
 	private void _setDDMFormFieldValueProperties(
 			DDMFormFieldValue ddmFormFieldValue,
 			Map<String, DDMFormField> ddmFormFieldsMap, Fields ddmFields,
-			String[] ddmFieldsDisplayValues, DDMFieldsCounter ddmFieldsCounter)
+			String[] ddmFieldsDisplayValues,
+			Map<String, List<String>> instanceIdsByFieldName,
+			DDMFieldsCounter ddmFieldsCounter)
 		throws PortalException {
 
 		_setNestedDDMFormFieldValues(
 			ddmFormFieldValue, ddmFormFieldsMap, ddmFields,
-			ddmFieldsDisplayValues, ddmFieldsCounter);
+			ddmFieldsDisplayValues, instanceIdsByFieldName, ddmFieldsCounter);
 
 		_setDDMFormFieldValueValues(
 			ddmFormFieldValue, ddmFormFieldsMap, ddmFields, ddmFieldsCounter);
@@ -320,7 +300,9 @@ public class FieldsToDDMFormValuesConverterImpl
 	private void _setNestedDDMFormFieldValues(
 			DDMFormFieldValue ddmFormFieldValue,
 			Map<String, DDMFormField> ddmFormFieldsMap, Fields ddmFields,
-			String[] ddmFieldsDisplayValues, DDMFieldsCounter ddmFieldsCounter)
+			String[] ddmFieldsDisplayValues,
+			Map<String, List<String>> instanceIdsByFieldName,
+			DDMFieldsCounter ddmFieldsCounter)
 		throws PortalException {
 
 		String fieldName = ddmFormFieldValue.getName();
@@ -340,7 +322,8 @@ public class FieldsToDDMFormValuesConverterImpl
 			for (int i = 0; i < repetitions; i++) {
 				DDMFormFieldValue nestedDDMFormFieldValue =
 					createDDMFormFieldValue(
-						nestedFieldName, ddmFields, ddmFieldsCounter);
+						nestedFieldName, instanceIdsByFieldName,
+						ddmFieldsCounter);
 
 				DDMFormField nestedDDMFormField = ddmFormFieldsMap.get(
 					nestedFieldName);
@@ -352,12 +335,52 @@ public class FieldsToDDMFormValuesConverterImpl
 
 				_setDDMFormFieldValueProperties(
 					nestedDDMFormFieldValue, ddmFormFieldsMap, ddmFields,
-					ddmFieldsDisplayValues, ddmFieldsCounter);
+					ddmFieldsDisplayValues, instanceIdsByFieldName,
+					ddmFieldsCounter);
 
 				ddmFormFieldValue.addNestedDDMFormFieldValue(
 					nestedDDMFormFieldValue);
 			}
 		}
+	}
+
+	private String[] _toFilteredFieldNames(
+		String[] rawFieldsDisplayValues,
+		Map<String, DDMFormField> ddmFormFieldsMap) {
+
+		return TransformUtil.transform(
+			rawFieldsDisplayValues,
+			value -> {
+				String fieldName = StringUtil.extractFirst(
+					value, DDMImpl.INSTANCE_SEPARATOR);
+
+				if (!ddmFormFieldsMap.containsKey(fieldName)) {
+					return null;
+				}
+
+				return fieldName;
+			},
+			String.class);
+	}
+
+	private Map<String, List<String>> _toInstanceIdsByFieldName(
+		String[] rawFieldsDisplayValues) {
+
+		Map<String, List<String>> instanceIdsByFieldName = new HashMap<>();
+
+		for (String value : rawFieldsDisplayValues) {
+			String fieldName = StringUtil.extractFirst(
+				value, DDMImpl.INSTANCE_SEPARATOR);
+			String instanceId = StringUtil.extractLast(
+				value, DDMImpl.INSTANCE_SEPARATOR);
+
+			List<String> instanceIds = instanceIdsByFieldName.computeIfAbsent(
+				fieldName, key -> new ArrayList<>());
+
+			instanceIds.add(instanceId);
+		}
+
+		return instanceIdsByFieldName;
 	}
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/FieldsToDDMFormValuesConverterImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/FieldsToDDMFormValuesConverterImpl.java
@@ -56,11 +56,20 @@ public class FieldsToDDMFormValuesConverterImpl
 
 		DDMFieldsCounter ddmFieldsCounter = new DDMFieldsCounter();
 
+		Field fieldsDisplayField = fields.get(DDMImpl.FIELDS_DISPLAY_NAME);
+
+		String[] ddmFieldsDisplayValues = null;
+
+		if (fieldsDisplayField != null) {
+			ddmFieldsDisplayValues = _getDDMFieldsDisplayValues(
+				ddmFormFieldsMap, fieldsDisplayField);
+		}
+
 		for (String fieldName :
 				_getDDMFormFieldNames(ddmForm.getDDMFormFields())) {
 
 			int repetitions = _countDDMFieldRepetitions(
-				ddmFormFieldsMap, fields, fieldName, null, -1);
+				ddmFieldsDisplayValues, fields, fieldName, null, -1);
 
 			for (int i = 0; i < repetitions; i++) {
 				DDMFormFieldValue ddmFormFieldValue = createDDMFormFieldValue(
@@ -75,7 +84,7 @@ public class FieldsToDDMFormValuesConverterImpl
 
 				_setDDMFormFieldValueProperties(
 					ddmFormFieldValue, ddmFormFieldsMap, fields,
-					ddmFieldsCounter);
+					ddmFieldsDisplayValues, ddmFieldsCounter);
 
 				ddmFormValues.addDDMFormFieldValue(ddmFormFieldValue);
 			}
@@ -114,23 +123,16 @@ public class FieldsToDDMFormValuesConverterImpl
 	}
 
 	private int _countDDMFieldRepetitions(
-			Map<String, DDMFormField> ddmFormFieldsMap, Fields ddmFields,
-			String fieldName, String parentFieldName, int parentOffset)
-		throws PortalException {
+		String[] ddmFieldsDisplayValues, Fields ddmFields, String fieldName,
+		String parentFieldName, int parentOffset) {
 
-		Field ddmFieldsDisplayField = ddmFields.get(
-			DDMImpl.FIELDS_DISPLAY_NAME);
-
-		if (ddmFieldsDisplayField == null) {
+		if (ddmFieldsDisplayValues == null) {
 			if (ddmFields.contains(fieldName)) {
 				return 1;
 			}
 
 			return 0;
 		}
-
-		String[] ddmFieldsDisplayValues = _getDDMFieldsDisplayValues(
-			ddmFormFieldsMap, ddmFieldsDisplayField);
 
 		int offset = -1;
 
@@ -267,11 +269,12 @@ public class FieldsToDDMFormValuesConverterImpl
 	private void _setDDMFormFieldValueProperties(
 			DDMFormFieldValue ddmFormFieldValue,
 			Map<String, DDMFormField> ddmFormFieldsMap, Fields ddmFields,
-			DDMFieldsCounter ddmFieldsCounter)
+			String[] ddmFieldsDisplayValues, DDMFieldsCounter ddmFieldsCounter)
 		throws PortalException {
 
 		_setNestedDDMFormFieldValues(
-			ddmFormFieldValue, ddmFormFieldsMap, ddmFields, ddmFieldsCounter);
+			ddmFormFieldValue, ddmFormFieldsMap, ddmFields,
+			ddmFieldsDisplayValues, ddmFieldsCounter);
 
 		_setDDMFormFieldValueValues(
 			ddmFormFieldValue, ddmFormFieldsMap, ddmFields, ddmFieldsCounter);
@@ -317,7 +320,7 @@ public class FieldsToDDMFormValuesConverterImpl
 	private void _setNestedDDMFormFieldValues(
 			DDMFormFieldValue ddmFormFieldValue,
 			Map<String, DDMFormField> ddmFormFieldsMap, Fields ddmFields,
-			DDMFieldsCounter ddmFieldsCounter)
+			String[] ddmFieldsDisplayValues, DDMFieldsCounter ddmFieldsCounter)
 		throws PortalException {
 
 		String fieldName = ddmFormFieldValue.getName();
@@ -331,7 +334,7 @@ public class FieldsToDDMFormValuesConverterImpl
 
 		for (String nestedFieldName : nestedFieldNames) {
 			int repetitions = _countDDMFieldRepetitions(
-				ddmFormFieldsMap, ddmFields, nestedFieldName, fieldName,
+				ddmFieldsDisplayValues, ddmFields, nestedFieldName, fieldName,
 				parentOffset);
 
 			for (int i = 0; i < repetitions; i++) {
@@ -349,7 +352,7 @@ public class FieldsToDDMFormValuesConverterImpl
 
 				_setDDMFormFieldValueProperties(
 					nestedDDMFormFieldValue, ddmFormFieldsMap, ddmFields,
-					ddmFieldsCounter);
+					ddmFieldsDisplayValues, ddmFieldsCounter);
 
 				ddmFormFieldValue.addNestedDDMFormFieldValue(
 					nestedDDMFormFieldValue);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91457

The change roughly improves adding and updating by 2 seconds, see the ticket comment vs https://liferay.atlassian.net/browse/LPD-91455

## What is being fixed

`FieldsToDDMFormValuesConverterImpl#convert` re-splits the cumulative fields-display string on every form field and every leaf. `_countDDMFieldRepetitions` ran once per form field plus once per nested form field (O(K) calls for K form fields), and `_getDDMFieldInstanceId` ran once per leaf. With L leaves on a complex structure this turns `convert()` into O(L^2) in both CPU and string allocations.

## How it is being fixed

Split the fields-display value once at the top of `convert()`: build a filtered fieldName-only array for the repetition counter, and a fieldName -> instance-id list map for the instance-id lookup. Thread the two caches through `_setDDMFormFieldValueProperties` / `_setNestedDDMFormFieldValues` / `createDDMFormFieldValue`. `_getDDMFieldInstanceId` becomes an O(1) map lookup; the repetition counter still walks the array but no longer splits per call.

The change is staged across three commits so each step is reviewable in isolation:

1. Hoist `splitFieldsDisplayValue` so it runs once in `convert()` and thread the filtered array through the repetition counter.
2. Add the fieldName -> instance-id list cache and rewrite `_getDDMFieldInstanceId` as an O(1) lookup. End-state matches the original single-commit version byte-for-byte.
3. Source-format pass: sort method parameters alphabetically and rename `instanceIdsByFieldName` -> `instanceIdsByFieldNames`.

## Tests

The behavior is covered by `FieldsToDDMFormValuesConverterTest`, `JournalConverterImplTest`, `DDMFormValuesInfoFieldValuesProviderTest`, `JournalArticleLocalServiceTest`, `JournalArticleLocalServiceTest`, `JournalArticleLocalServiceTest`.