### PR TITLE
LPD-93204 Stop replicating finder cache when replication is skipped

### DIFF
--- a/modules/apps/portal-cache/portal-cache-impl/src/main/java/com/liferay/portal/cache/internal/dao/orm/EntityCacheImpl.java
+++ b/modules/apps/portal-cache/portal-cache-impl/src/main/java/com/liferay/portal/cache/internal/dao/orm/EntityCacheImpl.java
@@ -390,7 +390,8 @@ public class EntityCacheImpl
 		_notify(className, baseModel, updateByEntityCache);
 
 		if (!_clusterExecutor.isEnabled() ||
-			!ClusterInvokeThreadLocal.isEnabled()) {
+			!ClusterInvokeThreadLocal.isEnabled() ||
+			SkipReplicationThreadLocal.isEnabled()) {
 
 			return;
 		}

--- a/modules/apps/portal-cache/portal-cache-impl/src/test/java/com/liferay/portal/cache/internal/dao/orm/EntityCacheImplTest.java
+++ b/modules/apps/portal-cache/portal-cache-impl/src/test/java/com/liferay/portal/cache/internal/dao/orm/EntityCacheImplTest.java
@@ -6,9 +6,12 @@
 package com.liferay.portal.cache.internal.dao.orm;
 
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.cache.PortalCache;
+import com.liferay.portal.kernel.cache.SkipReplicationThreadLocal;
 import com.liferay.portal.kernel.cluster.ClusterExecutor;
+import com.liferay.portal.kernel.cluster.ClusterRequest;
 import com.liferay.portal.kernel.dao.orm.ArgumentsResolver;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
@@ -73,6 +76,57 @@ public class EntityCacheImplTest {
 		_classLoader = EntityCacheImplTest.class.getClassLoader();
 		_nullModel = ReflectionTestUtil.getFieldValue(
 			BasePersistenceImpl.class, "nullModel");
+	}
+
+	@Test
+	public void testNotifyFinderCacheWhenSkipReplicationIsEnabled() {
+		EntityCacheImpl entityCacheImpl = new EntityCacheImpl();
+
+		ClusterExecutor clusterExecutor = Mockito.mock(ClusterExecutor.class);
+
+		Mockito.when(
+			clusterExecutor.isEnabled()
+		).thenReturn(
+			true
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			entityCacheImpl, "_clusterExecutor", clusterExecutor);
+
+		ReflectionTestUtil.setFieldValue(
+			entityCacheImpl, "_multiVMPool",
+			ProxyUtil.newProxyInstance(
+				_classLoader, new Class<?>[] {MultiVMPool.class},
+				new MultiVMPoolInvocationHandler(_classLoader, true)));
+
+		entityCacheImpl.activate(_bundleContext);
+
+		// The finder cache notification is broadcast to the cluster by default
+
+		entityCacheImpl.clearCache();
+
+		Mockito.verify(
+			clusterExecutor, Mockito.times(1)
+		).execute(
+			Mockito.any(ClusterRequest.class)
+		);
+
+		Mockito.clearInvocations(clusterExecutor);
+
+		// The finder cache notification is not broadcast to the cluster when
+		// replication is skipped by an outer scope
+
+		try (SafeCloseable safeCloseable =
+				SkipReplicationThreadLocal.setEnabledWithSafeCloseable(true)) {
+
+			entityCacheImpl.clearCache();
+		}
+
+		Mockito.verify(
+			clusterExecutor, Mockito.never()
+		).execute(
+			Mockito.any(ClusterRequest.class)
+		);
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93204

## What Is Being Fixed

In EntityCacheImpl, the finder cache notification is broadcast to the cluster manually in _notifyFinderCache (see LPD-88642). When an outer scope had already enabled SkipReplicationThreadLocal to keep an entity cache change local, that manual broadcast still fired, leaking a finder cache notification to the other cluster nodes even though replication was meant to be skipped.

## How It Is Being Fixed

_notifyFinderCache now also returns early — skipping the cluster broadcast — when SkipReplicationThreadLocal.isEnabled(). The finder cache is still updated locally through _notify, so the local node stays consistent while nothing is replicated, matching the manual replication contract introduced in LPD-88642. A unit test in EntityCacheImplTest verifies that clearCache broadcasts a cluster request by default and broadcasts none when SkipReplicationThreadLocal is enabled.
