### PR TITLE
LPD-90963 Fix malformed Blob assertion in testCreateDraft template

### DIFF
--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryModel.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryModel.java
@@ -12,6 +12,8 @@ import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.version.VersionedModel;
 
+import java.sql.Blob;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -160,6 +162,20 @@ public interface ERCVersionedEntryModel
 	@Override
 	public void setCompanyId(long companyId);
 
+	/**
+	 * Returns the blob of this erc versioned entry.
+	 *
+	 * @return the blob of this erc versioned entry
+	 */
+	public Blob getBlob();
+
+	/**
+	 * Sets the blob of this erc versioned entry.
+	 *
+	 * @param blob the blob of this erc versioned entry
+	 */
+	public void setBlob(Blob blob);
+
 	@Override
 	public ERCVersionedEntry cloneWithOriginalValues();
 
@@ -168,4 +184,4 @@ public interface ERCVersionedEntryModel
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-801384982
+// LIFERAY-SERVICE-BUILDER-HASH:-1688053007

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryTable.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryTable.java
@@ -8,6 +8,7 @@ package com.liferay.portal.tools.service.builder.test.model;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.base.BaseTable;
 
+import java.sql.Blob;
 import java.sql.Types;
 
 /**
@@ -43,10 +44,12 @@ public class ERCVersionedEntryTable extends BaseTable<ERCVersionedEntryTable> {
 		"groupId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
 	public final Column<ERCVersionedEntryTable, Long> companyId = createColumn(
 		"companyId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
+	public final Column<ERCVersionedEntryTable, Blob> blob = createColumn(
+		"blob_", Blob.class, Types.BLOB, Column.FLAG_DEFAULT);
 
 	private ERCVersionedEntryTable() {
 		super("ERCVersionedEntry", ERCVersionedEntryTable::new);
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:489743092
+// LIFERAY-SERVICE-BUILDER-HASH:1767433638

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryVersionModel.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryVersionModel.java
@@ -11,6 +11,8 @@ import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.version.VersionModel;
 
+import java.sql.Blob;
+
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -157,6 +159,20 @@ public interface ERCVersionedEntryVersionModel
 	@Override
 	public void setCompanyId(long companyId);
 
+	/**
+	 * Returns the blob of this erc versioned entry version.
+	 *
+	 * @return the blob of this erc versioned entry version
+	 */
+	public Blob getBlob();
+
+	/**
+	 * Sets the blob of this erc versioned entry version.
+	 *
+	 * @param blob the blob of this erc versioned entry version
+	 */
+	public void setBlob(Blob blob);
+
 	@Override
 	public ERCVersionedEntryVersion cloneWithOriginalValues();
 
@@ -165,4 +181,4 @@ public interface ERCVersionedEntryVersionModel
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:585529757
+// LIFERAY-SERVICE-BUILDER-HASH:-647546140

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryVersionTable.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryVersionTable.java
@@ -8,6 +8,7 @@ package com.liferay.portal.tools.service.builder.test.model;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.base.BaseTable;
 
+import java.sql.Blob;
 import java.sql.Types;
 
 /**
@@ -45,10 +46,12 @@ public class ERCVersionedEntryVersionTable
 	public final Column<ERCVersionedEntryVersionTable, Long> companyId =
 		createColumn(
 			"companyId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
+	public final Column<ERCVersionedEntryVersionTable, Blob> blob =
+		createColumn("blob_", Blob.class, Types.BLOB, Column.FLAG_DEFAULT);
 
 	private ERCVersionedEntryVersionTable() {
 		super("ERCVersionedEntryVersion", ERCVersionedEntryVersionTable::new);
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1336671367
+// LIFERAY-SERVICE-BUILDER-HASH:-71320565

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryVersionWrapper.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryVersionWrapper.java
@@ -8,6 +8,8 @@ package com.liferay.portal.tools.service.builder.test.model;
 import com.liferay.portal.kernel.model.ModelWrapper;
 import com.liferay.portal.kernel.model.wrapper.BaseModelWrapper;
 
+import java.sql.Blob;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -43,6 +45,7 @@ public class ERCVersionedEntryVersionWrapper
 		attributes.put("ercVersionedEntryId", getErcVersionedEntryId());
 		attributes.put("groupId", getGroupId());
 		attributes.put("companyId", getCompanyId());
+		attributes.put("blob", getBlob());
 
 		return attributes;
 	}
@@ -92,11 +95,27 @@ public class ERCVersionedEntryVersionWrapper
 		if (companyId != null) {
 			setCompanyId(companyId);
 		}
+
+		Blob blob = (Blob)attributes.get("blob");
+
+		if (blob != null) {
+			setBlob(blob);
+		}
 	}
 
 	@Override
 	public ERCVersionedEntryVersion cloneWithOriginalValues() {
 		return wrap(model.cloneWithOriginalValues());
+	}
+
+	/**
+	 * Returns the blob of this erc versioned entry version.
+	 *
+	 * @return the blob of this erc versioned entry version
+	 */
+	@Override
+	public Blob getBlob() {
+		return model.getBlob();
 	}
 
 	/**
@@ -177,6 +196,16 @@ public class ERCVersionedEntryVersionWrapper
 	@Override
 	public int getVersion() {
 		return model.getVersion();
+	}
+
+	/**
+	 * Sets the blob of this erc versioned entry version.
+	 *
+	 * @param blob the blob of this erc versioned entry version
+	 */
+	@Override
+	public void setBlob(Blob blob) {
+		model.setBlob(blob);
 	}
 
 	/**
@@ -292,4 +321,4 @@ public class ERCVersionedEntryVersionWrapper
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-582979379
+// LIFERAY-SERVICE-BUILDER-HASH:1599941869

--- a/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryWrapper.java
+++ b/modules/util/portal-tools-service-builder-test-api/src/main/java/com/liferay/portal/tools/service/builder/test/model/ERCVersionedEntryWrapper.java
@@ -8,6 +8,8 @@ package com.liferay.portal.tools.service.builder.test.model;
 import com.liferay.portal.kernel.model.ModelWrapper;
 import com.liferay.portal.kernel.model.wrapper.BaseModelWrapper;
 
+import java.sql.Blob;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -39,6 +41,7 @@ public class ERCVersionedEntryWrapper
 		attributes.put("ercVersionedEntryId", getErcVersionedEntryId());
 		attributes.put("groupId", getGroupId());
 		attributes.put("companyId", getCompanyId());
+		attributes.put("blob", getBlob());
 
 		return attributes;
 	}
@@ -87,11 +90,27 @@ public class ERCVersionedEntryWrapper
 		if (companyId != null) {
 			setCompanyId(companyId);
 		}
+
+		Blob blob = (Blob)attributes.get("blob");
+
+		if (blob != null) {
+			setBlob(blob);
+		}
 	}
 
 	@Override
 	public ERCVersionedEntry cloneWithOriginalValues() {
 		return wrap(model.cloneWithOriginalValues());
+	}
+
+	/**
+	 * Returns the blob of this erc versioned entry.
+	 *
+	 * @return the blob of this erc versioned entry
+	 */
+	@Override
+	public Blob getBlob() {
+		return model.getBlob();
 	}
 
 	/**
@@ -177,6 +196,16 @@ public class ERCVersionedEntryWrapper
 	@Override
 	public void persist() {
 		model.persist();
+	}
+
+	/**
+	 * Sets the blob of this erc versioned entry.
+	 *
+	 * @param blob the blob of this erc versioned entry
+	 */
+	@Override
+	public void setBlob(Blob blob) {
+		model.setBlob(blob);
 	}
 
 	/**
@@ -284,4 +313,4 @@ public class ERCVersionedEntryWrapper
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1214024493
+// LIFERAY-SERVICE-BUILDER-HASH:352160151

--- a/modules/util/portal-tools-service-builder-test-service/service.xml
+++ b/modules/util/portal-tools-service-builder-test-service/service.xml
@@ -259,6 +259,10 @@
 		<!-- Audit fields -->
 
 		<column name="companyId" type="long" />
+
+		<!-- Other fields -->
+
+		<column lazy="false" name="blob" type="Blob" />
 	</entity>
 	<entity local-service="true" name="FinderWhereClauseEntry" remote-service="false">
 

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/ERCVersionedEntryCacheModel.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/ERCVersionedEntryCacheModel.java
@@ -83,7 +83,6 @@ public class ERCVersionedEntryCacheModel
 		sb.append(groupId);
 		sb.append(", companyId=");
 		sb.append(companyId);
-		sb.append("}");
 
 		return sb.toString();
 	}
@@ -177,4 +176,4 @@ public class ERCVersionedEntryCacheModel
 	public long companyId;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1056414359
+// LIFERAY-SERVICE-BUILDER-HASH:-1407182578

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/ERCVersionedEntryModelImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/ERCVersionedEntryModelImpl.java
@@ -32,7 +32,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
@@ -61,7 +60,8 @@ public class ERCVersionedEntryModelImpl
 		{"mvccVersion", Types.BIGINT}, {"uuid_", Types.VARCHAR},
 		{"externalReferenceCode", Types.VARCHAR}, {"headId", Types.BIGINT},
 		{"head", Types.BOOLEAN}, {"ercVersionedEntryId", Types.BIGINT},
-		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT}
+		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT},
+		{"blob_", Types.BLOB}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -76,10 +76,11 @@ public class ERCVersionedEntryModelImpl
 		TABLE_COLUMNS_MAP.put("ercVersionedEntryId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("blob_", Types.BLOB);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table ERCVersionedEntry (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,headId LONG,head BOOLEAN,ercVersionedEntryId LONG not null primary key,groupId LONG,companyId LONG)";
+		"create table ERCVersionedEntry (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,headId LONG,head BOOLEAN,ercVersionedEntryId LONG not null primary key,groupId LONG,companyId LONG,blob_ BLOB)";
 
 	public static final String TABLE_SQL_DROP = "drop table ERCVersionedEntry";
 
@@ -101,62 +102,13 @@ public class ERCVersionedEntryModelImpl
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
 	 */
 	@Deprecated
