### PR TITLE
[LPP] LPD-91219 Remove obsolete Release reference

### DIFF
--- a/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/QuartzSchedulerEngine.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/QuartzSchedulerEngine.java
@@ -14,7 +14,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBus;
-import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.scheduler.JobState;
 import com.liferay.portal.kernel.scheduler.JobStateSerializeUtil;
@@ -782,11 +781,6 @@ public class QuartzSchedulerEngine implements SchedulerEngine {
 	private MessageBus _messageBus;
 
 	private Scheduler _persistedScheduler;
-
-	@Reference(
-		target = "(&(release.bundle.symbolic.name=com.liferay.portal.scheduler.quartz)(release.schema.version>=1.0.2))"
-	)
-	private Release _release;
 
 	@Reference
 	private SchedulerEngineAuditor _schedulerEngineAuditor;


### PR DESCRIPTION
**Ticket:** https://liferay.atlassian.net/browse/LPD-91219

QuartzSchedulerEngine had a Release reference that caused it to deactivate and reactivate during an upgrade, resulting in a NullPointerException in SchedulerEngineHelperImpl.

This PR removes the reference. It is no longer needed after LPS-137525 (94608d5) deferred the scheduler engine startup via `DependencyManagerSyncUtil.registerSyncCallable`, which executes after the upgrade completes.

For additional details, see commit message.
