### PR TITLE
LPD-92755 Index User custom fields during a full reindex

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/expando/ExpandoBridgeIndexerImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/expando/ExpandoBridgeIndexerImpl.java
@@ -371,7 +371,7 @@ public class ExpandoBridgeIndexerImpl implements ExpandoBridgeIndexer {
 							classNameId -> {
 								ClassName classNameObject =
 									_classNameLocalService.fetchByClassNameId(
-										companyId);
+										classNameId);
 
 								if (classNameObject == null) {
 									return null;

--- a/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/search/test/UserIndexerIndexedFieldsTest.java
+++ b/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/search/test/UserIndexerIndexedFieldsTest.java
@@ -91,17 +91,14 @@ public class UserIndexerIndexedFieldsTest {
 	@Before
 	public void setUp() throws Exception {
 		_setUpExpandoTableSearchFixture();
-
-		setUpIndexedFieldsFixture();
-
-		setUpIndexerFixture();
-
-		setUpUserSearchFixture();
+		_setUpIndexedFieldsFixture();
+		_setUpIndexerFixture();
+		_setUpUserSearchFixture();
 	}
 
 	@Test
 	public void testAddress() throws Exception {
-		User user1 = addUser();
+		User user1 = _addUser();
 
 		_userSearchFixture.addAddress(user1);
 
@@ -130,7 +127,7 @@ public class UserIndexerIndexedFieldsTest {
 			User.class, ExpandoColumnConstants.INDEX_TYPE_KEYWORD,
 			"customField");
 
-		User user = addUser();
+		User user = _addUser();
 
 		ExpandoBridge expandoBridge = user.getExpandoBridge();
 
@@ -153,7 +150,7 @@ public class UserIndexerIndexedFieldsTest {
 
 	@Test
 	public void testJobTitle() throws Exception {
-		User user1 = addUser();
+		User user1 = _addUser();
 
 		user1.setJobTitle(RandomTestUtil.randomString());
 
@@ -180,9 +177,9 @@ public class UserIndexerIndexedFieldsTest {
 
 	@Test
 	public void testOrganizationIds() throws Exception {
-		Organization organization = addOrganization();
+		Organization organization = _addOrganization();
 
-		User user = addUser();
+		User user = _addUser();
 
 		_userLocalService.addOrganizationUser(
 			organization.getOrganizationId(), user.getUserId());
@@ -206,7 +203,7 @@ public class UserIndexerIndexedFieldsTest {
 
 	@Test
 	public void testUserGroupIds() throws Exception {
-		User user = addUser();
+		User user = _addUser();
 
 		UserGroup userGroup = _userGroupSearchFixture.addUserGroup(
 			UserGroupSearchFixture.getTestUserGroupBlueprintBuilder());
@@ -236,7 +233,7 @@ public class UserIndexerIndexedFieldsTest {
 	@Rule
 	public SearchTestRule searchTestRule = new SearchTestRule();
 
-	protected Organization addOrganization() {
+	private Organization _addOrganization() {
 		OrganizationBlueprintBuilder organizationBlueprintBuilder =
 			OrganizationSearchFixture.getTestOrganizationBlueprintBuilder();
 
@@ -244,46 +241,9 @@ public class UserIndexerIndexedFieldsTest {
 			organizationBlueprintBuilder.build());
 	}
 
-	protected User addUser() throws Exception {
+	private User _addUser() throws Exception {
 		return _userSearchFixture.addUser(
 			RandomTestUtil.randomString(), _group, new String[0]);
-	}
-
-	protected void setUpIndexedFieldsFixture() {
-		_indexedFieldsFixture = new IndexedFieldsFixture(
-			_resourcePermissionLocalService, _searchEngineHelper, _uidFactory);
-	}
-
-	protected void setUpIndexerFixture() {
-		_indexerFixture = new IndexerFixture<>(User.class);
-	}
-
-	protected void setUpUserSearchFixture() throws Exception {
-		GroupSearchFixture groupSearchFixture = new GroupSearchFixture();
-
-		_organizationSearchFixture = new OrganizationSearchFixture(
-			_organizationLocalService);
-
-		_userGroupSearchFixture = new UserGroupSearchFixture(
-			_userGroupLocalService);
-
-		_userSearchFixture = new UserSearchFixture(
-			_userLocalService, groupSearchFixture, _organizationSearchFixture,
-			_userGroupSearchFixture);
-
-		_userSearchFixture.setUp();
-
-		_addresses = _userSearchFixture.getAddresses();
-
-		_groups = groupSearchFixture.getGroups();
-
-		_organizations = _organizationSearchFixture.getOrganizations();
-
-		_users = _userSearchFixture.getUsers();
-
-		_userGroups = _userGroupSearchFixture.getUserGroups();
-
-		_group = groupSearchFixture.addGroup(new GroupBlueprint());
 	}
 
 	private String _getEmailAddressDomain(String emailAddress) {
@@ -491,6 +451,43 @@ public class UserIndexerIndexedFieldsTest {
 
 		_expandoColumns = _expandoTableSearchFixture.getExpandoColumns();
 		_expandoTables = _expandoTableSearchFixture.getExpandoTables();
+	}
+
+	private void _setUpIndexedFieldsFixture() {
+		_indexedFieldsFixture = new IndexedFieldsFixture(
+			_resourcePermissionLocalService, _searchEngineHelper, _uidFactory);
+	}
+
+	private void _setUpIndexerFixture() {
+		_indexerFixture = new IndexerFixture<>(User.class);
+	}
+
+	private void _setUpUserSearchFixture() throws Exception {
+		GroupSearchFixture groupSearchFixture = new GroupSearchFixture();
+
+		_organizationSearchFixture = new OrganizationSearchFixture(
+			_organizationLocalService);
+
+		_userGroupSearchFixture = new UserGroupSearchFixture(
+			_userGroupLocalService);
+
+		_userSearchFixture = new UserSearchFixture(
+			_userLocalService, groupSearchFixture, _organizationSearchFixture,
+			_userGroupSearchFixture);
+
+		_userSearchFixture.setUp();
+
+		_addresses = _userSearchFixture.getAddresses();
+
+		_groups = groupSearchFixture.getGroups();
+
+		_organizations = _organizationSearchFixture.getOrganizations();
+
+		_users = _userSearchFixture.getUsers();
+
+		_userGroups = _userGroupSearchFixture.getUserGroups();
+
+		_group = groupSearchFixture.addGroup(new GroupBlueprint());
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/search/test/UserIndexerIndexedFieldsTest.java
+++ b/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/search/test/UserIndexerIndexedFieldsTest.java
@@ -6,6 +6,13 @@
 package com.liferay.users.admin.search.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.expando.kernel.model.ExpandoBridge;
+import com.liferay.expando.kernel.model.ExpandoColumn;
+import com.liferay.expando.kernel.model.ExpandoColumnConstants;
+import com.liferay.expando.kernel.model.ExpandoTable;
+import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
+import com.liferay.expando.kernel.service.ExpandoTableLocalService;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Address;
@@ -18,7 +25,9 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.ReindexCacheThreadLocal;
 import com.liferay.portal.kernel.search.SearchEngineHelper;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
@@ -35,6 +44,7 @@ import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.model.uid.UIDFactory;
 import com.liferay.portal.search.test.rule.SearchTestRule;
+import com.liferay.portal.search.test.util.ExpandoTableSearchFixture;
 import com.liferay.portal.search.test.util.FieldValuesAssert;
 import com.liferay.portal.search.test.util.IndexedFieldsFixture;
 import com.liferay.portal.search.test.util.IndexerFixture;
@@ -56,6 +66,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -79,6 +90,8 @@ public class UserIndexerIndexedFieldsTest {
 
 	@Before
 	public void setUp() throws Exception {
+		_setUpExpandoTableSearchFixture();
+
 		setUpIndexedFieldsFixture();
 
 		setUpIndexerFixture();
@@ -109,6 +122,33 @@ public class UserIndexerIndexedFieldsTest {
 			name ->
 				!name.contains(StringPool.PERIOD) && !name.equals("timestamp"),
 			searchTerm);
+	}
+
+	@Test
+	public void testCustomField() throws Exception {
+		expandoTableSearchFixture.addExpandoColumn(
+			User.class, ExpandoColumnConstants.INDEX_TYPE_KEYWORD,
+			"customField");
+
+		User user = addUser();
+
+		ExpandoBridge expandoBridge = user.getExpandoBridge();
+
+		String customFieldValue = RandomTestUtil.randomString();
+
+		expandoBridge.setAttribute("customField", customFieldValue);
+
+		try (SafeCloseable safeCloseable =
+				ReindexCacheThreadLocal.openReindexMode()) {
+
+			indexerFixture.reindexCompany(user.getCompanyId());
+		}
+
+		Document document = indexerFixture.searchOnlyOne(user.getFirstName());
+
+		Assert.assertEquals(
+			customFieldValue,
+			document.get("expando__keyword__custom_fields__customField"));
 	}
 
 	@Test
@@ -245,6 +285,16 @@ public class UserIndexerIndexedFieldsTest {
 		group = groupSearchFixture.addGroup(new GroupBlueprint());
 	}
 
+	@Inject
+	protected ClassNameLocalService classNameLocalService;
+
+	@Inject
+	protected ExpandoColumnLocalService expandoColumnLocalService;
+
+	@Inject
+	protected ExpandoTableLocalService expandoTableLocalService;
+
+	protected ExpandoTableSearchFixture expandoTableSearchFixture;
 	protected Group group;
 	protected IndexedFieldsFixture indexedFieldsFixture;
 	protected IndexerFixture<User> indexerFixture;
@@ -471,8 +521,23 @@ public class UserIndexerIndexedFieldsTest {
 		}
 	}
 
+	private void _setUpExpandoTableSearchFixture() {
+		expandoTableSearchFixture = new ExpandoTableSearchFixture(
+			classNameLocalService, expandoColumnLocalService,
+			expandoTableLocalService);
+
+		_expandoColumns = expandoTableSearchFixture.getExpandoColumns();
+		_expandoTables = expandoTableSearchFixture.getExpandoTables();
+	}
+
 	@DeleteAfterTestRun
 	private List<Address> _addresses = new ArrayList<>();
+
+	@DeleteAfterTestRun
+	private List<ExpandoColumn> _expandoColumns;
+
+	@DeleteAfterTestRun
+	private List<ExpandoTable> _expandoTables;
 
 	@DeleteAfterTestRun
 	private List<Group> _groups;

--- a/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/search/test/UserIndexerIndexedFieldsTest.java
+++ b/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/search/test/UserIndexerIndexedFieldsTest.java
@@ -103,15 +103,15 @@ public class UserIndexerIndexedFieldsTest {
 	public void testAddress() throws Exception {
 		User user1 = addUser();
 
-		userSearchFixture.addAddress(user1);
+		_userSearchFixture.addAddress(user1);
 
-		User user2 = userLocalService.updateUser(user1);
+		User user2 = _userLocalService.updateUser(user1);
 
 		String searchTerm = user2.getFirstName();
 
-		Document document = indexerFixture.searchOnlyOne(searchTerm);
+		Document document = _indexerFixture.searchOnlyOne(searchTerm);
 
-		indexedFieldsFixture.postProcessDocument(document);
+		_indexedFieldsFixture.postProcessDocument(document);
 
 		Map<String, String> map = _getExpectedFieldValues(user2);
 
@@ -126,7 +126,7 @@ public class UserIndexerIndexedFieldsTest {
 
 	@Test
 	public void testCustomField() throws Exception {
-		expandoTableSearchFixture.addExpandoColumn(
+		_expandoTableSearchFixture.addExpandoColumn(
 			User.class, ExpandoColumnConstants.INDEX_TYPE_KEYWORD,
 			"customField");
 
@@ -141,10 +141,10 @@ public class UserIndexerIndexedFieldsTest {
 		try (SafeCloseable safeCloseable =
 				ReindexCacheThreadLocal.openReindexMode()) {
 
-			indexerFixture.reindexCompany(user.getCompanyId());
+			_indexerFixture.reindexCompany(user.getCompanyId());
 		}
 
-		Document document = indexerFixture.searchOnlyOne(user.getFirstName());
+		Document document = _indexerFixture.searchOnlyOne(user.getFirstName());
 
 		Assert.assertEquals(
 			customFieldValue,
@@ -157,13 +157,13 @@ public class UserIndexerIndexedFieldsTest {
 
 		user1.setJobTitle(RandomTestUtil.randomString());
 
-		User user2 = userLocalService.updateUser(user1);
+		User user2 = _userLocalService.updateUser(user1);
 
 		String searchTerm = user2.getFirstName();
 
-		Document document = indexerFixture.searchOnlyOne(searchTerm);
+		Document document = _indexerFixture.searchOnlyOne(searchTerm);
 
-		indexedFieldsFixture.postProcessDocument(document);
+		_indexedFieldsFixture.postProcessDocument(document);
 
 		Map<String, String> map = _getExpectedFieldValues(user2);
 
@@ -184,14 +184,14 @@ public class UserIndexerIndexedFieldsTest {
 
 		User user = addUser();
 
-		userLocalService.addOrganizationUser(
+		_userLocalService.addOrganizationUser(
 			organization.getOrganizationId(), user.getUserId());
 
 		String searchTerm = user.getFirstName();
 
-		Document document = indexerFixture.searchOnlyOne(searchTerm);
+		Document document = _indexerFixture.searchOnlyOne(searchTerm);
 
-		indexedFieldsFixture.postProcessDocument(document);
+		_indexedFieldsFixture.postProcessDocument(document);
 
 		Map<String, String> map = _getExpectedFieldValues(user);
 
@@ -208,18 +208,19 @@ public class UserIndexerIndexedFieldsTest {
 	public void testUserGroupIds() throws Exception {
 		User user = addUser();
 
-		UserGroup userGroup = userGroupSearchFixture.addUserGroup(
+		UserGroup userGroup = _userGroupSearchFixture.addUserGroup(
 			UserGroupSearchFixture.getTestUserGroupBlueprintBuilder());
 
-		userGroupLocalService.addUserUserGroup(user.getUserId(), userGroup);
+		_userGroupLocalService.addUserUserGroup(user.getUserId(), userGroup);
 
-		userGroupLocalService.addGroupUserGroup(group.getGroupId(), userGroup);
+		_userGroupLocalService.addGroupUserGroup(
+			_group.getGroupId(), userGroup);
 
 		String searchTerm = user.getFirstName();
 
-		Document document = indexerFixture.searchOnlyOne(searchTerm);
+		Document document = _indexerFixture.searchOnlyOne(searchTerm);
 
-		indexedFieldsFixture.postProcessDocument(document);
+		_indexedFieldsFixture.postProcessDocument(document);
 
 		Map<String, String> map = _getExpectedFieldValues(user);
 
@@ -239,92 +240,51 @@ public class UserIndexerIndexedFieldsTest {
 		OrganizationBlueprintBuilder organizationBlueprintBuilder =
 			OrganizationSearchFixture.getTestOrganizationBlueprintBuilder();
 
-		return organizationSearchFixture.addOrganization(
+		return _organizationSearchFixture.addOrganization(
 			organizationBlueprintBuilder.build());
 	}
 
 	protected User addUser() throws Exception {
-		return userSearchFixture.addUser(
-			RandomTestUtil.randomString(), group, new String[0]);
+		return _userSearchFixture.addUser(
+			RandomTestUtil.randomString(), _group, new String[0]);
 	}
 
 	protected void setUpIndexedFieldsFixture() {
-		indexedFieldsFixture = new IndexedFieldsFixture(
-			resourcePermissionLocalService, searchEngineHelper, uidFactory);
+		_indexedFieldsFixture = new IndexedFieldsFixture(
+			_resourcePermissionLocalService, _searchEngineHelper, _uidFactory);
 	}
 
 	protected void setUpIndexerFixture() {
-		indexerFixture = new IndexerFixture<>(User.class);
+		_indexerFixture = new IndexerFixture<>(User.class);
 	}
 
 	protected void setUpUserSearchFixture() throws Exception {
 		GroupSearchFixture groupSearchFixture = new GroupSearchFixture();
 
-		organizationSearchFixture = new OrganizationSearchFixture(
-			organizationLocalService);
+		_organizationSearchFixture = new OrganizationSearchFixture(
+			_organizationLocalService);
 
-		userGroupSearchFixture = new UserGroupSearchFixture(
-			userGroupLocalService);
+		_userGroupSearchFixture = new UserGroupSearchFixture(
+			_userGroupLocalService);
 
-		userSearchFixture = new UserSearchFixture(
-			userLocalService, groupSearchFixture, organizationSearchFixture,
-			userGroupSearchFixture);
+		_userSearchFixture = new UserSearchFixture(
+			_userLocalService, groupSearchFixture, _organizationSearchFixture,
+			_userGroupSearchFixture);
 
-		userSearchFixture.setUp();
+		_userSearchFixture.setUp();
 
-		_addresses = userSearchFixture.getAddresses();
+		_addresses = _userSearchFixture.getAddresses();
 
 		_groups = groupSearchFixture.getGroups();
 
-		_organizations = organizationSearchFixture.getOrganizations();
+		_organizations = _organizationSearchFixture.getOrganizations();
 
-		_users = userSearchFixture.getUsers();
+		_users = _userSearchFixture.getUsers();
 
-		_userGroups = userGroupSearchFixture.getUserGroups();
+		_userGroups = _userGroupSearchFixture.getUserGroups();
 
-		group = groupSearchFixture.addGroup(new GroupBlueprint());
+		_group = groupSearchFixture.addGroup(new GroupBlueprint());
 	}
-
-	@Inject
-	protected ClassNameLocalService classNameLocalService;
-
-	@Inject
-	protected ExpandoColumnLocalService expandoColumnLocalService;
-
-	@Inject
-	protected ExpandoTableLocalService expandoTableLocalService;
-
-	protected ExpandoTableSearchFixture expandoTableSearchFixture;
-	protected Group group;
-	protected IndexedFieldsFixture indexedFieldsFixture;
-	protected IndexerFixture<User> indexerFixture;
-
-	@Inject
-	protected OrganizationLocalService organizationLocalService;
-
-	protected OrganizationSearchFixture organizationSearchFixture;
-
-	@Inject
-	protected ResourcePermissionLocalService resourcePermissionLocalService;
-
-	@Inject
-	protected RoleLocalService roleLocalService;
-
-	@Inject
-	protected SearchEngineHelper searchEngineHelper;
-
-	@Inject
-	protected UIDFactory uidFactory;
-
-	@Inject
-	protected UserGroupLocalService userGroupLocalService;
-
-	protected UserGroupSearchFixture userGroupSearchFixture;
-
-	@Inject
-	protected UserLocalService userLocalService;
-
-	protected UserSearchFixture userSearchFixture;
 
 	private String _getEmailAddressDomain(String emailAddress) {
 		return emailAddress.substring(emailAddress.indexOf(StringPool.AT) + 1);
@@ -401,7 +361,9 @@ public class UserIndexerIndexedFieldsTest {
 			() -> {
 				List<String> roleNames = new ArrayList<>();
 
-				for (Role role : roleLocalService.getRoles(user.getRoleIds())) {
+				for (Role role :
+						_roleLocalService.getRoles(user.getRoleIds())) {
+
 					roleNames.add(StringUtil.toLowerCase(role.getName()));
 				}
 
@@ -415,16 +377,17 @@ public class UserIndexerIndexedFieldsTest {
 
 		_populateLocalizedNameFieldValues(map, user);
 
-		indexedFieldsFixture.populateUID(user, map);
+		_indexedFieldsFixture.populateUID(user, map);
 
-		indexedFieldsFixture.populateDate(
+		_indexedFieldsFixture.populateDate(
 			Field.CREATE_DATE, user.getCreateDate(), map);
-		indexedFieldsFixture.populateDate(
+		_indexedFieldsFixture.populateDate(
 			Field.MODIFIED_DATE, user.getModifiedDate(), map);
 
-		indexedFieldsFixture.populateDate("birthDate", user.getBirthday(), map);
+		_indexedFieldsFixture.populateDate(
+			"birthDate", user.getBirthday(), map);
 
-		indexedFieldsFixture.populateRoleIdFields(
+		_indexedFieldsFixture.populateRoleIdFields(
 			user.getCompanyId(), User.class.getName(), user.getUserId(),
 			user.getGroupId(), null, map);
 
@@ -522,33 +485,75 @@ public class UserIndexerIndexedFieldsTest {
 	}
 
 	private void _setUpExpandoTableSearchFixture() {
-		expandoTableSearchFixture = new ExpandoTableSearchFixture(
-			classNameLocalService, expandoColumnLocalService,
-			expandoTableLocalService);
+		_expandoTableSearchFixture = new ExpandoTableSearchFixture(
+			_classNameLocalService, _expandoColumnLocalService,
+			_expandoTableLocalService);
 
-		_expandoColumns = expandoTableSearchFixture.getExpandoColumns();
-		_expandoTables = expandoTableSearchFixture.getExpandoTables();
+		_expandoColumns = _expandoTableSearchFixture.getExpandoColumns();
+		_expandoTables = _expandoTableSearchFixture.getExpandoTables();
 	}
 
 	@DeleteAfterTestRun
 	private List<Address> _addresses = new ArrayList<>();
 
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@Inject
+	private ExpandoColumnLocalService _expandoColumnLocalService;
+
 	@DeleteAfterTestRun
 	private List<ExpandoColumn> _expandoColumns;
+
+	@Inject
+	private ExpandoTableLocalService _expandoTableLocalService;
 
 	@DeleteAfterTestRun
 	private List<ExpandoTable> _expandoTables;
 
+	private ExpandoTableSearchFixture _expandoTableSearchFixture;
+	private Group _group;
+
 	@DeleteAfterTestRun
 	private List<Group> _groups;
+
+	private IndexedFieldsFixture _indexedFieldsFixture;
+	private IndexerFixture<User> _indexerFixture;
+
+	@Inject
+	private OrganizationLocalService _organizationLocalService;
 
 	@DeleteAfterTestRun
 	private List<Organization> _organizations;
 
+	private OrganizationSearchFixture _organizationSearchFixture;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@Inject
+	private SearchEngineHelper _searchEngineHelper;
+
+	@Inject
+	private UIDFactory _uidFactory;
+
+	@Inject
+	private UserGroupLocalService _userGroupLocalService;
+
 	@DeleteAfterTestRun
 	private List<UserGroup> _userGroups = new ArrayList<>();
 
+	private UserGroupSearchFixture _userGroupSearchFixture;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
 	@DeleteAfterTestRun
 	private List<User> _users;
+
+	private UserSearchFixture _userSearchFixture;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92755

## What Is Being Fixed

When a segment condition is built on a User custom field, the segment member count dropped to 0 after a full reindex. During the reindex, `ExpandoBridgeIndexerImpl` resolved the Expando column's class name by passing the company ID to `ClassNameLocalService.fetchByClassNameId`, so the lookup failed and the custom field was never indexed.

## How It Is Being Fixed

The lookup now passes the class name ID instead of the company ID, so the Expando column's class name resolves correctly and User custom fields are indexed during a full reindex. A regression test (`testCustomField`) was added to `UserIndexerIndexedFieldsTest`, and the test class was refactored to make its members private.
