### PR TITLE
[LPP] LPD-78503

### DIFF
--- a/modules/apps/portlet/portlet-test/src/testIntegration/java/com/liferay/portlet/test/PortletLocalServiceTest.java
+++ b/modules/apps/portlet/portlet-test/src/testIntegration/java/com/liferay/portlet/test/PortletLocalServiceTest.java
@@ -9,10 +9,13 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.expando.kernel.model.BaseCustomAttributesDisplay;
 import com.liferay.expando.kernel.model.CustomAttributesDisplay;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -45,6 +48,32 @@ public class PortletLocalServiceTest {
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testFetchPortletById() throws Exception {
+		Bundle bundle = FrameworkUtil.getBundle(getClass());
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		String portletName = RandomTestUtil.randomString();
+
+		ServiceRegistration<Portlet> serviceRegistration =
+			bundleContext.registerService(
+				Portlet.class, new TestPortlet(),
+				HashMapDictionaryBuilder.<String, Object>put(
+					"com.liferay.portlet.instanceable", "true"
+				).put(
+					"jakarta.portlet.name", portletName
+				).build());
+
+		try {
+			_assertFetchPortletById(portletName, null);
+			_assertFetchPortletById(portletName, RandomTestUtil.randomString());
+		}
+		finally {
+			serviceRegistration.unregister();
+		}
+	}
 
 	@Test
 	public void testGetCustomAttributesDisplaysWithCustomAttributesDisplayDisabled()
@@ -133,6 +162,35 @@ public class PortletLocalServiceTest {
 				serviceRegistration.unregister();
 			}
 		}
+	}
+
+	private void _assertFetchPortletById(String portletName, String instanceId)
+		throws Exception {
+
+		String portletId = PortletIdCodec.encode(portletName, instanceId);
+
+		long companyId = TestPropsValues.getCompanyId();
+
+		com.liferay.portal.kernel.model.Portlet portlet =
+			_portletLocalService.fetchPortletById(companyId, portletId);
+
+		Assert.assertEquals(instanceId, portlet.getInstanceId());
+		Assert.assertEquals(portletId, portlet.getPortletId());
+		Assert.assertEquals(portletName, portlet.getPortletName());
+		Assert.assertTrue(portlet.isInstanceable());
+		Assert.assertFalse(portlet.isStatic());
+		Assert.assertFalse(portlet.isStaticStart());
+
+		portlet.setStatic(true);
+		portlet.setStaticStart(true);
+
+		Assert.assertTrue(portlet.isStatic());
+		Assert.assertTrue(portlet.isStaticStart());
+
+		portlet = _portletLocalService.fetchPortletById(companyId, portletId);
+
+		Assert.assertFalse(portlet.isStatic());
+		Assert.assertFalse(portlet.isStaticStart());
 	}
 
 	@Inject

--- a/modules/apps/portlet/portlet-test/src/testIntegration/java/com/liferay/portlet/test/PortletLocalServiceTest.java
+++ b/modules/apps/portlet/portlet-test/src/testIntegration/java/com/liferay/portlet/test/PortletLocalServiceTest.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -49,6 +50,15 @@ public class PortletLocalServiceTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
+	@After
+	public void tearDown() throws Exception {
+		for (ServiceRegistration<?> serviceRegistration :
+				_serviceRegistrations) {
+
+			serviceRegistration.unregister();
+		}
+	}
+
 	@Test
 	public void testFetchPortletById() throws Exception {
 		Bundle bundle = FrameworkUtil.getBundle(getClass());
@@ -57,22 +67,17 @@ public class PortletLocalServiceTest {
 
 		String portletName = RandomTestUtil.randomString();
 
-		ServiceRegistration<Portlet> serviceRegistration =
+		_serviceRegistrations.add(
 			bundleContext.registerService(
 				Portlet.class, new TestPortlet(),
 				HashMapDictionaryBuilder.<String, Object>put(
 					"com.liferay.portlet.instanceable", "true"
 				).put(
 					"jakarta.portlet.name", portletName
-				).build());
+				).build()));
 
