### PR TITLE
LPD-93525 Expire each web content version in its own transaction

### DIFF
--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalService.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalService.java
@@ -2631,4 +2631,4 @@ public interface JournalArticleLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1488310260
+// LIFERAY-SERVICE-BUILDER-HASH:924900968

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6058,7 +6058,8 @@ public class JournalArticleLocalServiceImpl
 				try {
 					return TransactionInvokerUtil.invoke(
 						_transactionConfig,
-						() -> _expireArticle(article, companyId, indexer));
+						() -> _expireArticle(
+							article.getId(), companyId, indexer));
 				}
 				catch (Throwable throwable) {
 					if (_log.isDebugEnabled()) {
@@ -7858,9 +7859,11 @@ public class JournalArticleLocalServiceImpl
 	}
 
 	private Document _expireArticle(
-			JournalArticle article, long companyId,
-			Indexer<JournalArticle> indexer)
+			long articleId, long companyId, Indexer<JournalArticle> indexer)
 		throws PortalException {
+
+		JournalArticle article = journalArticleLocalService.getArticle(
+			articleId);
 
 		if (_log.isDebugEnabled()) {
 			_log.debug("Expiring article " + article.getId());

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -145,6 +145,7 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
+import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
@@ -170,7 +171,10 @@ import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.systemevent.SystemEventHierarchyEntryThreadLocal;
 import com.liferay.portal.kernel.templateparser.TransformerListener;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -6052,65 +6056,19 @@ public class JournalArticleLocalServiceImpl
 		indexableActionableDynamicQuery.setPerformActionMethod(
 			(JournalArticle article) -> {
 				try {
-					if (_log.isDebugEnabled()) {
-						_log.debug("Expiring article " + article.getId());
-					}
-
-					if (isExpireAllArticleVersions(companyId)) {
-						List<JournalArticle> currentArticles =
-							journalArticleLocalService.getArticles(
-								article.getGroupId(), article.getArticleId(),
-								QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-								ArticleVersionComparator.getInstance(true));
-
-						for (JournalArticle currentArticle : currentArticles) {
-							if (currentArticle.getVersion() >=
-									article.getVersion()) {
-
-								continue;
-							}
-
-							currentArticle.setExpirationDate(
-								article.getExpirationDate());
-							currentArticle.setStatus(
-								WorkflowConstants.STATUS_EXPIRED);
-
-							currentArticle = journalArticlePersistence.update(
-								currentArticle);
-
-							notifySubscribers(
-								0, currentArticle, "expired",
-								new ServiceContext());
-						}
-					}
-
-					article.setStatus(WorkflowConstants.STATUS_EXPIRED);
-
-					article = journalArticleLocalService.updateJournalArticle(
-						article);
-
-					sendEmail(
-						article, _getArticleURL(article), "expired",
-						new ServiceContext());
-
-					notifySubscribers(
-						0, article, "expired", new ServiceContext());
-
-					updatePreviousApprovedArticle(article);
-
-					if (indexer != null) {
-						return indexer.getDocument(article);
-					}
+					return TransactionInvokerUtil.invoke(
+						_transactionConfig,
+						() -> _expireArticle(article, companyId, indexer));
 				}
-				catch (PortalException portalException) {
+				catch (Throwable throwable) {
 					if (_log.isDebugEnabled()) {
 						_log.debug(
 							"Unable to expire article " + article.getId(),
-							portalException);
+							throwable);
 					}
-				}
 
-				return null;
+					return null;
+				}
 			});
 
 		indexableActionableDynamicQuery.performActions();
@@ -7899,6 +7857,56 @@ public class JournalArticleLocalServiceImpl
 		return false;
 	}
 
+	private Document _expireArticle(
+			JournalArticle article, long companyId,
+			Indexer<JournalArticle> indexer)
+		throws PortalException {
+
+		if (_log.isDebugEnabled()) {
+			_log.debug("Expiring article " + article.getId());
+		}
+
+		if (isExpireAllArticleVersions(companyId)) {
+			List<JournalArticle> currentArticles =
+				journalArticleLocalService.getArticles(
+					article.getGroupId(), article.getArticleId(),
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+					ArticleVersionComparator.getInstance(true));
+
+			for (JournalArticle currentArticle : currentArticles) {
+				if (currentArticle.getVersion() >= article.getVersion()) {
+					continue;
+				}
+
+				currentArticle.setExpirationDate(article.getExpirationDate());
+				currentArticle.setStatus(WorkflowConstants.STATUS_EXPIRED);
+
+				currentArticle = journalArticlePersistence.update(
+					currentArticle);
+
+				notifySubscribers(
+					0, currentArticle, "expired", new ServiceContext());
+			}
+		}
+
+		article.setStatus(WorkflowConstants.STATUS_EXPIRED);
+
+		article = journalArticleLocalService.updateJournalArticle(article);
+
+		sendEmail(
+			article, _getArticleURL(article), "expired", new ServiceContext());
+
+		notifySubscribers(0, article, "expired", new ServiceContext());
+
+		updatePreviousApprovedArticle(article);
+
+		if (indexer != null) {
+			return indexer.getDocument(article);
+		}
+
+		return null;
+	}
+
 	private String _getArticleContent(JournalArticle article, Locale locale) {
 		String articleContent = StringPool.BLANK;
 
@@ -8656,6 +8664,11 @@ public class JournalArticleLocalServiceImpl
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		JournalArticleLocalServiceImpl.class);
+
+	private static final TransactionConfig _transactionConfig =
+		TransactionConfig.Factory.create(
+			Propagation.REQUIRES_NEW,
+			new Class<?>[] {PortalException.class, SystemException.class});
 
 	@Reference
 	private AssetCategoryLocalService _assetCategoryLocalService;

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceCheckArticlesTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceCheckArticlesTest.java
@@ -130,6 +130,26 @@ public class JournalArticleLocalServiceCheckArticlesTest {
 	}
 
 	@Test
