### PR TITLE
LPD-89993 LPD-90754

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/display/template/IGPortletDisplayTemplateHandler.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/display/template/IGPortletDisplayTemplateHandler.java
@@ -19,12 +19,14 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.template.TemplateHandler;
 import com.liferay.portal.kernel.template.TemplateVariableGroup;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portlet.display.template.BasePortletDisplayTemplateHandler;
 import com.liferay.portlet.display.template.constants.PortletDisplayTemplateConstants;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -52,7 +54,10 @@ public class IGPortletDisplayTemplateHandler
 
 	@Override
 	public Map<String, Object> getCustomContextObjects() {
-		Map<String, Object> contextObjects = new HashMap<>();
+		Map<String, Object> contextObjects = HashMapBuilder.<String, Object>put(
+			"dlFileEntryPreviewImageMimeTypes",
+			PropsUtil.getArray(PropsKeys.DL_FILE_ENTRY_PREVIEW_IMAGE_MIME_TYPES)
+		).build();
 
 		try {
 			contextObjects.put("dlUtil", DLUtil.getDL());

--- a/modules/apps/document-library/document-library-web/src/main/resources/com/liferay/document/library/web/portlet/display/template/dependencies/portlet_display_template_carousel.ftl
+++ b/modules/apps/document-library/document-library-web/src/main/resources/com/liferay/document/library/web/portlet/display/template/dependencies/portlet_display_template_carousel.ftl
@@ -15,10 +15,8 @@
 	</style>
 
 	<div id="<@portlet.namespace />carousel">
-		<#assign imageMimeTypes = propsUtil.getArray("dl.file.entry.preview.image.mime.types") />
-
 		<#list entries as entry>
-			<#if imageMimeTypes?seq_contains(entry.getMimeType())>
+			<#if dlFileEntryPreviewImageMimeTypes?seq_contains(entry.getMimeType())>
 				<div class="carousel-item image-viewer-base-image">
 					<img alt="${htmlUtil.escapeAttribute(entry.getDescription())}" src="${dlUtil.getPreviewURL(entry, entry.getFileVersion(), themeDisplay, "")}" />
 				</div>

--- a/modules/apps/document-library/document-library-web/src/main/resources/com/liferay/document/library/web/template/dependencies/portlet_display_template_carousel.ftl
+++ b/modules/apps/document-library/document-library-web/src/main/resources/com/liferay/document/library/web/template/dependencies/portlet_display_template_carousel.ftl
@@ -15,10 +15,8 @@
 	</style>
 
 	<div id="<@portlet.namespace />carousel">
-		<#assign imageMimeTypes = propsUtil.getArray("dl.file.entry.preview.image.mime.types") />
-
 		<#list entries as entry>
-			<#if imageMimeTypes?seq_contains(entry.getMimeType())>
+			<#if dlFileEntryPreviewImageMimeTypes?seq_contains(entry.getMimeType())>
 				<div class="carousel-item image-viewer-base-image">
 					<img src="${dlUtil.getPreviewURL(entry, entry.getFileVersion(), themeDisplay, "")}" />
 				</div>

--- a/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/configuration/FreeMarkerEngineConfiguration.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/configuration/FreeMarkerEngineConfiguration.java
@@ -79,7 +79,7 @@ public interface FreeMarkerEngineConfiguration {
 	public String[] restrictedMethods();
 
 	@Meta.AD(
-		deflt = "httpUtil|httpUtilUnsafe|objectUtil|propsUtil|serviceLocator|staticFieldGetter|staticUtil",
+		deflt = "httpUtil|httpUtilUnsafe|objectUtil|portletConfig|propsUtil|serviceLocator|staticFieldGetter|staticUtil",
 		name = "restricted-variables", required = false
 	)
 	public String[] restrictedVariables();

--- a/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/configuration/FreeMarkerEngineConfiguration.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/configuration/FreeMarkerEngineConfiguration.java
@@ -79,7 +79,7 @@ public interface FreeMarkerEngineConfiguration {
 	public String[] restrictedMethods();
 
 	@Meta.AD(
-		deflt = "httpUtil|httpUtilUnsafe|objectUtil|serviceLocator|staticFieldGetter|staticUtil",
+		deflt = "httpUtil|httpUtilUnsafe|objectUtil|propsUtil|serviceLocator|staticFieldGetter|staticUtil",
 		name = "restricted-variables", required = false
 	)
 	public String[] restrictedVariables();

--- a/modules/apps/portal-template/portal-template-test/src/testIntegration/java/com/liferay/portal/template/test/TemplateContextHelperTest.java
+++ b/modules/apps/portal-template/portal-template-test/src/testIntegration/java/com/liferay/portal/template/test/TemplateContextHelperTest.java
@@ -11,13 +11,18 @@ import com.liferay.expando.kernel.service.ExpandoRowLocalService;
 import com.liferay.expando.kernel.service.ExpandoTableLocalService;
 import com.liferay.expando.kernel.service.ExpandoValueLocalService;
 import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.template.StringTemplateResource;
+import com.liferay.portal.kernel.template.Template;
+import com.liferay.portal.kernel.template.TemplateManager;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.template.ServiceLocator;
 import com.liferay.portal.template.engine.TemplateContextHelper;
@@ -27,15 +32,22 @@ import java.io.InputStream;
 
 import java.net.URL;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
 
 import org.springframework.mock.web.MockHttpServletRequest;
 
@@ -202,5 +214,49 @@ public class TemplateContextHelperTest {
 		Assert.assertEquals(
 			" nonce=\"TEST_NONCE\"", contextObjects.get("nonceAttribute"));
 	}
+
+	@Test
+	public void testSensitiveVariablesNotAccessibleInRestrictedTemplateContext()
+		throws Exception {
+
+		Bundle bundle = FrameworkUtil.getBundle(
+			TemplateContextHelperTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		Collection<ServiceReference<TemplateManager>> serviceReferences =
+			bundleContext.getServiceReferences(TemplateManager.class, null);
+
+		Assert.assertFalse(serviceReferences.isEmpty());
+
+		for (ServiceReference<TemplateManager> serviceReference :
+				serviceReferences) {
+
+			TemplateManager templateManager = bundleContext.getService(
+				serviceReference);
+
+			try {
+				Template template = templateManager.getTemplate(
+					new StringTemplateResource("test", "x"), true);
+
+				for (String sensitiveVariable : _sensitiveVariables) {
+					template.put(sensitiveVariable, new Object());
+
+					Assert.assertFalse(
+						StringBundler.concat(
+							sensitiveVariable, " accessible in ",
+							templateManager.getName()),
+						template.containsKey(sensitiveVariable));
+				}
+			}
+			finally {
+				bundleContext.ungetService(serviceReference);
+			}
+		}
+	}
+
+	private static final Set<String> _sensitiveVariables = SetUtil.fromArray(
+		"httpUtil", "httpUtilUnsafe", "portletConfig", "propsUtil",
+		"serviceLocator", "staticFieldGetter");
 
 }

--- a/modules/apps/portal-template/portal-template-test/src/testIntegration/java/com/liferay/portal/template/test/TemplateContextHelperTest.java
+++ b/modules/apps/portal-template/portal-template-test/src/testIntegration/java/com/liferay/portal/template/test/TemplateContextHelperTest.java
@@ -11,18 +11,13 @@ import com.liferay.expando.kernel.service.ExpandoRowLocalService;
 import com.liferay.expando.kernel.service.ExpandoTableLocalService;
 import com.liferay.expando.kernel.service.ExpandoValueLocalService;
 import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.template.StringTemplateResource;
-import com.liferay.portal.kernel.template.Template;
-import com.liferay.portal.kernel.template.TemplateManager;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.ProxyUtil;
-import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.template.ServiceLocator;
 import com.liferay.portal.template.engine.TemplateContextHelper;
@@ -32,22 +27,15 @@ import java.io.InputStream;
 
 import java.net.URL;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.ServiceReference;
 
 import org.springframework.mock.web.MockHttpServletRequest;
 
@@ -214,49 +202,5 @@ public class TemplateContextHelperTest {
 		Assert.assertEquals(
 			" nonce=\"TEST_NONCE\"", contextObjects.get("nonceAttribute"));
 	}
-
-	@Test
-	public void testSensitiveVariablesNotAccessibleInRestrictedTemplateContext()
-		throws Exception {
-
-		Bundle bundle = FrameworkUtil.getBundle(
-			TemplateContextHelperTest.class);
-
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		Collection<ServiceReference<TemplateManager>> serviceReferences =
-			bundleContext.getServiceReferences(TemplateManager.class, null);
-
-		Assert.assertFalse(serviceReferences.isEmpty());
-
-		for (ServiceReference<TemplateManager> serviceReference :
-				serviceReferences) {
-
-			TemplateManager templateManager = bundleContext.getService(
-				serviceReference);
-
-			try {
-				Template template = templateManager.getTemplate(
-					new StringTemplateResource("test", "x"), true);
-
-				for (String sensitiveVariable : _sensitiveVariables) {
-					template.put(sensitiveVariable, new Object());
-
-					Assert.assertFalse(
-						StringBundler.concat(
-							sensitiveVariable, " accessible in ",
-							templateManager.getName()),
-						template.containsKey(sensitiveVariable));
-				}
-			}
-			finally {
-				bundleContext.ungetService(serviceReference);
-			}
-		}
-	}
-
-	private static final Set<String> _sensitiveVariables = SetUtil.fromArray(
-		"httpUtil", "httpUtilUnsafe", "portletConfig", "propsUtil",
-		"serviceLocator", "staticFieldGetter");
 
 }

--- a/modules/apps/portal-template/portal-template-test/src/testIntegration/java/com/liferay/portal/template/test/TemplateRestrictedVariablesTest.java
+++ b/modules/apps/portal-template/portal-template-test/src/testIntegration/java/com/liferay/portal/template/test/TemplateRestrictedVariablesTest.java
@@ -1,0 +1,102 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.template.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.template.StringTemplateResource;
+import com.liferay.portal.kernel.template.Template;
+import com.liferay.portal.kernel.template.TemplateManager;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Collection;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+
+/**
+ * @author Dante Wang
+ * @author Debora Buriti
+ */
+@RunWith(Arquillian.class)
+public class TemplateRestrictedVariablesTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void test() throws Exception {
+		Bundle bundle = FrameworkUtil.getBundle(
+			TemplateContextHelperTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		Collection<ServiceReference<TemplateManager>> serviceReferences =
+			bundleContext.getServiceReferences(TemplateManager.class, null);
+
+		Assert.assertFalse(serviceReferences.isEmpty());
+
+		for (ServiceReference<TemplateManager> serviceReference :
+				serviceReferences) {
+
+			TemplateManager templateManager = bundleContext.getService(
+				serviceReference);
+
+			String[] restrictedVariables =
+				templateManager.getRestrictedVariables();
+
+			Assert.assertTrue(
+				ArrayUtil.containsAll(
+					restrictedVariables, _RESTRICTED_VARIABLES));
+
+			try {
+				Template template = templateManager.getTemplate(
+					new StringTemplateResource(
+						RandomTestUtil.randomString(),
+						RandomTestUtil.randomString()),
+					true);
+
+				for (String restrictedVariable : restrictedVariables) {
+					Assert.assertFalse(
+						StringBundler.concat(
+							restrictedVariable, " accessible in ",
+							templateManager.getName()),
+						template.containsKey(restrictedVariable));
+
+					template.put(restrictedVariable, new Object());
+
+					Assert.assertFalse(
+						StringBundler.concat(
+							restrictedVariable, " accessible in ",
+							templateManager.getName()),
+						template.containsKey(restrictedVariable));
+				}
+			}
+			finally {
+				bundleContext.ungetService(serviceReference);
+			}
+		}
+	}
+
+	private static final String[] _RESTRICTED_VARIABLES = {
+		"httpUtil", "httpUtilUnsafe", "portletConfig", "propsUtil",
+		"serviceLocator", "staticFieldGetter"
+	};
+
+}

--- a/modules/apps/portal-template/portal-template-velocity/src/main/java/com/liferay/portal/template/velocity/configuration/VelocityEngineConfiguration.java
+++ b/modules/apps/portal-template/portal-template-velocity/src/main/java/com/liferay/portal/template/velocity/configuration/VelocityEngineConfiguration.java
@@ -63,7 +63,7 @@ public interface VelocityEngineConfiguration {
 	public String[] restrictedPackages();
 
 	@Meta.AD(
-		deflt = "httpUtil|httpUtilUnsafe|propsUtil|serviceLocator|staticFieldGetter",
+		deflt = "httpUtil|httpUtilUnsafe|portletConfig|propsUtil|serviceLocator|staticFieldGetter",
 		name = "restricted-variables", required = false
 	)
 	public String[] restrictedVariables();

--- a/modules/apps/portal-template/portal-template-velocity/src/main/java/com/liferay/portal/template/velocity/configuration/VelocityEngineConfiguration.java
+++ b/modules/apps/portal-template/portal-template-velocity/src/main/java/com/liferay/portal/template/velocity/configuration/VelocityEngineConfiguration.java
@@ -63,7 +63,7 @@ public interface VelocityEngineConfiguration {
 	public String[] restrictedPackages();
 
 	@Meta.AD(
-		deflt = "httpUtil|httpUtilUnsafe|serviceLocator|staticFieldGetter",
+		deflt = "httpUtil|httpUtilUnsafe|propsUtil|serviceLocator|staticFieldGetter",
 		name = "restricted-variables", required = false
 	)
 	public String[] restrictedVariables();

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/dependencies/adt_media_gallery_carousel.ftl
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/dependencies/adt_media_gallery_carousel.ftl
@@ -15,10 +15,8 @@
 	</style>
 
 	<div id="<@portlet.namespace />carousel">
-		<#assign imageMimeTypes = propsUtil.getArray("dl.file.entry.preview.image.mime.types") />
-
 		<#list entries as entry>
-			<#if imageMimeTypes?seq_contains(entry.getMimeType())>
+			<#if dlFileEntryPreviewImageMimeTypes?seq_contains(entry.getMimeType())>
 				<div class="carousel-item image-viewer-base-image">
 					<img src="${dlUtil.getPreviewURL(entry, entry.getFileVersion(), themeDisplay, "")}" />
 				</div>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89993 - Restrict propsUtil in template engines

propsUtil exposes portal configuration properties, including sensitive values like database credentials, to template authors in Web Content and widget templates.
This PR adds the service to the default restricted-variables list for both the FreeMarker and Velocity engines.
The carousel ADT in document-library-web relied on propsUtil to retrieve the list of supported image MIME types. Since propsUtil is now restricted, those values are injected directly into the template context instead.

https://liferay.atlassian.net/browse/LPD-90754 - Restrict portletConfig in template engines

portletConfig exposes the Tomcat InstanceManager through the portlet context, allowing template authors to instantiate arbitrary Java classes and enabling arbitrary file reads and JSP webshell deployment for remote code execution.
This PR Adds portletConfig to the default restricted-variables list for both the FreeMarker and Velocity engines.