-	public static final boolean ENTITY_CACHE_ENABLED = true;
+	public static final boolean ENTITY_CACHE_ENABLED = false;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
 	 */
 	@Deprecated
-	public static final boolean FINDER_CACHE_ENABLED = true;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public static final boolean COLUMN_BITMASK_ENABLED = true;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long COMPANYID_COLUMN_BITMASK = 1L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long EXTERNALREFERENCECODE_COLUMN_BITMASK = 2L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long GROUPID_COLUMN_BITMASK = 4L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long HEAD_COLUMN_BITMASK = 8L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long HEADID_COLUMN_BITMASK = 16L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 32L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
-	 *		#getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long ERCVERSIONEDENTRYID_COLUMN_BITMASK = 64L;
+	public static final boolean FINDER_CACHE_ENABLED = false;
 
 	public static final long LOCK_EXPIRATION_TIME = GetterUtil.getLong(
 		com.liferay.portal.tools.service.builder.test.service.util.ServiceProps.
@@ -274,6 +226,7 @@ public class ERCVersionedEntryModelImpl
 				"groupId", ERCVersionedEntry::getGroupId);
 			attributeGetterFunctions.put(
 				"companyId", ERCVersionedEntry::getCompanyId);
+			attributeGetterFunctions.put("blob", ERCVersionedEntry::getBlob);
 
 			_attributeGetterFunctions = Collections.unmodifiableMap(
 				attributeGetterFunctions);
@@ -320,6 +273,10 @@ public class ERCVersionedEntryModelImpl
 				"companyId",
 				(BiConsumer<ERCVersionedEntry, Long>)
 					ERCVersionedEntry::setCompanyId);
+			attributeSetterBiConsumers.put(
+				"blob",
+				(BiConsumer<ERCVersionedEntry, Blob>)
+					ERCVersionedEntry::setBlob);
 
 			_attributeSetterBiConsumers = Collections.unmodifiableMap(
 				(Map)attributeSetterBiConsumers);
@@ -336,6 +293,7 @@ public class ERCVersionedEntryModelImpl
 			getExternalReferenceCode());
 		ercVersionedEntryVersion.setGroupId(getGroupId());
 		ercVersionedEntryVersion.setCompanyId(getCompanyId());
+		ercVersionedEntryVersion.setBlob(getBlob());
 	}
 
 	@Override
@@ -526,28 +484,18 @@ public class ERCVersionedEntryModelImpl
 			this.<Long>getColumnOriginalValue("companyId"));
 	}
 
-	public long getColumnBitmask() {
-		if (_columnBitmask > 0) {
-			return _columnBitmask;
+	@Override
+	public Blob getBlob() {
+		return _blob;
+	}
+
+	@Override
+	public void setBlob(Blob blob) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
 		}
 
-		if ((_columnOriginalValues == null) ||
-			(_columnOriginalValues == Collections.EMPTY_MAP)) {
-
-			return 0;
-		}
-
-		for (Map.Entry<String, Object> entry :
-				_columnOriginalValues.entrySet()) {
-
-			if (!Objects.equals(
-					entry.getValue(), getColumnValue(entry.getKey()))) {
-
-				_columnBitmask |= _columnBitmasks.get(entry.getKey());
-			}
-		}
-
-		return _columnBitmask;
+		_blob = blob;
 	}
 
 	@Override
@@ -683,8 +631,6 @@ public class ERCVersionedEntryModelImpl
 	@Override
 	public void resetOriginalValues() {
 		_columnOriginalValues = Collections.emptyMap();
-
-		_columnBitmask = 0;
 	}
 
 	@Override
@@ -795,6 +741,7 @@ public class ERCVersionedEntryModelImpl
 	private long _ercVersionedEntryId;
 	private long _groupId;
 	private long _companyId;
+	private Blob _blob;
 
 	public <T> T getColumnValue(String columnName) {
 		if (columnName.equals("head")) {
@@ -839,6 +786,7 @@ public class ERCVersionedEntryModelImpl
 		_columnOriginalValues.put("ercVersionedEntryId", _ercVersionedEntryId);
 		_columnOriginalValues.put("groupId", _groupId);
 		_columnOriginalValues.put("companyId", _companyId);
+		_columnOriginalValues.put("blob_", _blob);
 	}
 
 	private static final Map<String, String> _attributeNames;
@@ -847,42 +795,13 @@ public class ERCVersionedEntryModelImpl
 		Map<String, String> attributeNames = new HashMap<>();
 
 		attributeNames.put("uuid_", "uuid");
+		attributeNames.put("blob_", "blob");
 
 		_attributeNames = Collections.unmodifiableMap(attributeNames);
 	}
 
 	private transient Map<String, Object> _columnOriginalValues;
-
-	public static long getColumnBitmask(String columnName) {
-		return _columnBitmasks.get(columnName);
-	}
-
-	private static final Map<String, Long> _columnBitmasks;
-
-	static {
-		Map<String, Long> columnBitmasks = new HashMap<>();
-
-		columnBitmasks.put("mvccVersion", 1L);
-
-		columnBitmasks.put("uuid_", 2L);
-
-		columnBitmasks.put("externalReferenceCode", 4L);
-
-		columnBitmasks.put("headId", 8L);
-
-		columnBitmasks.put("head", 16L);
-
-		columnBitmasks.put("ercVersionedEntryId", 32L);
-
-		columnBitmasks.put("groupId", 64L);
-
-		columnBitmasks.put("companyId", 128L);
-
-		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
-	}
-
-	private long _columnBitmask;
 	private ERCVersionedEntry _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1033458556
+// LIFERAY-SERVICE-BUILDER-HASH:723147727

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/ERCVersionedEntryVersionCacheModel.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/ERCVersionedEntryVersionCacheModel.java
@@ -69,7 +69,6 @@ public class ERCVersionedEntryVersionCacheModel
 		sb.append(groupId);
 		sb.append(", companyId=");
 		sb.append(companyId);
-		sb.append("}");
 
 		return sb.toString();
 	}
@@ -159,4 +158,4 @@ public class ERCVersionedEntryVersionCacheModel
 	public long companyId;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1146275545
+// LIFERAY-SERVICE-BUILDER-HASH:-1729621124

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/ERCVersionedEntryVersionModelImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/model/impl/ERCVersionedEntryVersionModelImpl.java
@@ -32,7 +32,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
@@ -63,7 +62,7 @@ public class ERCVersionedEntryVersionModelImpl
 		{"version", Types.INTEGER}, {"uuid_", Types.VARCHAR},
 		{"externalReferenceCode", Types.VARCHAR},
 		{"ercVersionedEntryId", Types.BIGINT}, {"groupId", Types.BIGINT},
