### PR TITLE
LPD-85611 Honor explicit deprecation flag overrides on company creation

### DIFF
--- a/modules/apps/feature-flag/feature-flag-test/src/testIntegration/java/com/liferay/feature/flag/test/CompanyModelListenerTest.java
+++ b/modules/apps/feature-flag/feature-flag-test/src/testIntegration/java/com/liferay/feature/flag/test/CompanyModelListenerTest.java
@@ -94,6 +94,10 @@ public class CompanyModelListenerTest {
 				CompanyConstants.SYSTEM,
 				FeatureFlagType.DEPRECATION.getPredicate());
 
+		Assert.assertFalse(
+			"No deprecation feature flags were found to test",
+			deprecationFeatureFlags.isEmpty());
+
 		for (FeatureFlag deprecationFeatureFlag : deprecationFeatureFlags) {
 			Assert.assertEquals(
 				StringBundler.concat(

--- a/modules/apps/feature-flag/feature-flag-test/src/testIntegration/java/com/liferay/feature/flag/test/CompanyModelListenerTest.java
+++ b/modules/apps/feature-flag/feature-flag-test/src/testIntegration/java/com/liferay/feature/flag/test/CompanyModelListenerTest.java
@@ -6,6 +6,7 @@
 package com.liferay.feature.flag.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.feature.flag.FeatureFlag;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManager;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagType;
@@ -16,7 +17,9 @@ import com.liferay.portal.kernel.portlet.PortalPreferences;
 import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portlet.PortalPreferencesWrapper;
@@ -79,6 +82,29 @@ public class CompanyModelListenerTest {
 					FeatureFlagConstants.PREFERENCE_NAMESPACE,
 					deprecationFeatureFlag.getKey()));
 			Assert.assertFalse(deprecationFeatureFlag.isEnabled());
+		}
+	}
+
+	@Test
+	public void testSystemDeprecationFeatureFlagsRespectPortalProperties()
+		throws Exception {
+
+		List<FeatureFlag> deprecationFeatureFlags =
+			_featureFlagManager.getFeatureFlags(
+				CompanyConstants.SYSTEM,
+				FeatureFlagType.DEPRECATION.getPredicate());
+
+		for (FeatureFlag deprecationFeatureFlag : deprecationFeatureFlags) {
+			Assert.assertEquals(
+				StringBundler.concat(
+					"System deprecation feature flag ",
+					deprecationFeatureFlag.getKey(),
+					" must reflect its portal.properties value (and any ",
+					"portal-ext.properties or LIFERAY_* env override)"),
+				GetterUtil.getBoolean(
+					PropsUtil.get(
+						"feature.flag." + deprecationFeatureFlag.getKey())),
+				deprecationFeatureFlag.isEnabled());
 		}
 	}
 

--- a/modules/apps/feature-flag/feature-flag-test/src/testIntegration/java/com/liferay/feature/flag/test/CompanyModelListenerTest.java
+++ b/modules/apps/feature-flag/feature-flag-test/src/testIntegration/java/com/liferay/feature/flag/test/CompanyModelListenerTest.java
@@ -6,7 +6,6 @@
 package com.liferay.feature.flag.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.feature.flag.FeatureFlag;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManager;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagType;
@@ -16,6 +15,7 @@ import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
 import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
@@ -60,19 +60,25 @@ public class CompanyModelListenerTest {
 				FeatureFlagConstants.PREFERENCE_NAMESPACE,
 				FeatureFlagConstants.PREFERENCE_KEY_DEPRECATION_PROCESSED));
 
-		Company company = CompanyTestUtil.addCompany();
+		_company1 = CompanyTestUtil.addCompany();
 
 		portalPreferencesWrapper =
 			(PortalPreferencesWrapper)
 				_portalPreferencesLocalService.getPreferences(
-					company.getCompanyId(),
+					_company1.getCompanyId(),
 					PortletKeys.PREFS_OWNER_TYPE_COMPANY);
 
 		portalPreferences = portalPreferencesWrapper.getPortalPreferencesImpl();
 
