### PR TITLE
LPD-93067 Set default site name for cluster test Tomcat nodes

### DIFF
--- a/portal-test/src/com/liferay/portal/test/cluster/tomcat/dependencies/portal-ext.properties.tpl
+++ b/portal-test/src/com/liferay/portal/test/cluster/tomcat/dependencies/portal-ext.properties.tpl
@@ -10,3 +10,4 @@ module.framework.base.dir=${OSGI_BASE}
 module.framework.configs.dir=${OSGI_CONFIGS}
 module.framework.state.dir=${OSGI_STATE}
 setup.wizard.enabled=false
+virtual.hosts.default.site.name=Guest


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93067

## What Is Being Fixed

ClusterGeneralTest.testValidatePublishOnTwoNodes fails deterministically on master. LPD-74656 added a VirtualHostFilter shortcut that 302-redirects a request for "/" to the home URL when virtual.hosts.default.site.name is empty. The cluster integration test bundle leaves that property empty, and TomcatNode.start(true) warms up each forked node with an HTTP GET on "/". With the redirect in place the warm-up is answered with a redirect instead of rendering "/", and the test's staging publish then never materializes the live layout, so the master node cannot fetch it and the assertion fails.

## How It Is Being Fixed

Set virtual.hosts.default.site.name=Guest in the cluster test nodes' portal-ext.properties template. This makes the VirtualHostFilter redirect condition false, so the node warm-up renders "/" in place as it did before LPD-74656. The change is scoped to the forked cluster test nodes and does not affect other integration tests or product code.

## Why Are There No Tests?

This repairs the harness configuration of an existing test (testValidatePublishOnTwoNodes) rather than adding new behavior, so no new test is warranted. Verified by the full com.liferay.portal.cache.internal.test cluster suite passing (28/28).