-		{"companyId", Types.BIGINT}
+		{"companyId", Types.BIGINT}, {"blob_", Types.BLOB}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -77,10 +76,11 @@ public class ERCVersionedEntryVersionModelImpl
 		TABLE_COLUMNS_MAP.put("ercVersionedEntryId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("blob_", Types.BLOB);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table ERCVersionedEntryVersion (ercVersionedEntryVersionId LONG not null primary key,version INTEGER,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,ercVersionedEntryId LONG,groupId LONG,companyId LONG)";
+		"create table ERCVersionedEntryVersion (ercVersionedEntryVersionId LONG not null primary key,version INTEGER,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,ercVersionedEntryId LONG,groupId LONG,companyId LONG,blob_ BLOB)";
 
 	public static final String TABLE_SQL_DROP =
 		"drop table ERCVersionedEntryVersion";
@@ -103,49 +103,13 @@ public class ERCVersionedEntryVersionModelImpl
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
 	 */
 	@Deprecated
-	public static final boolean ENTITY_CACHE_ENABLED = true;
+	public static final boolean ENTITY_CACHE_ENABLED = false;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
 	 */
 	@Deprecated
-	public static final boolean FINDER_CACHE_ENABLED = true;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
-	 */
-	@Deprecated
-	public static final boolean COLUMN_BITMASK_ENABLED = true;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long COMPANYID_COLUMN_BITMASK = 1L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long ERCVERSIONEDENTRYID_COLUMN_BITMASK = 2L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long GROUPID_COLUMN_BITMASK = 4L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 8L;
-
-	/**
-	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
-	 */
-	@Deprecated
-	public static final long VERSION_COLUMN_BITMASK = 16L;
+	public static final boolean FINDER_CACHE_ENABLED = false;
 
 	public static final long LOCK_EXPIRATION_TIME = GetterUtil.getLong(
 		com.liferay.portal.tools.service.builder.test.service.util.ServiceProps.
@@ -267,6 +231,8 @@ public class ERCVersionedEntryVersionModelImpl
 				"groupId", ERCVersionedEntryVersion::getGroupId);
 			attributeGetterFunctions.put(
 				"companyId", ERCVersionedEntryVersion::getCompanyId);
+			attributeGetterFunctions.put(
+				"blob", ERCVersionedEntryVersion::getBlob);
 
 			_attributeGetterFunctions = Collections.unmodifiableMap(
 				attributeGetterFunctions);
@@ -314,6 +280,10 @@ public class ERCVersionedEntryVersionModelImpl
 				"companyId",
 				(BiConsumer<ERCVersionedEntryVersion, Long>)
 					ERCVersionedEntryVersion::setCompanyId);
+			attributeSetterBiConsumers.put(
+				"blob",
+				(BiConsumer<ERCVersionedEntryVersion, Blob>)
+					ERCVersionedEntryVersion::setBlob);
 
 			_attributeSetterBiConsumers = Collections.unmodifiableMap(
 				(Map)attributeSetterBiConsumers);
@@ -332,6 +302,7 @@ public class ERCVersionedEntryVersionModelImpl
 		ercVersionedEntry.setExternalReferenceCode(getExternalReferenceCode());
 		ercVersionedEntry.setGroupId(getGroupId());
 		ercVersionedEntry.setCompanyId(getCompanyId());
+		ercVersionedEntry.setBlob(getBlob());
 	}
 
 	@Override
@@ -507,28 +478,18 @@ public class ERCVersionedEntryVersionModelImpl
 			this.<Long>getColumnOriginalValue("companyId"));
 	}
 
-	public long getColumnBitmask() {
-		if (_columnBitmask > 0) {
-			return _columnBitmask;
+	@Override
+	public Blob getBlob() {
+		return _blob;
+	}
+
+	@Override
+	public void setBlob(Blob blob) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
 		}
 
-		if ((_columnOriginalValues == null) ||
-			(_columnOriginalValues == Collections.EMPTY_MAP)) {
-
-			return 0;
-		}
-
-		for (Map.Entry<String, Object> entry :
-				_columnOriginalValues.entrySet()) {
-
-			if (!Objects.equals(
-					entry.getValue(), getColumnValue(entry.getKey()))) {
-
-				_columnBitmask |= _columnBitmasks.get(entry.getKey());
-			}
-		}
-
-		return _columnBitmask;
+		_blob = blob;
 	}
 
 	@Override
@@ -676,8 +637,6 @@ public class ERCVersionedEntryVersionModelImpl
 	@Override
 	public void resetOriginalValues() {
 		_columnOriginalValues = Collections.emptyMap();
-
-		_columnBitmask = 0;
 	}
 
 	@Override
@@ -787,6 +746,7 @@ public class ERCVersionedEntryVersionModelImpl
 	private long _ercVersionedEntryId;
 	private long _groupId;
 	private long _companyId;
+	private Blob _blob;
 
 	public <T> T getColumnValue(String columnName) {
 		columnName = _attributeNames.getOrDefault(columnName, columnName);
@@ -827,6 +787,7 @@ public class ERCVersionedEntryVersionModelImpl
 		_columnOriginalValues.put("ercVersionedEntryId", _ercVersionedEntryId);
 		_columnOriginalValues.put("groupId", _groupId);
 		_columnOriginalValues.put("companyId", _companyId);
+		_columnOriginalValues.put("blob_", _blob);
 	}
 
 	private static final Map<String, String> _attributeNames;
@@ -835,40 +796,13 @@ public class ERCVersionedEntryVersionModelImpl
 		Map<String, String> attributeNames = new HashMap<>();
 
 		attributeNames.put("uuid_", "uuid");
+		attributeNames.put("blob_", "blob");
 
 		_attributeNames = Collections.unmodifiableMap(attributeNames);
 	}
 
 	private transient Map<String, Object> _columnOriginalValues;
-
-	public static long getColumnBitmask(String columnName) {
-		return _columnBitmasks.get(columnName);
-	}
-
-	private static final Map<String, Long> _columnBitmasks;
-
-	static {
-		Map<String, Long> columnBitmasks = new HashMap<>();
-
-		columnBitmasks.put("ercVersionedEntryVersionId", 1L);
-
-		columnBitmasks.put("version", 2L);
-
-		columnBitmasks.put("uuid_", 4L);
-
-		columnBitmasks.put("externalReferenceCode", 8L);
-
-		columnBitmasks.put("ercVersionedEntryId", 16L);
-
-		columnBitmasks.put("groupId", 32L);
-
-		columnBitmasks.put("companyId", 64L);
-
-		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
-	}
-
-	private long _columnBitmask;
 	private ERCVersionedEntryVersion _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1160237269
+// LIFERAY-SERVICE-BUILDER-HASH:1456181218

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/base/ERCVersionedEntryLocalServiceBaseImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/base/ERCVersionedEntryLocalServiceBaseImpl.java
@@ -946,6 +946,7 @@ public abstract class ERCVersionedEntryLocalServiceBaseImpl
 			publishedERCVersionedEntry.getGroupId());
 		draftERCVersionedEntry.setCompanyId(
 			publishedERCVersionedEntry.getCompanyId());
+		draftERCVersionedEntry.setBlob(publishedERCVersionedEntry.getBlob());
 
 		draftERCVersionedEntry.resetOriginalValues();
 
@@ -1027,4 +1028,4 @@ public abstract class ERCVersionedEntryLocalServiceBaseImpl
 		ERCVersionedEntryLocalServiceBaseImpl.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:712558739