-		try {
-			_assertFetchPortletById(portletName, null);
-			_assertFetchPortletById(portletName, RandomTestUtil.randomString());
-		}
-		finally {
-			serviceRegistration.unregister();
-		}
+		_assertFetchPortletById(portletName, null);
+		_assertFetchPortletById(portletName, RandomTestUtil.randomString());
 	}
 
 	@Test
@@ -86,82 +91,69 @@ public class PortletLocalServiceTest {
 		TestCustomAttributesDisplay disabledFFCustomAttributesDisplay =
 			new TestCustomAttributesDisplay(RandomTestUtil.randomString());
 		String portletName = RandomTestUtil.randomString();
-		List<ServiceRegistration<?>> serviceRegistrations = new ArrayList<>();
 
-		try {
-			serviceRegistrations.add(
-				bundleContext.registerService(
-					CustomAttributesDisplay.class,
-					disabledFFCustomAttributesDisplay,
-					MapUtil.singletonDictionary(
-						"jakarta.portlet.name", portletName)));
+		_serviceRegistrations.add(
+			bundleContext.registerService(
+				CustomAttributesDisplay.class,
+				disabledFFCustomAttributesDisplay,
+				MapUtil.singletonDictionary(
+					"jakarta.portlet.name", portletName)));
 
-			String enabledFFKey = RandomTestUtil.randomString();
+		String enabledFFKey = RandomTestUtil.randomString();
 
-			PropsUtil.set("feature.flag." + enabledFFKey, "true");
+		PropsUtil.set("feature.flag." + enabledFFKey, "true");
 
-			TestCustomAttributesDisplay enabledFFCustomAttributesDisplay =
-				new TestCustomAttributesDisplay(enabledFFKey);
+		TestCustomAttributesDisplay enabledFFCustomAttributesDisplay =
+			new TestCustomAttributesDisplay(enabledFFKey);
 
-			serviceRegistrations.add(
-				bundleContext.registerService(
-					CustomAttributesDisplay.class,
-					enabledFFCustomAttributesDisplay,
-					MapUtil.singletonDictionary(
-						"jakarta.portlet.name", portletName)));
+		_serviceRegistrations.add(
+			bundleContext.registerService(
+				CustomAttributesDisplay.class, enabledFFCustomAttributesDisplay,
+				MapUtil.singletonDictionary(
+					"jakarta.portlet.name", portletName)));
 
-			TestCustomAttributesDisplay nullFFCustomAttributesDisplay =
-				new TestCustomAttributesDisplay(null);
+		TestCustomAttributesDisplay nullFFCustomAttributesDisplay =
+			new TestCustomAttributesDisplay(null);
 
-			serviceRegistrations.add(
-				bundleContext.registerService(
-					CustomAttributesDisplay.class,
-					nullFFCustomAttributesDisplay,
-					MapUtil.singletonDictionary(
-						"jakarta.portlet.name", portletName)));
+		_serviceRegistrations.add(
+			bundleContext.registerService(
+				CustomAttributesDisplay.class, nullFFCustomAttributesDisplay,
+				MapUtil.singletonDictionary(
+					"jakarta.portlet.name", portletName)));
 
-			serviceRegistrations.add(
-				bundleContext.registerService(
-					Portlet.class, new TestPortlet(),
-					MapUtil.singletonDictionary(
-						"jakarta.portlet.name", portletName)));
+		_serviceRegistrations.add(
+			bundleContext.registerService(
+				Portlet.class, new TestPortlet(),
+				MapUtil.singletonDictionary(
+					"jakarta.portlet.name", portletName)));
 
-			Thread.sleep(200);
+		Thread.sleep(200);
 
-			List<CustomAttributesDisplay> customAttributesDisplays =
-				TransformUtil.transform(
-					_portletLocalService.getCustomAttributesDisplays(),
-					customAttributesDisplay -> {
-						if (Objects.equals(
-								TestCustomAttributesDisplay.class.getName(),
-								customAttributesDisplay.getClassName())) {
+		List<CustomAttributesDisplay> customAttributesDisplays =
+			TransformUtil.transform(
+				_portletLocalService.getCustomAttributesDisplays(),
+				customAttributesDisplay -> {
+					if (Objects.equals(
+							TestCustomAttributesDisplay.class.getName(),
+							customAttributesDisplay.getClassName())) {
 
-							return customAttributesDisplay;
-						}
+						return customAttributesDisplay;
+					}
 
-						return null;
-					});
+					return null;
+				});
 
-			Assert.assertFalse(
-				customAttributesDisplays.contains(
-					disabledFFCustomAttributesDisplay));
-			Assert.assertTrue(
-				customAttributesDisplays.contains(
-					enabledFFCustomAttributesDisplay));
-			Assert.assertTrue(
-				customAttributesDisplays.contains(
-					nullFFCustomAttributesDisplay));
-			Assert.assertEquals(
-				customAttributesDisplays.toString(), 2,
-				customAttributesDisplays.size());
-		}
-		finally {
-			for (ServiceRegistration<?> serviceRegistration :
-					serviceRegistrations) {
-
-				serviceRegistration.unregister();
-			}
-		}
+		Assert.assertFalse(
+			customAttributesDisplays.contains(
+				disabledFFCustomAttributesDisplay));
+		Assert.assertTrue(
+			customAttributesDisplays.contains(
+				enabledFFCustomAttributesDisplay));
+		Assert.assertTrue(
+			customAttributesDisplays.contains(nullFFCustomAttributesDisplay));
+		Assert.assertEquals(
+			customAttributesDisplays.toString(), 2,
+			customAttributesDisplays.size());
 	}
 
 	private void _assertFetchPortletById(String portletName, String instanceId)