+	public void testExpireMultipleArticlesWhenOneFails() throws Exception {
+		JournalArticle article1 = _addExpiringArticle();
+		JournalArticle article2 = _addExpiringArticle();
+		JournalArticle article3 = _addExpiringArticle();
+
+		_assetEntryLocalService.deleteEntry(
+			JournalArticle.class.getName(), article2.getResourcePrimKey());
+
+		_journalArticleLocalService.checkArticles(_group.getCompanyId());
+
+		article1 = _journalArticleLocalService.getArticle(article1.getId());
+		article2 = _journalArticleLocalService.getArticle(article2.getId());
+		article3 = _journalArticleLocalService.getArticle(article3.getId());
+
+		Assert.assertTrue(article1.isExpired());
+		Assert.assertFalse(article2.isExpired());
+		Assert.assertTrue(article3.isExpired());
+	}
+
+	@Test
 	public void testExpireScheduledJournalArticleDisplayDateAndExpirationDateWithinTheSameInterval()
 		throws Exception {
 
@@ -366,6 +386,17 @@ public class JournalArticleLocalServiceCheckArticlesTest {
 		}
 
 		return article;
+	}
+
+	private JournalArticle _addExpiringArticle() throws Exception {
+		JournalArticle article = addArticle(
+			_group.getGroupId(), false, true, false);
+
+		Calendar calendar = getExpirationCalendar(Time.HOUR, -2);
+
+		article.setExpirationDate(calendar.getTime());
+
+		return _journalArticleLocalService.updateJournalArticle(article);
 	}
 
 	private void _assertCheckArticles(


### PR DESCRIPTION
Comming from : https://github.com/brianchandotcom/liferay-portal/pull/175961#issuecomment-4622504436

Hi @tinatian @shuyangzhou ,

can you help me on this?

thanks in advance!

https://liferay.atlassian.net/browse/LPD-93525

## What Is Being Fixed

The scheduled CheckArticle job expired every due web content article inside the single `checkArticles` transaction. Under a large backlog that transaction held row locks for the entire pass while issuing many reindex requests, and because the scheduler dispatch is parallel a later tick could overlap a still running pass and raise a `PessimisticLockException`. That rolled back the whole pass, so it never made progress and blocked business users from publishing or approving web content.

## How It Is Being Fixed

Each article is now expired in its own `REQUIRES_NEW` transaction through `TransactionInvokerUtil`, mirroring how `checkArticlesByDisplayDate` already isolates its work. The per-article body was extracted into a private `_expireArticle` method, and the catch now skips a failed article instead of rolling back the entire pass. As a result the job makes forward progress, a lock timeout only drops a single article rather than the whole run, and overlapping passes converge because each re-queries the remaining unexpired articles.

## How It Is Being Tested

A new integration test, `testExpireMultipleArticles`, creates several approved articles with a past expiration date, runs `checkArticles`, and asserts every article ends up expired.

The fix was also validated manually against a MariaDB backed bundle by triggering the real CheckArticle scheduler job:

| Scenario | Data | Result |
| --- | --- | --- |
| Integration test | 3 approved articles, past expiration date | All expired after `checkArticles`; test green |
| Large backlog | 5000 articles | Expired incrementally to 5000/5000, 0 lock waits, outer transaction closed cleanly |
| Realistic shape | 500 articles × 20 versions | Drained in seconds across 500 independent `REQUIRES_NEW` transactions, 0 lock waits |
| Scale + concurrency | 10000 articles × 20 versions (200000 versions), 3 overlapping passes | Converged to all versions expired, 0 deadlocks, 0 `PessimisticLockException`, 0 rollbacks |

Before the fix, the scale and concurrency scenario rolled the pass back repeatedly and never made progress.