+// LIFERAY-SERVICE-BUILDER-HASH:1739079984

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/ERCVersionedEntryModelArgumentsResolver.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/ERCVersionedEntryModelArgumentsResolver.java
@@ -13,8 +13,7 @@ import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryTabl
 import com.liferay.portal.tools.service.builder.test.model.impl.ERCVersionedEntryImpl;
 import com.liferay.portal.tools.service.builder.test.model.impl.ERCVersionedEntryModelImpl;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Objects;
 
 /**
  * The arguments resolver class for retrieving value from ERCVersionedEntry.
@@ -50,28 +49,9 @@ public class ERCVersionedEntryModelArgumentsResolver
 		ERCVersionedEntryModelImpl ercVersionedEntryModelImpl =
 			(ERCVersionedEntryModelImpl)baseModel;
 
-		long columnBitmask = ercVersionedEntryModelImpl.getColumnBitmask();
+		if (!checkColumn ||
+			_hasModifiedColumns(ercVersionedEntryModelImpl, columnNames)) {
 
-		if (!checkColumn || (columnBitmask == 0)) {
-			return _getValue(ercVersionedEntryModelImpl, finderPath, original);
-		}
-
-		Long finderPathColumnBitmask = _finderPathColumnBitmasksCache.get(
-			finderPath);
-
-		if (finderPathColumnBitmask == null) {
-			finderPathColumnBitmask = 0L;
-
-			for (String columnName : columnNames) {
-				finderPathColumnBitmask |=
-					ercVersionedEntryModelImpl.getColumnBitmask(columnName);
-			}
-
-			_finderPathColumnBitmasksCache.put(
-				finderPath, finderPathColumnBitmask);
-		}
-
-		if ((columnBitmask & finderPathColumnBitmask) != 0) {
 			return _getValue(ercVersionedEntryModelImpl, finderPath, original);
 		}
 
@@ -115,8 +95,26 @@ public class ERCVersionedEntryModelArgumentsResolver
 		return arguments;
 	}
 
-	private static final Map<FinderPath, Long> _finderPathColumnBitmasksCache =
-		new ConcurrentHashMap<>();
+	private static boolean _hasModifiedColumns(
+		ERCVersionedEntryModelImpl ercVersionedEntryModelImpl,
+		String[] columnNames) {
+
+		if (columnNames.length == 0) {
+			return false;
+		}
+
+		for (String columnName : columnNames) {
+			if (!Objects.equals(
+					ercVersionedEntryModelImpl.getColumnOriginalValue(
+						columnName),
+					ercVersionedEntryModelImpl.getColumnValue(columnName))) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1682090847
+// LIFERAY-SERVICE-BUILDER-HASH:1792999623

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/ERCVersionedEntryPersistenceImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/ERCVersionedEntryPersistenceImpl.java
@@ -28,7 +28,6 @@ import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
-import com.liferay.portal.spring.extender.service.ServiceReference;
 import com.liferay.portal.tools.service.builder.test.exception.DuplicateERCVersionedEntryExternalReferenceCodeException;
 import com.liferay.portal.tools.service.builder.test.exception.NoSuchERCVersionedEntryException;
 import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntry;
@@ -101,8 +100,8 @@ public class ERCVersionedEntryPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUuid.find(
-			finderCache, new Object[] {uuid}, start, end, orderByComparator,
-			useFinderCache);
+			dummyFinderCache, new Object[] {uuid}, start, end,
+			orderByComparator, useFinderCache);
 	}
 
 	/**
@@ -142,7 +141,7 @@ public class ERCVersionedEntryPersistenceImpl
 		String uuid, OrderByComparator<ERCVersionedEntry> orderByComparator) {
 
 		return _collectionPersistenceFinderByUuid.fetchFirst(
-			finderCache, new Object[] {uuid}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid}, orderByComparator);
 	}
 
 	/**
@@ -153,7 +152,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public void removeByUuid(String uuid) {
 		_collectionPersistenceFinderByUuid.remove(
-			finderCache, new Object[] {uuid});
+			dummyFinderCache, new Object[] {uuid});
 	}
 
 	/**
@@ -165,7 +164,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public int countByUuid(String uuid) {
 		return _collectionPersistenceFinderByUuid.count(
-			finderCache, new Object[] {uuid});
+			dummyFinderCache, new Object[] {uuid});
 	}
 
 	private CollectionPersistenceFinder<ERCVersionedEntry>
@@ -193,7 +192,7 @@ public class ERCVersionedEntryPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUuid_Head.find(
-			finderCache, new Object[] {uuid, head}, start, end,
+			dummyFinderCache, new Object[] {uuid, head}, start, end,
 			orderByComparator, useFinderCache);
 	}
 
@@ -238,7 +237,7 @@ public class ERCVersionedEntryPersistenceImpl
 		OrderByComparator<ERCVersionedEntry> orderByComparator) {
 
 		return _collectionPersistenceFinderByUuid_Head.fetchFirst(
-			finderCache, new Object[] {uuid, head}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, head}, orderByComparator);
 	}
 
 	/**
@@ -250,7 +249,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public void removeByUuid_Head(String uuid, boolean head) {
 		_collectionPersistenceFinderByUuid_Head.remove(
-			finderCache, new Object[] {uuid, head});
+			dummyFinderCache, new Object[] {uuid, head});
 	}
 
 	/**
@@ -263,7 +262,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public int countByUuid_Head(String uuid, boolean head) {
 		return _collectionPersistenceFinderByUuid_Head.count(
-			finderCache, new Object[] {uuid, head});
+			dummyFinderCache, new Object[] {uuid, head});
 	}
 
 	private CollectionPersistenceFinder<ERCVersionedEntry>
@@ -291,7 +290,7 @@ public class ERCVersionedEntryPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUUID_G.find(
-			finderCache, new Object[] {uuid, groupId}, start, end,
+			dummyFinderCache, new Object[] {uuid, groupId}, start, end,
 			orderByComparator, useFinderCache);
 	}
 
@@ -336,7 +335,7 @@ public class ERCVersionedEntryPersistenceImpl
 		OrderByComparator<ERCVersionedEntry> orderByComparator) {
 
 		return _collectionPersistenceFinderByUUID_G.fetchFirst(
-			finderCache, new Object[] {uuid, groupId}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, groupId}, orderByComparator);
 	}
 
 	/**
@@ -348,7 +347,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public void removeByUUID_G(String uuid, long groupId) {
 		_collectionPersistenceFinderByUUID_G.remove(
-			finderCache, new Object[] {uuid, groupId});
+			dummyFinderCache, new Object[] {uuid, groupId});
 	}
 
 	/**
@@ -361,7 +360,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public int countByUUID_G(String uuid, long groupId) {
 		return _collectionPersistenceFinderByUUID_G.count(
-			finderCache, new Object[] {uuid, groupId});
+			dummyFinderCache, new Object[] {uuid, groupId});
 	}
 
 	private UniquePersistenceFinder<ERCVersionedEntry>
@@ -414,7 +413,8 @@ public class ERCVersionedEntryPersistenceImpl
 		String uuid, long groupId, boolean head, boolean useFinderCache) {
 
 		return _uniquePersistenceFinderByUUID_G_Head.fetch(
-			finderCache, new Object[] {uuid, groupId, head}, useFinderCache);
+			dummyFinderCache, new Object[] {uuid, groupId, head},
+			useFinderCache);
 	}
 
 	/**
@@ -447,7 +447,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public int countByUUID_G_Head(String uuid, long groupId, boolean head) {
 		return _uniquePersistenceFinderByUUID_G_Head.count(
-			finderCache, new Object[] {uuid, groupId, head});
+			dummyFinderCache, new Object[] {uuid, groupId, head});
 	}
 
 	private CollectionPersistenceFinder<ERCVersionedEntry>
@@ -475,7 +475,7 @@ public class ERCVersionedEntryPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUuid_C.find(
-			finderCache, new Object[] {uuid, companyId}, start, end,
+			dummyFinderCache, new Object[] {uuid, companyId}, start, end,
 			orderByComparator, useFinderCache);
 	}
 
@@ -520,7 +520,8 @@ public class ERCVersionedEntryPersistenceImpl
 		OrderByComparator<ERCVersionedEntry> orderByComparator) {
 
 		return _collectionPersistenceFinderByUuid_C.fetchFirst(
-			finderCache, new Object[] {uuid, companyId}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, companyId},
+			orderByComparator);
 	}
 
 	/**
@@ -532,7 +533,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public void removeByUuid_C(String uuid, long companyId) {
 		_collectionPersistenceFinderByUuid_C.remove(
-			finderCache, new Object[] {uuid, companyId});
+			dummyFinderCache, new Object[] {uuid, companyId});
 	}
 
 	/**
@@ -545,7 +546,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public int countByUuid_C(String uuid, long companyId) {
 		return _collectionPersistenceFinderByUuid_C.count(
-			finderCache, new Object[] {uuid, companyId});
+			dummyFinderCache, new Object[] {uuid, companyId});
 	}
 
 	private CollectionPersistenceFinder<ERCVersionedEntry>
@@ -574,7 +575,7 @@ public class ERCVersionedEntryPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUuid_C_Head.find(
-			finderCache, new Object[] {uuid, companyId, head}, start, end,
+			dummyFinderCache, new Object[] {uuid, companyId, head}, start, end,
 			orderByComparator, useFinderCache);
 	}
 
@@ -622,7 +623,7 @@ public class ERCVersionedEntryPersistenceImpl
 		OrderByComparator<ERCVersionedEntry> orderByComparator) {
 
 		return _collectionPersistenceFinderByUuid_C_Head.fetchFirst(
-			finderCache, new Object[] {uuid, companyId, head},
+			dummyFinderCache, new Object[] {uuid, companyId, head},
 			orderByComparator);
 	}
 
@@ -636,7 +637,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public void removeByUuid_C_Head(String uuid, long companyId, boolean head) {
 		_collectionPersistenceFinderByUuid_C_Head.remove(
-			finderCache, new Object[] {uuid, companyId, head});
+			dummyFinderCache, new Object[] {uuid, companyId, head});
 	}
 
 	/**
@@ -650,7 +651,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public int countByUuid_C_Head(String uuid, long companyId, boolean head) {
 		return _collectionPersistenceFinderByUuid_C_Head.count(
-			finderCache, new Object[] {uuid, companyId, head});
+			dummyFinderCache, new Object[] {uuid, companyId, head});
 	}
 
 	private CollectionPersistenceFinder<ERCVersionedEntry>
@@ -678,8 +679,8 @@ public class ERCVersionedEntryPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByERC_G.find(
-			finderCache, new Object[] {externalReferenceCode, groupId}, start,
-			end, orderByComparator, useFinderCache);
+			dummyFinderCache, new Object[] {externalReferenceCode, groupId},
+			start, end, orderByComparator, useFinderCache);
 	}
 
 	/**
@@ -724,7 +725,7 @@ public class ERCVersionedEntryPersistenceImpl
 		OrderByComparator<ERCVersionedEntry> orderByComparator) {
 
 		return _collectionPersistenceFinderByERC_G.fetchFirst(
-			finderCache, new Object[] {externalReferenceCode, groupId},
+			dummyFinderCache, new Object[] {externalReferenceCode, groupId},
 			orderByComparator);
 	}
 
@@ -737,7 +738,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public void removeByERC_G(String externalReferenceCode, long groupId) {
 		_collectionPersistenceFinderByERC_G.remove(
-			finderCache, new Object[] {externalReferenceCode, groupId});
+			dummyFinderCache, new Object[] {externalReferenceCode, groupId});
 	}
 
 	/**
@@ -750,7 +751,7 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public int countByERC_G(String externalReferenceCode, long groupId) {
 		return _collectionPersistenceFinderByERC_G.count(
-			finderCache, new Object[] {externalReferenceCode, groupId});
+			dummyFinderCache, new Object[] {externalReferenceCode, groupId});
 	}
 
 	private UniquePersistenceFinder<ERCVersionedEntry>
@@ -804,7 +805,8 @@ public class ERCVersionedEntryPersistenceImpl
 		boolean useFinderCache) {
 
 		return _uniquePersistenceFinderByERC_G_Head.fetch(
-			finderCache, new Object[] {externalReferenceCode, groupId, head},
+			dummyFinderCache,
+			new Object[] {externalReferenceCode, groupId, head},
 			useFinderCache);
 	}
 
@@ -840,7 +842,8 @@ public class ERCVersionedEntryPersistenceImpl
 		String externalReferenceCode, long groupId, boolean head) {
 
 		return _uniquePersistenceFinderByERC_G_Head.count(
-			finderCache, new Object[] {externalReferenceCode, groupId, head});
+			dummyFinderCache,
+			new Object[] {externalReferenceCode, groupId, head});
 	}
 
 	private UniquePersistenceFinder<ERCVersionedEntry>
@@ -886,7 +889,7 @@ public class ERCVersionedEntryPersistenceImpl
 		long headId, boolean useFinderCache) {
 
 		return _uniquePersistenceFinderByHeadId.fetch(
-			finderCache, new Object[] {headId}, useFinderCache);
+			dummyFinderCache, new Object[] {headId}, useFinderCache);
 	}
 
 	/**
@@ -913,13 +916,14 @@ public class ERCVersionedEntryPersistenceImpl
 	@Override
 	public int countByHeadId(long headId) {
 		return _uniquePersistenceFinderByHeadId.count(
-			finderCache, new Object[] {headId});
+			dummyFinderCache, new Object[] {headId});
 	}
 
 	public ERCVersionedEntryPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
 
 		dbColumnNames.put("uuid", "uuid_");
+		dbColumnNames.put("blob", "blob_");
 
 		setDBColumnNames(dbColumnNames);
 
@@ -1157,7 +1161,7 @@ public class ERCVersionedEntryPersistenceImpl
 
 	@Override
 	protected EntityCache getEntityCache() {
-		return entityCache;
+		return dummyEntityCache;
 	}
 
 	@Override
@@ -1438,14 +1442,8 @@ public class ERCVersionedEntryPersistenceImpl
 	public void destroy() {
 		ERCVersionedEntryUtil.setPersistence(null);
 
-		entityCache.removeCache(ERCVersionedEntryImpl.class.getName());
+		dummyEntityCache.removeCache(ERCVersionedEntryImpl.class.getName());
 	}
-
-	@ServiceReference(type = EntityCache.class)
-	protected EntityCache entityCache;
-
-	@ServiceReference(type = FinderCache.class)
-	protected FinderCache finderCache;
 
 	private static final String _ENTITY_ALIAS_PREFIX =
 		ERCVersionedEntryModelImpl.ENTITY_ALIAS + ".";
@@ -1466,12 +1464,12 @@ public class ERCVersionedEntryPersistenceImpl
 		ERCVersionedEntryPersistenceImpl.class);
 
 	private static final Set<String> _badColumnNames = SetUtil.fromArray(
-		new String[] {"uuid"});
+		new String[] {"uuid", "blob"});
 
 	@Override
 	protected FinderCache getFinderCache() {
-		return finderCache;
+		return dummyFinderCache;
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:545969811
+// LIFERAY-SERVICE-BUILDER-HASH:2137508036

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/ERCVersionedEntryVersionModelArgumentsResolver.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/ERCVersionedEntryVersionModelArgumentsResolver.java
@@ -13,8 +13,9 @@ import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryVers
 import com.liferay.portal.tools.service.builder.test.model.impl.ERCVersionedEntryVersionImpl;
 import com.liferay.portal.tools.service.builder.test.model.impl.ERCVersionedEntryVersionModelImpl;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * The arguments resolver class for retrieving value from ERCVersionedEntryVersion.
@@ -50,39 +51,12 @@ public class ERCVersionedEntryVersionModelArgumentsResolver
 		ERCVersionedEntryVersionModelImpl ercVersionedEntryVersionModelImpl =
 			(ERCVersionedEntryVersionModelImpl)baseModel;
 
-		long columnBitmask =
-			ercVersionedEntryVersionModelImpl.getColumnBitmask();
+		if (!checkColumn ||
+			_hasModifiedColumns(
+				ercVersionedEntryVersionModelImpl, columnNames) ||
+			_hasModifiedColumns(
+				ercVersionedEntryVersionModelImpl, _ORDER_BY_COLUMNS)) {
 
-		if (!checkColumn || (columnBitmask == 0)) {
-			return _getValue(
-				ercVersionedEntryVersionModelImpl, finderPath, original);
-		}
-
-		Long finderPathColumnBitmask = _finderPathColumnBitmasksCache.get(
-			finderPath);
-
-		if (finderPathColumnBitmask == null) {
-			finderPathColumnBitmask = 0L;
-
-			for (String columnName : columnNames) {
-				finderPathColumnBitmask |=
-					ercVersionedEntryVersionModelImpl.getColumnBitmask(
-						columnName);
-			}
-
-			if (finderPath.isBaseModelResult() &&
-				(ERCVersionedEntryVersionPersistenceImpl.
-					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION ==
-						finderPath.getCacheName())) {
-
-				finderPathColumnBitmask |= _ORDER_BY_COLUMNS_BITMASK;
-			}
-
-			_finderPathColumnBitmasksCache.put(
-				finderPath, finderPathColumnBitmask);
-		}
-
-		if ((columnBitmask & finderPathColumnBitmask) != 0) {
 			return _getValue(
 				ercVersionedEntryVersionModelImpl, finderPath, original);
 		}
@@ -129,19 +103,37 @@ public class ERCVersionedEntryVersionModelArgumentsResolver
 		return arguments;
 	}
 
-	private static final Map<FinderPath, Long> _finderPathColumnBitmasksCache =
-		new ConcurrentHashMap<>();
+	private static boolean _hasModifiedColumns(
+		ERCVersionedEntryVersionModelImpl ercVersionedEntryVersionModelImpl,
+		String[] columnNames) {
 
-	private static final long _ORDER_BY_COLUMNS_BITMASK;
+		if (columnNames.length == 0) {
+			return false;
+		}
+
+		for (String columnName : columnNames) {
+			if (!Objects.equals(
+					ercVersionedEntryVersionModelImpl.getColumnOriginalValue(
+						columnName),
+					ercVersionedEntryVersionModelImpl.getColumnValue(
+						columnName))) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static final String[] _ORDER_BY_COLUMNS;
 
 	static {
-		long orderByColumnsBitmask = 0;
+		List<String> orderByColumns = new ArrayList<String>();
 
-		orderByColumnsBitmask |=
-			ERCVersionedEntryVersionModelImpl.getColumnBitmask("version");
+		orderByColumns.add("version");
 
-		_ORDER_BY_COLUMNS_BITMASK = orderByColumnsBitmask;
+		_ORDER_BY_COLUMNS = orderByColumns.toArray(new String[0]);
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1814987501
+// LIFERAY-SERVICE-BUILDER-HASH:-808016544

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/ERCVersionedEntryVersionPersistenceImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/ERCVersionedEntryVersionPersistenceImpl.java
@@ -27,7 +27,6 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.spring.extender.service.ServiceReference;
 import com.liferay.portal.tools.service.builder.test.exception.NoSuchERCVersionedEntryVersionException;
 import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryVersion;
 import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryVersionTable;
@@ -99,7 +98,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByErcVersionedEntryId.find(
-			finderCache, new Object[] {ercVersionedEntryId}, start, end,
+			dummyFinderCache, new Object[] {ercVersionedEntryId}, start, end,
 			orderByComparator, useFinderCache);
 	}
 
@@ -145,7 +144,8 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		OrderByComparator<ERCVersionedEntryVersion> orderByComparator) {
 
 		return _collectionPersistenceFinderByErcVersionedEntryId.fetchFirst(
-			finderCache, new Object[] {ercVersionedEntryId}, orderByComparator);
+			dummyFinderCache, new Object[] {ercVersionedEntryId},
+			orderByComparator);
 	}
 
 	/**
@@ -156,7 +156,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public void removeByErcVersionedEntryId(long ercVersionedEntryId) {
 		_collectionPersistenceFinderByErcVersionedEntryId.remove(
-			finderCache, new Object[] {ercVersionedEntryId});
+			dummyFinderCache, new Object[] {ercVersionedEntryId});
 	}
 
 	/**
@@ -168,7 +168,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public int countByErcVersionedEntryId(long ercVersionedEntryId) {
 		return _collectionPersistenceFinderByErcVersionedEntryId.count(
-			finderCache, new Object[] {ercVersionedEntryId});
+			dummyFinderCache, new Object[] {ercVersionedEntryId});
 	}
 
 	private UniquePersistenceFinder<ERCVersionedEntryVersion>
@@ -220,7 +220,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		long ercVersionedEntryId, int version, boolean useFinderCache) {
 
 		return _uniquePersistenceFinderByErcVersionedEntryId_Version.fetch(
-			finderCache, new Object[] {ercVersionedEntryId, version},
+			dummyFinderCache, new Object[] {ercVersionedEntryId, version},
 			useFinderCache);
 	}
 
@@ -254,7 +254,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		long ercVersionedEntryId, int version) {
 
 		return _uniquePersistenceFinderByErcVersionedEntryId_Version.count(
-			finderCache, new Object[] {ercVersionedEntryId, version});
+			dummyFinderCache, new Object[] {ercVersionedEntryId, version});
 	}
 
 	private CollectionPersistenceFinder<ERCVersionedEntryVersion>
@@ -281,8 +281,8 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUuid.find(
-			finderCache, new Object[] {uuid}, start, end, orderByComparator,
-			useFinderCache);
+			dummyFinderCache, new Object[] {uuid}, start, end,
+			orderByComparator, useFinderCache);
 	}
 
 	/**
@@ -324,7 +324,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		OrderByComparator<ERCVersionedEntryVersion> orderByComparator) {
 
 		return _collectionPersistenceFinderByUuid.fetchFirst(
-			finderCache, new Object[] {uuid}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid}, orderByComparator);
 	}
 
 	/**
@@ -335,7 +335,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public void removeByUuid(String uuid) {
 		_collectionPersistenceFinderByUuid.remove(
-			finderCache, new Object[] {uuid});
+			dummyFinderCache, new Object[] {uuid});
 	}
 
 	/**
@@ -347,7 +347,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public int countByUuid(String uuid) {
 		return _collectionPersistenceFinderByUuid.count(
-			finderCache, new Object[] {uuid});
+			dummyFinderCache, new Object[] {uuid});
 	}
 
 	private CollectionPersistenceFinder<ERCVersionedEntryVersion>
@@ -375,7 +375,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUuid_Version.find(
-			finderCache, new Object[] {uuid, version}, start, end,
+			dummyFinderCache, new Object[] {uuid, version}, start, end,
 			orderByComparator, useFinderCache);
 	}
 
@@ -420,7 +420,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		OrderByComparator<ERCVersionedEntryVersion> orderByComparator) {
 
 		return _collectionPersistenceFinderByUuid_Version.fetchFirst(
-			finderCache, new Object[] {uuid, version}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, version}, orderByComparator);
 	}
 
 	/**
@@ -432,7 +432,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public void removeByUuid_Version(String uuid, int version) {
 		_collectionPersistenceFinderByUuid_Version.remove(
-			finderCache, new Object[] {uuid, version});
+			dummyFinderCache, new Object[] {uuid, version});
 	}
 
 	/**
@@ -445,7 +445,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public int countByUuid_Version(String uuid, int version) {
 		return _collectionPersistenceFinderByUuid_Version.count(
-			finderCache, new Object[] {uuid, version});
+			dummyFinderCache, new Object[] {uuid, version});
 	}
 
 	private CollectionPersistenceFinder<ERCVersionedEntryVersion>
@@ -473,7 +473,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUUID_G.find(
-			finderCache, new Object[] {uuid, groupId}, start, end,
+			dummyFinderCache, new Object[] {uuid, groupId}, start, end,
 			orderByComparator, useFinderCache);
 	}
 
@@ -518,7 +518,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		OrderByComparator<ERCVersionedEntryVersion> orderByComparator) {
 
 		return _collectionPersistenceFinderByUUID_G.fetchFirst(
-			finderCache, new Object[] {uuid, groupId}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, groupId}, orderByComparator);
 	}
 
 	/**
@@ -530,7 +530,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public void removeByUUID_G(String uuid, long groupId) {
 		_collectionPersistenceFinderByUUID_G.remove(
-			finderCache, new Object[] {uuid, groupId});
+			dummyFinderCache, new Object[] {uuid, groupId});
 	}
 
 	/**
@@ -543,7 +543,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public int countByUUID_G(String uuid, long groupId) {
 		return _collectionPersistenceFinderByUUID_G.count(
-			finderCache, new Object[] {uuid, groupId});
+			dummyFinderCache, new Object[] {uuid, groupId});
 	}
 
 	private UniquePersistenceFinder<ERCVersionedEntryVersion>
@@ -596,7 +596,8 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		String uuid, long groupId, int version, boolean useFinderCache) {
 
 		return _uniquePersistenceFinderByUUID_G_Version.fetch(
-			finderCache, new Object[] {uuid, groupId, version}, useFinderCache);
+			dummyFinderCache, new Object[] {uuid, groupId, version},
+			useFinderCache);
 	}
 
 	/**
@@ -629,7 +630,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public int countByUUID_G_Version(String uuid, long groupId, int version) {
 		return _uniquePersistenceFinderByUUID_G_Version.count(
-			finderCache, new Object[] {uuid, groupId, version});
+			dummyFinderCache, new Object[] {uuid, groupId, version});
 	}
 
 	private CollectionPersistenceFinder<ERCVersionedEntryVersion>
@@ -657,7 +658,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUuid_C.find(
-			finderCache, new Object[] {uuid, companyId}, start, end,
+			dummyFinderCache, new Object[] {uuid, companyId}, start, end,
 			orderByComparator, useFinderCache);
 	}
 
@@ -702,7 +703,8 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		OrderByComparator<ERCVersionedEntryVersion> orderByComparator) {
 
 		return _collectionPersistenceFinderByUuid_C.fetchFirst(
-			finderCache, new Object[] {uuid, companyId}, orderByComparator);
+			dummyFinderCache, new Object[] {uuid, companyId},
+			orderByComparator);
 	}
 
 	/**
@@ -714,7 +716,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public void removeByUuid_C(String uuid, long companyId) {
 		_collectionPersistenceFinderByUuid_C.remove(
-			finderCache, new Object[] {uuid, companyId});
+			dummyFinderCache, new Object[] {uuid, companyId});
 	}
 
 	/**
@@ -727,7 +729,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public int countByUuid_C(String uuid, long companyId) {
 		return _collectionPersistenceFinderByUuid_C.count(
-			finderCache, new Object[] {uuid, companyId});
+			dummyFinderCache, new Object[] {uuid, companyId});
 	}
 
 	private CollectionPersistenceFinder<ERCVersionedEntryVersion>
@@ -756,8 +758,8 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		boolean useFinderCache) {
 
 		return _collectionPersistenceFinderByUuid_C_Version.find(
-			finderCache, new Object[] {uuid, companyId, version}, start, end,
-			orderByComparator, useFinderCache);
+			dummyFinderCache, new Object[] {uuid, companyId, version}, start,
+			end, orderByComparator, useFinderCache);
 	}
 
 	/**
@@ -805,7 +807,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		OrderByComparator<ERCVersionedEntryVersion> orderByComparator) {
 
 		return _collectionPersistenceFinderByUuid_C_Version.fetchFirst(
-			finderCache, new Object[] {uuid, companyId, version},
+			dummyFinderCache, new Object[] {uuid, companyId, version},
 			orderByComparator);
 	}
 
@@ -821,7 +823,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		String uuid, long companyId, int version) {
 
 		_collectionPersistenceFinderByUuid_C_Version.remove(
-			finderCache, new Object[] {uuid, companyId, version});
+			dummyFinderCache, new Object[] {uuid, companyId, version});
 	}
 
 	/**
@@ -835,13 +837,14 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	@Override
 	public int countByUuid_C_Version(String uuid, long companyId, int version) {
 		return _collectionPersistenceFinderByUuid_C_Version.count(
-			finderCache, new Object[] {uuid, companyId, version});
+			dummyFinderCache, new Object[] {uuid, companyId, version});
 	}
 
 	public ERCVersionedEntryVersionPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
 
 		dbColumnNames.put("uuid", "uuid_");
+		dbColumnNames.put("blob", "blob_");
 
 		setDBColumnNames(dbColumnNames);
 
@@ -1059,7 +1062,7 @@ public class ERCVersionedEntryVersionPersistenceImpl
 
 	@Override
 	protected EntityCache getEntityCache() {
-		return entityCache;
+		return dummyEntityCache;
 	}
 
 	@Override
@@ -1343,14 +1346,9 @@ public class ERCVersionedEntryVersionPersistenceImpl
 	public void destroy() {
 		ERCVersionedEntryVersionUtil.setPersistence(null);
 
-		entityCache.removeCache(ERCVersionedEntryVersionImpl.class.getName());
+		dummyEntityCache.removeCache(
+			ERCVersionedEntryVersionImpl.class.getName());
 	}
-
-	@ServiceReference(type = EntityCache.class)
-	protected EntityCache entityCache;
-
-	@ServiceReference(type = FinderCache.class)
-	protected FinderCache finderCache;
 
 	private static final String _ENTITY_ALIAS_PREFIX =
 		ERCVersionedEntryVersionModelImpl.ENTITY_ALIAS + ".";
@@ -1371,12 +1369,12 @@ public class ERCVersionedEntryVersionPersistenceImpl
 		ERCVersionedEntryVersionPersistenceImpl.class);
 
 	private static final Set<String> _badColumnNames = SetUtil.fromArray(
-		new String[] {"uuid"});
+		new String[] {"uuid", "blob"});
 
 	@Override
 	protected FinderCache getFinderCache() {
-		return finderCache;
+		return dummyFinderCache;
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-799923479
+// LIFERAY-SERVICE-BUILDER-HASH:1882434230

--- a/modules/util/portal-tools-service-builder-test-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/resources/META-INF/module-hbm.xml
@@ -159,6 +159,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="head" type="com.liferay.portal.dao.orm.hibernate.BooleanType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="groupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="companyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="blob_" name="blob" type="org.hibernate.type.BlobType" />
 	</class>
 	<class name="com.liferay.portal.tools.service.builder.test.model.impl.ERCVersionedEntryVersionImpl" table="ERCVersionedEntryVersion">
 		<id access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="ercVersionedEntryVersionId" type="long">
@@ -170,6 +171,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="ercVersionedEntryId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="groupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="companyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="blob_" name="blob" type="org.hibernate.type.BlobType" />
 	</class>
 	<class name="com.liferay.portal.tools.service.builder.test.model.impl.FinderWhereClauseEntryImpl" table="FinderWhereClauseEntry">
 		<id access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="finderWhereClauseEntryId" type="long">

--- a/modules/util/portal-tools-service-builder-test-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -94,6 +94,7 @@
 		<field name="ercVersionedEntryId" type="long" />
 		<field name="groupId" type="long" />
 		<field name="companyId" type="long" />
+		<field name="blob" type="Blob" />
 	</model>
 	<model name="com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryVersion">
 		<field name="ercVersionedEntryVersionId" type="long" />
@@ -103,6 +104,7 @@
 		<field name="ercVersionedEntryId" type="long" />
 		<field name="groupId" type="long" />
 		<field name="companyId" type="long" />
+		<field name="blob" type="Blob" />
 	</model>
 	<model name="com.liferay.portal.tools.service.builder.test.model.FinderWhereClauseEntry">
 		<field name="finderWhereClauseEntryId" type="long" />

--- a/modules/util/portal-tools-service-builder-test-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/resources/META-INF/sql/tables.sql
@@ -104,7 +104,8 @@ create table ERCVersionedEntry (
 	head BOOLEAN,
 	ercVersionedEntryId LONG not null primary key,
 	groupId LONG,
-	companyId LONG
+	companyId LONG,
+	blob_ BLOB
 );
 
 create table ERCVersionedEntryVersion (
@@ -114,7 +115,8 @@ create table ERCVersionedEntryVersion (
 	externalReferenceCode VARCHAR(75) null,
 	ercVersionedEntryId LONG,
 	groupId LONG,
-	companyId LONG
+	companyId LONG,
+	blob_ BLOB
 );
 
 create table EagerBlobEntry (

--- a/modules/util/portal-tools-service-builder-test-service/src/main/resources/service.properties
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.portal.tools.service.builder.test.service
-    build.number=4
-    build.date=1779290829977
+    build.number=5
+    build.date=1779693449640

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCVersionedEntryPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCVersionedEntryPersistenceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.tools.service.builder.test.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.dao.jdbc.OutputBlob;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQueryFactoryUtil;
@@ -30,9 +31,13 @@ import com.liferay.portal.tools.service.builder.test.service.ERCVersionedEntryLo
 import com.liferay.portal.tools.service.builder.test.service.persistence.ERCVersionedEntryPersistence;
 import com.liferay.portal.tools.service.builder.test.service.persistence.ERCVersionedEntryUtil;
 
+import java.io.ByteArrayInputStream;
 import java.io.Serializable;
 
+import java.sql.Blob;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -129,8 +134,22 @@ public class ERCVersionedEntryPersistenceTest {
 		newERCVersionedEntry.setGroupId(RandomTestUtil.nextLong());
 
 		newERCVersionedEntry.setCompanyId(RandomTestUtil.nextLong());
+		String newBlobString = RandomTestUtil.randomString();
+
+		byte[] newBlobBytes = newBlobString.getBytes("UTF-8");
+
+		Blob newBlobBlob = new OutputBlob(
+			new ByteArrayInputStream(newBlobBytes), newBlobBytes.length);
+
+		newERCVersionedEntry.setBlob(newBlobBlob);
 
 		_ercVersionedEntries.add(_persistence.update(newERCVersionedEntry));
+
+		Session session = _persistence.openSession();
+
+		session.flush();
+
+		session.clear();
 
 		ERCVersionedEntry existingERCVersionedEntry =
 			_persistence.findByPrimaryKey(newERCVersionedEntry.getPrimaryKey());
@@ -156,6 +175,12 @@ public class ERCVersionedEntryPersistenceTest {
 		Assert.assertEquals(
 			existingERCVersionedEntry.getCompanyId(),
 			newERCVersionedEntry.getCompanyId());
+		Blob existingBlob = existingERCVersionedEntry.getBlob();
+
+		Assert.assertTrue(
+			Arrays.equals(
+				existingBlob.getBytes(1, (int)existingBlob.length()),
+				newBlobBytes));
 	}
 
 	@Test
@@ -174,6 +199,7 @@ public class ERCVersionedEntryPersistenceTest {
 		draftERCVersionedEntry.setHeadId(-ercVersionedEntry.getHeadId());
 		draftERCVersionedEntry.setGroupId(ercVersionedEntry.getGroupId());
 		draftERCVersionedEntry.setCompanyId(ercVersionedEntry.getCompanyId());
+		draftERCVersionedEntry.setBlob(ercVersionedEntry.getBlob());
 
 		_ercVersionedEntries.add(_persistence.update(draftERCVersionedEntry));
 
@@ -193,6 +219,13 @@ public class ERCVersionedEntryPersistenceTest {
 		Assert.assertEquals(
 			ercVersionedEntry.getCompanyId(),
 			draftERCVersionedEntry.getCompanyId());
+		Blob Blob = ercVersionedEntry.getBlob();
+		Blob draftBlob = draftERCVersionedEntry.getBlob();
+
+		Assert.assertTrue(
+			Arrays.equals(
+				Blob.getBytes(1, (int)Blob.length()),
+				draftBlob.getBytes(1, (int)draftBlob.length())));
 	}
 
 	@Test(
@@ -219,6 +252,14 @@ public class ERCVersionedEntryPersistenceTest {
 		ercVersionedEntry2.setGroupId(ercVersionedEntry1.getGroupId());
 
 		ercVersionedEntry2.setCompanyId(RandomTestUtil.nextLong());
+		String blobString = RandomTestUtil.randomString();
+
+		byte[] blobBytes = blobString.getBytes("UTF-8");
+
+		Blob blobBlob = new OutputBlob(
+			new ByteArrayInputStream(blobBytes), blobBytes.length);
+
+		ercVersionedEntry2.setBlob(blobBlob);
 
 		_ercVersionedEntries.add(_persistence.update(ercVersionedEntry2));
 	}
@@ -683,6 +724,14 @@ public class ERCVersionedEntryPersistenceTest {
 		ercVersionedEntry.setGroupId(RandomTestUtil.nextLong());
 
 		ercVersionedEntry.setCompanyId(RandomTestUtil.nextLong());
+		String blobString = RandomTestUtil.randomString();
+
+		byte[] blobBytes = blobString.getBytes("UTF-8");
+
+		Blob blobBlob = new OutputBlob(
+			new ByteArrayInputStream(blobBytes), blobBytes.length);
+
+		ercVersionedEntry.setBlob(blobBlob);
 
 		_ercVersionedEntries.add(_persistence.update(ercVersionedEntry));
 
@@ -695,4 +744,4 @@ public class ERCVersionedEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:696240845
+// LIFERAY-SERVICE-BUILDER-HASH:2008175139

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCVersionedEntryVersionPersistenceTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/test/ERCVersionedEntryVersionPersistenceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.tools.service.builder.test.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.dao.jdbc.OutputBlob;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQueryFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.ProjectionFactoryUtil;
@@ -26,9 +27,13 @@ import com.liferay.portal.tools.service.builder.test.model.ERCVersionedEntryVers
 import com.liferay.portal.tools.service.builder.test.service.persistence.ERCVersionedEntryVersionPersistence;
 import com.liferay.portal.tools.service.builder.test.service.persistence.ERCVersionedEntryVersionUtil;
 
+import java.io.ByteArrayInputStream;
 import java.io.Serializable;
 
+import java.sql.Blob;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -130,9 +135,23 @@ public class ERCVersionedEntryVersionPersistenceTest {
 		newERCVersionedEntryVersion.setGroupId(RandomTestUtil.nextLong());
 
 		newERCVersionedEntryVersion.setCompanyId(RandomTestUtil.nextLong());
+		String newBlobString = RandomTestUtil.randomString();
+
+		byte[] newBlobBytes = newBlobString.getBytes("UTF-8");
+
+		Blob newBlobBlob = new OutputBlob(
+			new ByteArrayInputStream(newBlobBytes), newBlobBytes.length);
+
+		newERCVersionedEntryVersion.setBlob(newBlobBlob);
 
 		_ercVersionedEntryVersions.add(
 			_persistence.update(newERCVersionedEntryVersion));
+
+		Session session = _persistence.openSession();
+
+		session.flush();
+
+		session.clear();
 
 		ERCVersionedEntryVersion existingERCVersionedEntryVersion =
 			_persistence.findByPrimaryKey(
@@ -159,6 +178,12 @@ public class ERCVersionedEntryVersionPersistenceTest {
 		Assert.assertEquals(
 			existingERCVersionedEntryVersion.getCompanyId(),
 			newERCVersionedEntryVersion.getCompanyId());
+		Blob existingBlob = existingERCVersionedEntryVersion.getBlob();
+
+		Assert.assertTrue(
+			Arrays.equals(
+				existingBlob.getBytes(1, (int)existingBlob.length()),
+				newBlobBytes));
 	}
 
 	@Test
@@ -583,6 +608,14 @@ public class ERCVersionedEntryVersionPersistenceTest {
 		ercVersionedEntryVersion.setGroupId(RandomTestUtil.nextLong());
 
 		ercVersionedEntryVersion.setCompanyId(RandomTestUtil.nextLong());
+		String blobString = RandomTestUtil.randomString();
+
+		byte[] blobBytes = blobString.getBytes("UTF-8");
+
+		Blob blobBlob = new OutputBlob(
+			new ByteArrayInputStream(blobBytes), blobBytes.length);
+
+		ercVersionedEntryVersion.setBlob(blobBlob);
 
 		_ercVersionedEntryVersions.add(
 			_persistence.update(ercVersionedEntryVersion));
@@ -596,4 +629,4 @@ public class ERCVersionedEntryVersionPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-46805671
+// LIFERAY-SERVICE-BUILDER-HASH:-594888191

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_test.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_test.ftl
@@ -385,7 +385,7 @@ public class ${entity.name}PersistenceTest {
 							Blob ${entityColumn.methodName} = ${entity.variableName}.get${entityColumn.methodName}();
 							Blob draft${entityColumn.methodName} = draft${entity.name}.get${entityColumn.methodName}();
 
-							Assert.assertTrue(Arrays.equals(${entityColumn.variableName}.getBytes(1, (int)${entityColumn.variableName}.length()), Arrays.equals(draft${entityColumn.name}.getBytes(1, (int)draft${entityColumn.name}.length()));
+							Assert.assertTrue(Arrays.equals(${entityColumn.methodName}.getBytes(1, (int)${entityColumn.methodName}.length()), draft${entityColumn.methodName}.getBytes(1, (int)draft${entityColumn.methodName}.length())));
 						<#elseif stringUtil.equals(entityColumn.type, "boolean")>
 							Assert.assertEquals(${entity.variableName}.is${entityColumn.methodName}(), draft${entity.name}.is${entityColumn.methodName}());
 						<#elseif stringUtil.equals(entityColumn.type, "Date")>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90963

**What is being fixed:** The Blob branch of `testCreateDraft` in `persistence_test.ftl` emitted non-compilable Java: a stray inner `Arrays.equals(` call, identifiers that did not match the locals declared two lines above, and unbalanced parentheses. The bug stayed latent since LPD-26381 (2024-05-29) because no entity in the repository combined `external-reference-code`, `versioned="true"`, and a Blob column — the three preconditions needed for this branch to render.

**How it is being fixed:** The broken line is replaced with a single well-formed `Assert.assertTrue(Arrays.equals(...))` call that uses the `${entityColumn.methodName}` identifiers already declared above. To lock in regression coverage and verify the fix end-to-end, a Blob column is added to `ERCVersionedEntry` in `portal-tools-service-builder-test-service` — the only entity in the repository now satisfying all three preconditions. The accompanying Service Builder regeneration produces a `*PersistenceTest.java` that compiles, and a portal-wide `buildService` confirms no other module is affected.