@@ -195,6 +187,9 @@ public class PortletLocalServiceTest {
 
 	@Inject
 	private PortletLocalService _portletLocalService;
+
+	private final List<ServiceRegistration<?>> _serviceRegistrations =
+		new ArrayList<>();
 
 	private class TestCustomAttributesDisplay
 		extends BaseCustomAttributesDisplay {

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutImpl.java
@@ -37,7 +37,6 @@ import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.model.LayoutTypePortletConstants;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.PortletPreferences;
-import com.liferay.portal.kernel.model.PortletWrapper;
 import com.liferay.portal.kernel.model.Theme;
 import com.liferay.portal.kernel.portlet.LiferayPortletURL;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
@@ -512,45 +511,12 @@ public class LayoutImpl extends LayoutBaseImpl {
 				continue;
 			}
 
-			Portlet embeddedPortlet = portlet;
-
-			if (portlet.isInstanceable()) {
-
-				// Instanceable portlets do not need to be cloned because they
-				// are already cloned. See the method getPortletById in the
-				// class PortletLocalServiceImpl and how it references the
-				// method getClonedInstance in the class PortletImpl.
-
-			}
-			else {
-				embeddedPortlet = new PortletWrapper(portlet) {
-
-					@Override
-					public boolean getStatic() {
-						return _staticPortlet;
-					}
-
-					@Override
-					public boolean isStatic() {
-						return _staticPortlet;
-					}
-
-					@Override
-					public void setStatic(boolean staticPortlet) {
-						_staticPortlet = staticPortlet;
-					}
-
-					private boolean _staticPortlet;
-
-				};
-			}
-
 			// We set embedded portlets as static on order to avoid adding the
 			// close and/or move icons.
 
-			embeddedPortlet.setStatic(true);
+			portlet.setStatic(true);
 
-			portlets.add(embeddedPortlet);
+			portlets.add(portlet);
 		}
 
 		return portlets;

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
@@ -26,7 +26,6 @@ import com.liferay.portal.kernel.model.LayoutTypePortletConstants;
 import com.liferay.portal.kernel.model.Plugin;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.PortletPreferencesIds;
-import com.liferay.portal.kernel.model.PortletWrapper;
 import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.model.Theme;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
@@ -631,62 +630,13 @@ public class LayoutTypePortletImpl
 				continue;
 			}
 
