### PR TITLE
LPD-82794 ES upgrade v3

### DIFF
--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/component/enabler/ComponentEnabler.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/component/enabler/ComponentEnabler.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.elasticsearch8.internal.component.enabler;
+
+import com.liferay.osgi.util.ComponentUtil;
+import com.liferay.portal.search.elasticsearch8.internal.configuration.ElasticsearchConfigurationWrapper;
+
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Joshua Cords
+ */
+@Component(service = {})
+public class ComponentEnabler {
+
+	@Activate
+	protected void activate(ComponentContext componentContext) {
+		ComponentUtil.enableComponents(
+			ElasticsearchConfigurationReady.class, null, componentContext,
+			ElasticsearchConfigurationWrapper.class);
+	}
+
+}

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/component/enabler/ElasticsearchConfigurationReady.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/component/enabler/ElasticsearchConfigurationReady.java
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.elasticsearch8.internal.component.enabler;
+
+/**
+ * @author Joshua Cords
+ */
+public interface ElasticsearchConfigurationReady {
+}

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/configuration/ElasticsearchConfigurationWrapper.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/configuration/ElasticsearchConfigurationWrapper.java
@@ -29,7 +29,7 @@ import org.osgi.service.component.annotations.Modified;
  */
 @Component(
 	configurationPid = "com.liferay.portal.search.elasticsearch8.configuration.ElasticsearchConfiguration",
-	service = ElasticsearchConfigurationWrapper.class
+	enabled = false, service = ElasticsearchConfigurationWrapper.class
 )
 public class ElasticsearchConfigurationWrapper
 	implements Comparator<ElasticsearchConfigurationObserver> {

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/sidecar/activator/SearchElasticsearch8ImplBundleActivator.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/sidecar/activator/SearchElasticsearch8ImplBundleActivator.java
@@ -7,19 +7,33 @@ package com.liferay.portal.search.elasticsearch8.internal.sidecar.activator;
 
 import com.liferay.petra.process.ProcessChannel;
 import com.liferay.petra.process.ProcessExecutor;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.concurrent.SystemExecutorServiceUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Release;
+import com.liferay.portal.kernel.module.util.ServiceLatch;
 import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.search.elasticsearch8.internal.component.enabler.ElasticsearchConfigurationReady;
 import com.liferay.portal.search.elasticsearch8.internal.sidecar.PersistedProcessUtil;
+import com.liferay.portal.tools.DBUpgrader;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.Serializable;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
 
 /**
  * @author Tina Tian
@@ -37,27 +51,141 @@ public class SearchElasticsearch8ImplBundleActivator
 	public void start(BundleContext bundleContext) throws Exception {
 		File sidecarProcessFile = bundleContext.getDataFile("sidecar.process");
 
-		if (!sidecarProcessFile.exists()) {
+		if (sidecarProcessFile.exists()) {
+			ServiceReference<ProcessExecutor> serviceReference =
+				bundleContext.getServiceReference(ProcessExecutor.class);
+
+			ExecutorService executorService =
+				SystemExecutorServiceUtil.getExecutorService();
+
+			_future = executorService.submit(
+				() -> PersistedProcessUtil.start(
+					bundleContext.getService(serviceReference),
+					sidecarProcessFile));
+		}
+
+		if ((!DBUpgrader.isUpgradeClient() &&
+			 !DBUpgrader.isUpgradeDatabaseAutoRunEnabled() &&
+			 !StartupHelperUtil.isUpgrading()) ||
+			!_hasLegacyElasticsearchConfiguration(bundleContext)) {
+
+			_publishElasticsearchConfigurationReady(bundleContext);
+
 			return;
 		}
 
-		ServiceReference<ProcessExecutor> serviceReference =
-			bundleContext.getServiceReference(ProcessExecutor.class);
+		Bundle bundle = bundleContext.getBundle();
 
-		ExecutorService executorService =
-			SystemExecutorServiceUtil.getExecutorService();
+		ServiceLatch serviceLatch = new ServiceLatch(bundleContext);
 
-		_future = executorService.submit(
-			() -> PersistedProcessUtil.start(
-				bundleContext.getService(serviceReference),
-				sidecarProcessFile));
+		serviceLatch.waitFor(
+			StringBundler.concat(
+				"(&(objectClass=", Release.class.getName(),
+				")(release.bundle.symbolic.name=", bundle.getSymbolicName(),
+				")(release.schema.version>=1.0.0))"));
+
+		serviceLatch.openOn(
+			() -> _publishElasticsearchConfigurationReady(bundleContext));
 	}
 
 	@Override
 	public void stop(BundleContext bundleContext) throws Exception {
+		if (_elasticsearchConfigurationReadyServiceRegistration != null) {
+			_elasticsearchConfigurationReadyServiceRegistration.unregister();
+
+			_elasticsearchConfigurationReadyServiceRegistration = null;
+		}
 	}
+
+	private boolean _hasLegacyElasticsearchConfiguration(
+		BundleContext bundleContext) {
+
+		ServiceReference<ConfigurationAdmin> serviceReference =
+			bundleContext.getServiceReference(ConfigurationAdmin.class);
+
+		if (serviceReference == null) {
+			return false;
+		}
+
+		ConfigurationAdmin configurationAdmin = bundleContext.getService(
+			serviceReference);
+
+		try {
+			Configuration[] configurations =
+				configurationAdmin.listConfigurations(
+					"(|(service.pid=*Elasticsearch*Configuration)" +
+						"(service.factoryPid=*Elasticsearch*Configuration))");
+
+			if (configurations == null) {
+				return false;
+			}
+
+			for (Configuration configuration : configurations) {
+				String className = configuration.getFactoryPid();
+
+				if (className == null) {
+					className = configuration.getPid();
+				}
+
+				if (!_isClassLoadable(bundleContext, className)) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+		catch (InvalidSyntaxException | IOException exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to query ConfigurationAdmin for legacy " +
+						"Elasticsearch configurations",
+					exception);
+			}
+
+			return false;
+		}
+		finally {
+			bundleContext.ungetService(serviceReference);
+		}
+	}
+
+	private boolean _isClassLoadable(
+		BundleContext bundleContext, String className) {
+
+		Bundle bundle = bundleContext.getBundle();
+
+		try {
+			bundle.loadClass(className);
+
+			return true;
+		}
+		catch (ClassNotFoundException classNotFoundException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(classNotFoundException);
+			}
+
+			return false;
+		}
+	}
+
+	private void _publishElasticsearchConfigurationReady(
+		BundleContext bundleContext) {
+
+		_elasticsearchConfigurationReadyServiceRegistration =
+			bundleContext.registerService(
+				ElasticsearchConfigurationReady.class,
+				new ElasticsearchConfigurationReady() {
+				},
+				null);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SearchElasticsearch8ImplBundleActivator.class);
 
 	private static volatile Future
 		<ObjectValuePair<ProcessChannel<Serializable>, byte[]>> _future;
+
+	private ServiceRegistration<ElasticsearchConfigurationReady>
+		_elasticsearchConfigurationReadyServiceRegistration;
 
 }

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/upgrade/v1_0_0/ElasticsearchConfigurationUpgradeProcess.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/upgrade/v1_0_0/ElasticsearchConfigurationUpgradeProcess.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.search.elasticsearch8.internal.upgrade.v1_0_0;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.persistence.upgrade.ConfigurationUpgradeStepFactory;
 import com.liferay.portal.file.install.constants.FileInstallConstants;
@@ -162,6 +163,19 @@ public class ElasticsearchConfigurationUpgradeProcess extends UpgradeProcess {
 				ElasticsearchConnectionConfiguration.class.getName());
 
 		upgradeStep.upgrade();
+
+		Configuration[] configurations = _configurationAdmin.listConfigurations(
+			StringBundler.concat(
+				"(service.factoryPid=",
+				ElasticsearchConnectionConfiguration.class.getName(), ")"));
+
+		if (configurations == null) {
+			return;
+		}
+
+		for (Configuration configuration : configurations) {
+			configuration.update(configuration.getProperties());
+		}
 	}
 
 	private static final String _CLASS_NAME_ELASTICSEARCH_CONFIGURATION =

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-test/src/testIntegration/java/com/liferay/portal/search/elasticsearch8/internal/upgrade/v1_0_0/test/ElasticsearchConfigurationUpgradeProcessTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-test/src/testIntegration/java/com/liferay/portal/search/elasticsearch8/internal/upgrade/v1_0_0/test/ElasticsearchConfigurationUpgradeProcessTest.java
@@ -59,7 +59,7 @@ public class ElasticsearchConfigurationUpgradeProcessTest {
 			).put(
 				"embeddedHttpPort", 9202
 			).put(
-				"operationMode", "EMBEDDED"
+				"operationMode", "REMOTE"
 			).put(
 				"restClientLoggerLevel", "ERROR"
 			).put(
@@ -79,7 +79,7 @@ public class ElasticsearchConfigurationUpgradeProcessTest {
 			).put(
 				"embeddedHttpPort", 9202
 			).put(
-				"operationMode", "EMBEDDED"
+				"operationMode", "REMOTE"
 			).put(
 				"restClientLoggerLevel", "ERROR"
 			).put(
@@ -112,7 +112,7 @@ public class ElasticsearchConfigurationUpgradeProcessTest {
 		Assert.assertNull(properties.get("embeddedHttpPort"));
 		Assert.assertNull(properties.get("operationMode"));
 		Assert.assertEquals(
-			Boolean.FALSE,
+			Boolean.TRUE,
 			GetterUtil.getBoolean(properties.get("productionModeEnabled")));
 		Assert.assertNull(properties.get("restClientLoggerLevel"));
 		Assert.assertEquals(


### PR DESCRIPTION
Hello @tinatian,

I figured out that I was gating the wrong path. In [Bryan's original PR](https://github.com/shuyangzhou/liferay-portal/pull/12281) he put the Reference on the ElasticsearchConfigurationWrapper. As the thing we are waiting on to be updated is the configuration, this makes perfect sense to apply the ComponentEnabler to the ElasticsearchConfigurationWrapper. Additionally, SidecarManager already is waiting on the ElasticsearchConfigurationWrapper so by delaying it's enablement we both stop Sidecar from starting when a remote connection will be used and prevent other services from using the Search Engine before it is ready.

This direction keeps the fast path, immediately starting when either we aren't upgrading or if there's no configuration that needs to upgraded, but will use the slow path of delaying the use of Elasticsearch connections if there is a legacy configuration that needs to be updated. (The legacy isn't hardcoded to ES7, so this will work for the ES8 -> configuration change in the future as well.)

I hope this satisfies all of core's concerns, let me know if you see any issues and thank you for your help!

https://liferay.atlassian.net/browse/LPD-82794