### PR TITLE
LPD-90059 Set user on ThemeDisplay to avoid NPE in isImpersonated

### DIFF
--- a/modules/apps/login/login-test/src/testIntegration/java/com/liferay/login/internal/portlet/action/test/UpdateEmailAddressActionTest.java
+++ b/modules/apps/login/login-test/src/testIntegration/java/com/liferay/login/internal/portlet/action/test/UpdateEmailAddressActionTest.java
@@ -94,8 +94,10 @@ public class UpdateEmailAddressActionTest {
 		themeDisplay.setPathMain("/c");
 		themeDisplay.setPermissionChecker(
 			PermissionThreadLocal.getPermissionChecker());
+		themeDisplay.setRealUser(TestPropsValues.getUser());
 		themeDisplay.setRequest(mockHttpServletRequest);
 		themeDisplay.setScopeGroupId(TestPropsValues.getGroupId());
+		themeDisplay.setUser(TestPropsValues.getUser());
 
 		mockHttpServletRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, themeDisplay);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90059

## What is being fixed

`UpdateEmailAddressActionTest#testRenderRefererURL` was failing with a
NullPointerException inside `ThemeDisplay.isImpersonated()`, which
requires both `_user` and `_realUser` to be set on the `ThemeDisplay`
instance used in the test.

## How it is being fixed

Set both `user` and `realUser` on the `ThemeDisplay` before attaching it
to the mock request in `_testRenderRefererURL`. This satisfies the
non-null check inside `isImpersonated()` and allows the test to reach
the referer URL rendering logic it was designed to cover.