-			Portlet staticPortlet = portlet;
-
-			if (portlet.isInstanceable()) {
-
-				// Instanceable portlets do not need to be cloned because they
-				// are already cloned. See the method getPortletById in the
-				// class PortletLocalServiceImpl and how it references the
-				// method getClonedInstance in the class PortletImpl.
-
-			}
-			else {
-				staticPortlet = new PortletWrapper(portlet) {
-
-					@Override
-					public boolean getStatic() {
-						return _staticPortlet;
-					}
-
-					@Override
-					public boolean getStaticStart() {
-						return _staticPortletStart;
-					}
-
-					@Override
-					public boolean isStatic() {
-						return _staticPortlet;
-					}
-
-					@Override
-					public boolean isStaticStart() {
-						return _staticPortletStart;
-					}
-
-					@Override
-					public void setStatic(boolean staticPortlet) {
-						_staticPortlet = staticPortlet;
-					}
-
-					@Override
-					public void setStaticStart(boolean staticPortletStart) {
-						_staticPortletStart = staticPortletStart;
-					}
-
-					private boolean _staticPortlet;
-					private boolean _staticPortletStart;
-
-				};
-			}
-
-			staticPortlet.setStatic(true);
+			portlet.setStatic(true);
 
 			if (position.startsWith("layout.static.portlets.start")) {
-				staticPortlet.setStaticStart(true);
+				portlet.setStaticStart(true);
 			}
 
-			portlets.add(staticPortlet);
+			portlets.add(portlet);
 		}
 
 		return portlets;

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -492,10 +492,6 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 
 		String rootPortletId = PortletIdCodec.decodePortletName(portletId);
 
-		if (portletId.equals(rootPortletId)) {
-			return companyPortletsMap.get(portletId);
-		}
-
 		Portlet portlet = companyPortletsMap.get(rootPortletId);
 
 		if (portlet != null) {

--- a/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
+++ b/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
@@ -13,7 +13,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.model.Portlet;
-import com.liferay.portal.kernel.model.PortletWrapper;
 import com.liferay.portal.kernel.portlet.PortletContainerUtil;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.PortletLayoutListener;
@@ -460,41 +459,11 @@ public class RuntimeTag extends TagSupport implements DirectTag {
 	public void setSettingsScope(String settingsScope) {
 	}
 
-	/**
-	 * @see com.liferay.portal.model.impl.LayoutTypePortletImpl#getStaticPortlets(
-	 *      String)
-	 */
 	protected static Portlet getPortlet(long companyId, String portletId)
 		throws Exception {
 
 		Portlet portlet = PortletLocalServiceUtil.getPortletById(
 			companyId, portletId);
-
-		// See LayoutTypePortletImpl#getStaticPortlets for why we only clone
-		// non-instanceable portlets
-
-		if (!portlet.isInstanceable()) {
-			portlet = new PortletWrapper(portlet) {
-
-				@Override
-				public boolean getStatic() {
-					return _staticPortlet;
-				}
-
-				@Override
-				public boolean isStatic() {
-					return _staticPortlet;
-				}
-
-				@Override
-				public void setStatic(boolean staticPortlet) {
-					_staticPortlet = staticPortlet;
-				}
-
-				private boolean _staticPortlet;
-
-			};
-		}
 
 		portlet.setStatic(true);
 


### PR DESCRIPTION
**Ticket:** https://liferay.atlassian.net/browse/LPD-78503

## What is being fixed

When `fetchPortletById` was called with a root portlet id (e.g. without the `_INSTANCE_` separator), it returned the cached portlet directly. Callers that then mutated the returned cached portlet, such as by calling `portlet.setStatic`, polluted the cache.

The cache pollution stayed invisible until LPD-64147 (318eae37a84ed) replaced `PortletImpl.clone()` with a `PortletWrapper` for instance portlet ids. Each new wrapper copies the cached portlet's `_static` value at creation, so the polluted value propagated to every subsequent wrapper.

As a result, we now observe `render_portlet.jsp` incorrectly hiding the Delete option for the portlet due to `portlet.isStatic()` returning the polluted value.

## How it is being fixed

`fetchPortletById` now wraps the cached portlet for every portlet id, including the root id case. The wrapper isolates `setStatic`/`setStaticStart` mutations to its own local fields, so the cached portlet is left unchanged.

This isolation makes the local wrappers in `RuntimeTag`, `LayoutImpl`, and `LayoutTypePortletImpl` redundant; the cleanup commit removes them.