+		Assert.assertEquals(
+			"true",
+			portalPreferences.getValue(
+				FeatureFlagConstants.PREFERENCE_NAMESPACE,
+				FeatureFlagConstants.PREFERENCE_KEY_DEPRECATION_PROCESSED));
+
 		List<FeatureFlag> deprecationFeatureFlags =
 			_featureFlagManager.getFeatureFlags(
-				company.getCompanyId(),
+				_company1.getCompanyId(),
 				FeatureFlagType.DEPRECATION.getPredicate());
 
 		for (FeatureFlag deprecationFeatureFlag : deprecationFeatureFlags) {
@@ -86,7 +92,45 @@ public class CompanyModelListenerTest {
 	}
 
 	@Test
-	public void testSystemDeprecationFeatureFlagsRespectPortalProperties()
+	public void testNewCompanyHonorsDeprecationFeatureFlagOverrides()
+		throws Exception {
+
+		_company1 = CompanyTestUtil.addCompany();
+
+		List<FeatureFlag> deprecationFeatureFlags =
+			_featureFlagManager.getFeatureFlags(
+				_company1.getCompanyId(),
+				FeatureFlagType.DEPRECATION.getPredicate());
+
+		Assert.assertFalse(
+			deprecationFeatureFlags.toString(),
+			deprecationFeatureFlags.isEmpty());
+
+		FeatureFlag deprecationFeatureFlag = deprecationFeatureFlags.get(0);
+
+		String key = deprecationFeatureFlag.getKey();
+
+		Assert.assertFalse(
+			key, _featureFlagManager.isEnabled(_company1.getCompanyId(), key));
+
+		String propertyKey = FeatureFlagConstants.getKey(key);
+
+		System.setProperty(propertyKey, "true");
+
+		try {
+			_company2 = CompanyTestUtil.addCompany();
+
+			Assert.assertTrue(
+				key,
+				_featureFlagManager.isEnabled(_company2.getCompanyId(), key));
+		}
+		finally {
+			System.clearProperty(propertyKey);
+		}
+	}
+
+	@Test
+	public void testSystemHonorsDeprecationFeatureFlagOverrides()
 		throws Exception {
 
 		List<FeatureFlag> deprecationFeatureFlags =
@@ -95,22 +139,32 @@ public class CompanyModelListenerTest {
 				FeatureFlagType.DEPRECATION.getPredicate());
 
 		Assert.assertFalse(
-			"No deprecation feature flags were found to test",
+			deprecationFeatureFlags.toString(),
 			deprecationFeatureFlags.isEmpty());
 
 		for (FeatureFlag deprecationFeatureFlag : deprecationFeatureFlags) {
+			String propertyKey = FeatureFlagConstants.getKey(
+				deprecationFeatureFlag.getKey());
+
+			boolean expected = false;
+
+			if (PropsUtil.isOverridden(propertyKey) &&
+				GetterUtil.getBoolean(PropsUtil.get(propertyKey))) {
+
+				expected = true;
+			}
+
 			Assert.assertEquals(
-				StringBundler.concat(
-					"System deprecation feature flag ",
-					deprecationFeatureFlag.getKey(),
-					" must reflect its portal.properties value (and any ",
-					"portal-ext.properties or LIFERAY_* env override)"),
-				GetterUtil.getBoolean(
-					PropsUtil.get(
-						"feature.flag." + deprecationFeatureFlag.getKey())),
+				deprecationFeatureFlag.getKey(), expected,
 				deprecationFeatureFlag.isEnabled());
 		}
 	}
+
+	@DeleteAfterTestRun
+	private Company _company1;
+
+	@DeleteAfterTestRun
+	private Company _company2;
 
 	@Inject
 	private FeatureFlagManager _featureFlagManager;

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/model/listener/CompanyModelListener.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portlet.PortalPreferencesWrapper;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -41,7 +42,8 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 	public void onAfterCreate(Company company) throws ModelListenerException {
 		TransactionCommitCallbackUtil.registerCallback(
 			() -> {
-				_processDeprecationFeatureFlags(company.getCompanyId());
+				_processDeprecationFeatureFlagsForCompany(
+					company.getCompanyId());
 
 				return null;
 			});
@@ -50,11 +52,11 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 	@Activate
 	protected void activate() {
 		if (StartupHelperUtil.isDBNew()) {
-			_processDeprecationFeatureFlags(CompanyConstants.SYSTEM);
+			_processDeprecationFeatureFlagsForSystem();
 		}
 
 		_companyLocalService.forEachCompanyId(
-			this::_processDeprecationFeatureFlags);
+			this::_processDeprecationFeatureFlagsForCompany);
 	}
 
 	private PortalPreferences _getPortalPreferences(long companyId) {
@@ -66,7 +68,9 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 		return portalPreferencesWrapper.getPortalPreferencesImpl();
 	}
 
-	private void _processDeprecationFeatureFlags(long companyId) {
+	private void _processDeprecationFeatureFlags(
+		long companyId, Predicate<FeatureFlag> enabledPredicate) {
+
 		PortalPreferences portalPreferences = _getPortalPreferences(companyId);
 
 		boolean processed = GetterUtil.getBoolean(
@@ -87,7 +91,8 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 
 		for (FeatureFlag deprecationFeatureFlag : deprecationFeatureFlags) {
 			_featureFlagsBagProvider.setEnabled(
-				companyId, deprecationFeatureFlag.getKey(), false);
+				companyId, deprecationFeatureFlag.getKey(),
+				enabledPredicate.test(deprecationFeatureFlag));
 		}
 
 		portalPreferences = _getPortalPreferences(companyId);
@@ -98,6 +103,16 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 
 		_portalPreferencesLocalService.updatePreferences(
 			companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY, portalPreferences);
+	}
+
+	private void _processDeprecationFeatureFlagsForCompany(long companyId) {
+		_processDeprecationFeatureFlags(
+			companyId, deprecationFeatureFlag -> false);
+	}
+
+	private void _processDeprecationFeatureFlagsForSystem() {
+		_processDeprecationFeatureFlags(
+			CompanyConstants.SYSTEM, FeatureFlag::isEnabled);
 	}
 
 	@Reference

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/model/listener/CompanyModelListener.java
@@ -22,10 +22,10 @@ import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portlet.PortalPreferencesWrapper;
 
 import java.util.List;
-import java.util.function.Predicate;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -42,8 +42,7 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 	public void onAfterCreate(Company company) throws ModelListenerException {
 		TransactionCommitCallbackUtil.registerCallback(
 			() -> {
-				_processDeprecationFeatureFlagsForCompany(
-					company.getCompanyId());
+				_processDeprecationFeatureFlags(company.getCompanyId());
 
 				return null;
 			});
@@ -52,11 +51,11 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 	@Activate
 	protected void activate() {
 		if (StartupHelperUtil.isDBNew()) {
-			_processDeprecationFeatureFlagsForSystem();
+			_processDeprecationFeatureFlags(CompanyConstants.SYSTEM);
 		}
 
 		_companyLocalService.forEachCompanyId(
-			this::_processDeprecationFeatureFlagsForCompany);
+			this::_processDeprecationFeatureFlags);
 	}
 
 	private PortalPreferences _getPortalPreferences(long companyId) {
@@ -68,9 +67,7 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 		return portalPreferencesWrapper.getPortalPreferencesImpl();
 	}
 
-	private void _processDeprecationFeatureFlags(
-		long companyId, Predicate<FeatureFlag> enabledPredicate) {
-
+	private void _processDeprecationFeatureFlags(long companyId) {
 		PortalPreferences portalPreferences = _getPortalPreferences(companyId);
 
 		boolean processed = GetterUtil.getBoolean(
@@ -90,9 +87,17 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 				FeatureFlagType.DEPRECATION.getPredicate());
 
 		for (FeatureFlag deprecationFeatureFlag : deprecationFeatureFlags) {
-			_featureFlagsBagProvider.setEnabled(
-				companyId, deprecationFeatureFlag.getKey(),
-				enabledPredicate.test(deprecationFeatureFlag));
+			String key = deprecationFeatureFlag.getKey();
+
+			boolean enabled = false;
+
+			if (PropsUtil.isOverridden(FeatureFlagConstants.getKey(key)) &&
+				deprecationFeatureFlag.isEnabled()) {
+
+				enabled = true;
+			}
+
+			_featureFlagsBagProvider.setEnabled(companyId, key, enabled);
 		}
 
 		portalPreferences = _getPortalPreferences(companyId);
@@ -103,16 +108,6 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 
 		_portalPreferencesLocalService.updatePreferences(
 			companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY, portalPreferences);
-	}
-
-	private void _processDeprecationFeatureFlagsForCompany(long companyId) {
-		_processDeprecationFeatureFlags(
-			companyId, deprecationFeatureFlag -> false);
-	}
-
-	private void _processDeprecationFeatureFlagsForSystem() {
-		_processDeprecationFeatureFlags(
-			CompanyConstants.SYSTEM, FeatureFlag::isEnabled);
 	}
 
 	@Reference

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 184.0.1
+Bundle-Version: 185.0.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/configuration/Configuration.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/configuration/Configuration.java
@@ -31,6 +31,8 @@ public interface Configuration {
 
 	public Properties getProperties(String prefix, boolean removePrefix);
 
+	public boolean isOverridden(String key);
+
 	public void set(String key, String value);
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/configuration/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/configuration/packageinfo
@@ -1,1 +1,1 @@
-version 9.0.0
+version 10.0.0

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/configuration/ClassLoaderAggregateProperties.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/configuration/ClassLoaderAggregateProperties.java
@@ -23,10 +23,12 @@ import java.net.URL;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import org.apache.commons.configuration.AbstractFileConfiguration;
 import org.apache.commons.configuration.CompositeConfiguration;
@@ -151,13 +153,18 @@ public class ClassLoaderAggregateProperties extends CompositeConfiguration {
 		return _loadedSources;
 	}
 
+	public Set<String> overriddenKeys() {
+		return _overriddenKeys;
+	}
+
 	private void _addBaseFileName(String fileName) {
 		URL url = _classLoader.getResource(fileName);
 
 		List<String> includeAndOverrides = new ArrayList<>();
 
 		Configuration configuration = _addPropertiesSource(
-			fileName, url, _baseCompositeConfiguration, includeAndOverrides);
+			fileName, url, _baseCompositeConfiguration, includeAndOverrides,
+			true);
 
 		if (configuration == null) {
 			throw new SystemException(
@@ -246,14 +253,14 @@ public class ClassLoaderAggregateProperties extends CompositeConfiguration {
 
 			_addPropertiesSource(
 				fileName, url, loadedCompositeConfiguration,
-				includeAndOverrides);
+				includeAndOverrides, false);
 		}
 	}
 
 	private Configuration _addPropertiesSource(
 		String sourceName, URL url,
 		CompositeConfiguration loadedCompositeConfiguration,
-		List<String> includeAndOverrides) {
+		List<String> includeAndOverrides, boolean base) {
 
 		try {
 			Configuration newConfiguration = null;
@@ -288,6 +295,14 @@ public class ClassLoaderAggregateProperties extends CompositeConfiguration {
 			}
 			else {
 				_loadedSources.add(sourceName);
+			}
+
+			if (!base) {
+				Iterator<String> keyIterator = newConfiguration.getKeys();
+
+				while (keyIterator.hasNext()) {
+					_overriddenKeys.add(keyIterator.next());
+				}
 			}
 
 			return newConfiguration;
@@ -430,6 +445,7 @@ public class ClassLoaderAggregateProperties extends CompositeConfiguration {
 	private final CompositeConfiguration _globalCompositeConfiguration =
 		new CompositeConfiguration();
 	private final List<String> _loadedSources = new ArrayList<>();
+	private final Set<String> _overriddenKeys = new HashSet<>();
 	private final String _prefix;
 	private final Configuration _prefixedSystemConfiguration;
 	private final SystemConfiguration _systemConfiguration =

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/configuration/ClassLoaderAggregateProperties.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/configuration/ClassLoaderAggregateProperties.java
@@ -164,7 +164,7 @@ public class ClassLoaderAggregateProperties extends CompositeConfiguration {
 
 		Configuration configuration = _addPropertiesSource(
 			fileName, url, _baseCompositeConfiguration, includeAndOverrides,
-			true);
+			false);
 
 		if (configuration == null) {
 			throw new SystemException(
@@ -253,14 +253,14 @@ public class ClassLoaderAggregateProperties extends CompositeConfiguration {
 
 			_addPropertiesSource(
 				fileName, url, loadedCompositeConfiguration,
-				includeAndOverrides, false);
+				includeAndOverrides, true);
 		}
 	}
 
 	private Configuration _addPropertiesSource(
 		String sourceName, URL url,
 		CompositeConfiguration loadedCompositeConfiguration,
-		List<String> includeAndOverrides, boolean base) {
+		List<String> includeAndOverrides, boolean override) {
 
 		try {
 			Configuration newConfiguration = null;
@@ -297,7 +297,7 @@ public class ClassLoaderAggregateProperties extends CompositeConfiguration {
 				_loadedSources.add(sourceName);
 			}
 
-			if (!base) {
+			if (override) {
 				Iterator<String> keyIterator = newConfiguration.getKeys();
 
 				while (keyIterator.hasNext()) {

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/configuration/ClassLoaderAggregatePropertiesUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/configuration/ClassLoaderAggregatePropertiesUtil.java
@@ -11,6 +11,8 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.EnvPropertiesUtil;
 import com.liferay.portal.kernel.util.SystemProperties;
 
+import java.util.Set;
+
 /**
  * @author Shuyang Zhou
  */
@@ -31,8 +33,16 @@ public class ClassLoaderAggregatePropertiesUtil {
 					classLoaderAggregateProperties.loadedSources()));
 		}
 
+		Set<String> overriddenKeys =
+			classLoaderAggregateProperties.overriddenKeys();
+
 		EnvPropertiesUtil.loadEnvOverrides(
-			_ENV_OVERRIDE_PREFIX, classLoaderAggregateProperties::setProperty);
+			_ENV_OVERRIDE_PREFIX,
+			(key, value) -> {
+				overriddenKeys.add(key);
+
+				classLoaderAggregateProperties.setProperty(key, value);
+			});
 
 		return classLoaderAggregateProperties;
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/configuration/ConfigurationImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/configuration/ConfigurationImpl.java
@@ -208,6 +208,18 @@ public class ConfigurationImpl implements Configuration {
 	}
 
 	@Override
+	public boolean isOverridden(String key) {
+		Set<String> overriddenKeys =
+			_classLoaderAggregateProperties.overriddenKeys();
+
+		if (overriddenKeys.contains(key) || (System.getProperty(key) != null)) {
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
 	public void set(String key, String value) {
 		_classLoaderAggregateProperties.setProperty(key, value);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsUtil.java
@@ -72,6 +72,10 @@ public class PropsUtil {
 		return _configuration.getProperties(prefix, removePrefix);
 	}
 
+	public static boolean isOverridden(String key) {
+		return _configuration.isOverridden(key);
+	}
+
 	public static void set(String key, String value) {
 		_configuration.set(key, value);
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsUtil_IW.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsUtil_IW.java
@@ -52,6 +52,10 @@ public class PropsUtil_IW {
 		return PropsUtil.getProperties(prefix, removePrefix);
 	}
 
+	public boolean isOverridden(java.lang.String key) {
+		return PropsUtil.isOverridden(key);
+	}
+
 	public void set(java.lang.String key, java.lang.String value) {
 		PropsUtil.set(key, value);
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 98.0.0
+version 98.1.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85611

## What is being fixed
LPD-80539 added a fresh-DB call to `_processDeprecationFeatureFlags(SYSTEM)` that wrote a hardcoded `false` into `PortalPreferences` for every deprecation feature flag. Because `PreferenceAwareFeatureFlag.isEnabled()` reads the stored preference before falling back to `PropsUtil`, that `false` silently masked any `portal-ext.properties` or `LIFERAY_*` env override at the system scope. The symmetric per-company path on `onAfterCreate` did the same thing — admin overrides ignored for newly created companies.

The previous PR (#1966) surfaced overrides at the system scope by writing `featureFlag.isEnabled()` instead of `false`, but that introduced an asymmetry (per-company path still ignored overrides) and effectively reverted the off-for-new  contract the deprecation feature flag documentation describes — since `isEnabled()` with no override resolves to the portal.properties default, which is `true` for all 27 deprecation flags.

  ## How it is being fixed

A new `Configuration.isOverridden(String key)` predicate distinguishes an explicit admin override (`portal-ext.properties`, `LIFERAY_*` env var, or `-D` JVM system property) from the hardcoded `portal.properties` default. Keys are recorded at load time in `ClassLoaderAggregateProperties` and exposed via `PropsUtil.isOverridden`; the  `com.liferay.portal.kernel.configuration` package version is bumped accordingly.

`CompanyModelListener` collapses its two scope-specific predicates into a single rule applied to both new-company creation and fresh-DB activation:

```java
PropsUtil.isOverridden(FeatureFlagConstants.getKey(key)) &&
      featureFlag.isEnabled()

  ┌──────────────┬────────────────────────────────────────┐
  │    Admin     │          Resulting preference          │
  │   override   │                                        │
  ├──────────────┼────────────────────────────────────────┤
  │ none         │ false (off-for-new — matches the       │
  │              │ documented default)                    │
  ├──────────────┼────────────────────────────────────────┤
  │ explicit     │ true                                   │
  │ true         │                                        │
  ├──────────────┼────────────────────────────────────────┤
  │ explicit     │ false                                  │
  │ false        │                                        │
  └──────────────┴────────────────────────────────────────┘
```

  A new `Configuration.isOverridden(String key)` predicate distinguishes an explicit admin override (`portal-ext.properties`, `LIFERAY_*` env var, or `-D` JVM system property) from the hardcoded `portal.properties` default. Keys are recorded at load time in `ClassLoaderAggregateProperties` and exposed via `PropsUtil.isOverridden`; the `com.liferay.portal.kernel.configuration` package version is bumped accordingly.

  `CompanyModelListener` collapses its two scope-specific predicates into a single rule applied to both new-company creation and fresh-DB activation:

  ```java
  PropsUtil.isOverridden(FeatureFlagConstants.getKey(key)) &&
      featureFlag.isEnabled()

  ┌────────────────┬──────────────────────────────────────────────────────┐
  │ Admin override │                 Resulting preference                 │
  ├────────────────┼──────────────────────────────────────────────────────┤
  │ none           │ false (off-for-new — matches the documented default) │
  ├────────────────┼──────────────────────────────────────────────────────┤
  │ explicit true  │ true                                                 │
  ├────────────────┼──────────────────────────────────────────────────────┤
  │ explicit false │ false                                                │
  └────────────────┴──────────────────────────────────────────────────────┘
```
  Both scopes now resolve the same conflict the same way: deprecation feature flags stay off out-of-the-box for new instances and new companies, but any portal-ext.properties, -D, or LIFERAY_* override is honored.