### PR TITLE
LPD-85380 Include license integration tests on Release Tester

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -8584,6 +8584,10 @@ information. Make sure to commit in all format-javadoc results.
 	</target>
 
 	<target name="integration-license-postgresql163">
+		<local name="test.deploy.license" />
+
+		<property name="test.deploy.license" value="false" />
+
 		<run-modules-integration-test
 			database.type="postgresql"
 			database.version="16.3"

--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -2993,6 +2993,7 @@ ${poshi.runner.testsuite.testcase.name}</echo>
 		<attribute name="database.type" />
 		<attribute default="${database.@{database.type}.version}" name="database.version" />
 		<attribute default="" name="gcs.store.enabled" />
+		<attribute default="" name="generate.license.test.properties" />
 		<attribute default="" name="ibm.store.enabled" />
 		<attribute default="" name="refreshdependencies" />
 		<attribute default="true" name="setup.testable.tomcat" />
@@ -3032,6 +3033,7 @@ ${poshi.runner.testsuite.testcase.name}</echo>
 								<param name="database.partition.export.and.import" value="@{database.partition.export.and.import}" />
 								<param name="database.type" value="@{database.type}" />
 								<param name="gcs.store.enabled" value="@{gcs.store.enabled}" />
+								<param name="generate.license.test.properties" value="@{generate.license.test.properties}" />
 								<param name="ibm.store.enabled" value="@{ibm.store.enabled}" />
 							</antcall>
 
@@ -8577,6 +8579,14 @@ information. Make sure to commit in all format-javadoc results.
 				</tar>
 			</test-tear-down>
 		</run-batch-test>
+	</target>
+
+	<target name="integration-license-postgresql163">
+		<run-modules-integration-test
+			database.type="postgresql"
+			database.version="16.3"
+			generate.license.test.properties="true"
+		/>
 	</target>
 
 	<target name="javadoc-test">

--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -2996,6 +2996,7 @@ ${poshi.runner.testsuite.testcase.name}</echo>
 		<attribute default="" name="generate.license.test.properties" />
 		<attribute default="" name="ibm.store.enabled" />
 		<attribute default="" name="refreshdependencies" />
+		<attribute default="" name="setup.wizard.enabled" />
 		<attribute default="true" name="setup.testable.tomcat" />
 		<attribute default="" name="subrepository.name" />
 		<attribute default="" name="test.build.fix.pack.zip.url" />
@@ -3035,6 +3036,7 @@ ${poshi.runner.testsuite.testcase.name}</echo>
 								<param name="gcs.store.enabled" value="@{gcs.store.enabled}" />
 								<param name="generate.license.test.properties" value="@{generate.license.test.properties}" />
 								<param name="ibm.store.enabled" value="@{ibm.store.enabled}" />
+								<param name="setup.wizard.enabled" value="@{setup.wizard.enabled}" />
 							</antcall>
 
 							<antcall inheritAll="false" target="prepare-system-ext-properties" />
@@ -8586,6 +8588,7 @@ information. Make sure to commit in all format-javadoc results.
 			database.type="postgresql"
 			database.version="16.3"
 			generate.license.test.properties="true"
+			setup.wizard.enabled="true"
 		/>
 	</target>
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -13558,6 +13558,9 @@ analytics.cloud.domain.allowed=*</echo>
 					<property name="release.info.version.major" value="${release.info.version.major}" />
 					<property name="release.info.version.minor" value="${release.info.version.minor}" />
 				</ant>
+
+				<echo append="true" file="portal-impl/src/portal-ext.properties">
+enterprise.product.enterprise.search.enabled=false</echo>
 			</then>
 		</if>
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -13550,6 +13550,17 @@ feature.flag.LPD-11342=true</echo>
 		<echo append="true" file="portal-impl/src/portal-ext.properties">
 analytics.cloud.domain.allowed=*</echo>
 
+		<if>
+			<equals arg1="${generate.license.test.properties}" arg2="true" />
+			<then>
+				<ant antfile="build-developer.xml" dir="${release.tool.dir}" inheritAll="false" target="generate-license-test-properties">
+					<property name="properties.file" value="${project.dir}/portal-impl/src/portal-ext.properties" />
+					<property name="release.info.version.major" value="${release.info.version.major}" />
+					<property name="release.info.version.minor" value="${release.info.version.minor}" />
+				</ant>
+			</then>
+		</if>
+
 		<apply-portal-ext-properties />
 	</target>
 

--- a/git-commit/liferay-release-tool-ee
+++ b/git-commit/liferay-release-tool-ee
@@ -1,1 +1,1 @@
-HEAD
+https://github.com/tinatian/liferay-release-tool-ee/pull/143

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BannedKeyLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BannedKeyLicenseTest.java
@@ -7,13 +7,10 @@ package com.liferay.portal.license.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.lang.SafeCloseable;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.test.log.LogEntry;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -23,10 +20,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -35,16 +29,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class BannedKeyLicenseTest extends BaseLicenseTestCase {
-
-	@ClassRule
-	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			new AssumeTestRule("assume"), new LiferayIntegrationTestRule());
-
-	public static void assume() {
-		Assume.assumeTrue(isReleaseBundle());
-	}
 
 	@BeforeClass
 	public static void setUpClass() {

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
@@ -15,6 +15,8 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
@@ -29,6 +31,7 @@ import com.liferay.portal.module.framework.ModuleFrameworkUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.LicenseUtil;
 
 import java.io.File;
@@ -59,6 +62,9 @@ import net.bytebuddy.implementation.FixedValue;
 import net.bytebuddy.matcher.ElementMatchers;
 
 import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.ClassRule;
+import org.junit.Rule;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -68,6 +74,16 @@ import org.osgi.framework.launch.Framework;
  * @author Tina Tian
  */
 public abstract class BaseLicenseTestCase implements Serializable {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new AssumeTestRule("assume"), new LiferayIntegrationTestRule());
+
+	public static void assume() {
+		Assume.assumeTrue(isReleaseBundle());
+	}
 
 	public static SafeCloseable disableValidateWithSafeCloseable() {
 		return setReturnValueWithSafeCloseable(

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
@@ -75,8 +75,15 @@ public abstract class BaseLicenseTestCase implements Serializable {
 	}
 
 	public static boolean isReleaseBundle() {
-		if (ReflectionsHolder._licenseManagerHelperClass != null) {
-			return true;
+		try {
+			if (ReflectionsHolder._licenseManagerHelperClass != null) {
+				return true;
+			}
+		}
+		catch (ExceptionInInitializerError exceptionInInitializerError) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exceptionInInitializerError);
+			}
 		}
 
 		return false;
@@ -687,15 +694,15 @@ public abstract class BaseLicenseTestCase implements Serializable {
 
 	private static final String _PROPERTY_PREFIX = "license.test.";
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		BaseLicenseTestCase.class);
+
 	private static String _licensePackageName;
 	private static Properties _licenseTestProperties;
 	private static Object _lifecycleAction;
 	private static Class<?> _lifecycleActionClass;
 
 	private static class ReflectionsHolder {
-
-		private static final Log _log = LogFactoryUtil.getLog(
-			BaseLicenseTestCase.class);
 
 		private static Instrumentation _instrumentation;
 		private static Class<?> _licenseManagerHelperClass;

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CKEditorLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CKEditorLicenseTest.java
@@ -10,8 +10,6 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -19,7 +17,6 @@ import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.URLUtil;
 import com.liferay.portal.test.rule.Inject;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.io.File;
 
@@ -33,11 +30,8 @@ import java.util.List;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -50,16 +44,6 @@ import org.osgi.service.cm.ConfigurationAdmin;
  */
 @RunWith(Arquillian.class)
 public class CKEditorLicenseTest extends BaseLicenseTestCase {
-
-	@ClassRule
-	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			new AssumeTestRule("assume"), new LiferayIntegrationTestRule());
-
-	public static void assume() {
-		Assume.assumeTrue(isReleaseBundle());
-	}
 
 	@BeforeClass
 	public static void setUpClass() {

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CheckLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CheckLicenseTest.java
@@ -9,10 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.license.util.App;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.kernel.util.Time;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.LicenseUtil;
 
 import java.io.InputStream;
@@ -24,11 +21,8 @@ import java.nio.file.StandardCopyOption;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -37,16 +31,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class CheckLicenseTest extends BaseLicenseTestCase {
-
-	@ClassRule
-	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			new AssumeTestRule("assume"), new LiferayIntegrationTestRule());
-
-	public static void assume() {
-		Assume.assumeTrue(isReleaseBundle());
-	}
 
 	@BeforeClass
 	public static void setUpClass() {

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/ClusterLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/ClusterLicenseTest.java
@@ -37,6 +37,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -44,6 +45,7 @@ import org.junit.runner.RunWith;
  * @author Dante Wang
  * @author Jiefeng Wu
  */
+@Ignore
 @RunWith(Arquillian.class)
 public class ClusterLicenseTest extends BaseLicenseTestCase {
 

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/ClusterLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/ClusterLicenseTest.java
@@ -9,14 +9,11 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.kernel.test.rule.TomcatClusterTestRule;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.test.cluster.tomcat.TomcatCluster;
 import com.liferay.portal.test.cluster.tomcat.TomcatNode;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.LicenseUtil;
 
 import java.io.OutputStream;
@@ -38,10 +35,8 @@ import java.util.concurrent.TimeoutException;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -53,18 +48,8 @@ import org.junit.runner.RunWith;
 public class ClusterLicenseTest extends BaseLicenseTestCase {
 
 	@ClassRule
-	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			new AssumeTestRule("assume"), new LiferayIntegrationTestRule());
-
-	@ClassRule
 	public static final TomcatClusterTestRule tomcatClusterTestRule =
 		new TomcatClusterTestRule();
-
-	public static void assume() {
-		Assume.assumeTrue(isReleaseBundle());
-	}
 
 	@BeforeClass
 	public static void setUpClass() {

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/DXPModuleLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/DXPModuleLicenseTest.java
@@ -9,10 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.kernel.util.Time;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.io.File;
 
@@ -21,11 +18,8 @@ import java.util.Objects;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -38,16 +32,6 @@ import org.osgi.framework.BundleContext;
  */
 @RunWith(Arquillian.class)
 public class DXPModuleLicenseTest extends BaseLicenseTestCase {
-
-	@ClassRule
-	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			new AssumeTestRule("assume"), new LiferayIntegrationTestRule());
-
-	public static void assume() {
-		Assume.assumeTrue(isReleaseBundle());
-	}
 
 	@BeforeClass
 	public static void setUpClass() {

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/EnterpriseDatabaseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/EnterpriseDatabaseTest.java
@@ -11,11 +11,8 @@ import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.Time;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -23,8 +20,6 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -33,16 +28,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class EnterpriseDatabaseTest extends BaseLicenseTestCase {
-
-	@ClassRule
-	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			new AssumeTestRule("assume"), new LiferayIntegrationTestRule());
-
-	public static void assume() {
-		Assume.assumeTrue(isReleaseBundle());
-	}
 
 	@BeforeClass
 	public static void setUpClass() {

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/FreeTierDomainLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/FreeTierDomainLicenseTest.java
@@ -10,13 +10,10 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.test.log.LogEntry;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.net.InetAddress;
 
@@ -24,10 +21,7 @@ import java.util.List;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -36,16 +30,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class FreeTierDomainLicenseTest extends BaseLicenseTestCase {
-
-	@ClassRule
-	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			new AssumeTestRule("assume"), new LiferayIntegrationTestRule());
-
-	public static void assume() {
-		Assume.assumeTrue(isReleaseBundle());
-	}
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/FreeTierVersionLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/FreeTierVersionLicenseTest.java
@@ -8,13 +8,10 @@ package com.liferay.portal.license.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.test.log.LogEntry;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.lang.reflect.Field;
 
@@ -24,10 +21,7 @@ import java.util.Properties;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -36,16 +30,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class FreeTierVersionLicenseTest extends BaseLicenseTestCase {
-
-	@ClassRule
-	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			new AssumeTestRule("assume"), new LiferayIntegrationTestRule());
-
-	public static void assume() {
-		Assume.assumeTrue(isReleaseBundle());
-	}
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/PropertiesUtilLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/PropertiesUtilLicenseTest.java
@@ -8,9 +8,6 @@ package com.liferay.portal.license.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.license.util.App;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.AssumeTestRule;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -20,9 +17,6 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -31,16 +25,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class PropertiesUtilLicenseTest extends BaseLicenseTestCase {
-
-	@ClassRule
-	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			new AssumeTestRule("assume"), new LiferayIntegrationTestRule());
-
-	public static void assume() {
-		Assume.assumeTrue(isReleaseBundle());
-	}
 
 	@Test
 	public void test() throws Exception {

--- a/release.properties
+++ b/release.properties
@@ -152,7 +152,7 @@
 ##
 
     release.tool.dir=ext/7.4.x
-    release.tool.sha=ef58cf95c037dd232dc654b38e55df159403db4b
+    release.tool.sha=62f5e8be196f686f53bae2bda5bd09c8333663e1
 
 ##
 ## Sonatype

--- a/test.properties
+++ b/test.properties
@@ -1470,6 +1470,10 @@
 
     test.batch.class.names.excludes[junit-test-csv-report]=${test.batch.class.names.excludes}
 
+    test.batch.class.names.excludes[modules-integration-*]=\
+        ${test.batch.class.names.excludes},\
+        **/portal-license-test/**/*Test.java
+
     test.batch.class.names.excludes[modules-unit]=\
         ${test.batch.class.names.excludes},\
         **/integrations/**/src/test/**/*Test.java,\
@@ -1502,11 +1506,10 @@
     test.batch.class.names.excludes.temporary=\
         modules/apps/archived/**,\
         modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/db/test/OracleDBCTTest.java,\
-        modules/apps/portal/portal-license-test/**,\
         modules/dxp/apps/osb/osb-patcher/osb-patcher-test/**,\
         modules/test/poshi/poshi-runner/src/test/java/com/liferay/poshi/runner/var/**
 
-    test.batch.class.names.filter[integration-*]=**/test/integration/**/*Test.java
+    test.batch.class.names.filter[integration-license-*]=**/testIntegration/**/*Test.java
     test.batch.class.names.filter[modules-integration-analytics-cloud]=**/testIntegration/**/*Test.java
     test.batch.class.names.filter[modules-integration-project-templates]=${test.batch.class.names.filter[modules-unit*]}
     test.batch.class.names.filter[modules-integration-project-templates-jdk17_zulu]=${test.batch.class.names.filter[modules-unit*]}
@@ -1523,6 +1526,7 @@
         **/src/testIntegration/**/*Test.java,\
         **/test/unit/**/*Test.java
 
+    test.batch.class.names.includes[integration-license-*]=**/portal-license-test/**/*Test.java
     test.batch.class.names.includes[junit-test-csv-report]=${test.batch.class.names.includes}
     test.batch.class.names.includes[modules-integration-project-templates]=**/project-templates/**/src/test/**/*Test.java
     test.batch.class.names.includes[modules-integration-project-templates-jdk17_zulu]=**/project-templates/**/src/test/**/*Test.java
@@ -1559,9 +1563,7 @@
         **/test/**/LibraryReferenceTest.java,\
         **/test/**/ModulesStructureTest.java
 
-    test.batch.class.names.includes.modules[integration-*]=\
-        **/test/integration/**/*Test.java,\
-        test/integration/**/*Test.java
+    test.batch.class.names.includes.modules[integration-license-*]=**/portal-license-test/**/*Test.java
 
     test.batch.class.names.includes.modules[modules-integration-*]=\
         **/src/testIntegration/**/*Test.java,\
@@ -5297,6 +5299,7 @@
         #functional-upgrade-weblogic151-postgresql163,\
         functional-upgrade-wildfly300-mariadb106,\
         functional-weblogic151-mysql84-jdk21_zulu,\
+        integration-license-postgresql163,\
         modules-integration-postgresql163,\
         portal-renamed-tomcat-in-path-postgresql163,\
         portal-startup-space-in-path-postgresql163
@@ -5473,6 +5476,7 @@
         functional-smoke-wildfly300-mysql84-jdk21_zulu,\
         functional-tomcat101-postgresql163,\
         functional-upgrade-tomcat101-postgresql163,\
+        integration-license-postgresql163,\
         patching-tool-postgresql163,\
         playwright-js-tomcat101-postgresql163,\
         portal-license-smoke-postgresql163,\


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85380

## What Is Being Fixed

License integration tests under `portal-license-test` were not being executed by the Release Tester.

## How It Is Being Fixed

A new `integration-license` test batch is added. Now, the Release Tester will invoke it to run the license integration tests and verify licensing behavior on every new release.

Several initialization and configuration issues are addressed in this pull request to allow the test suite to run cleanly on a release bundle. `BaseLicenseTestCase` is consolidated so every license test asserts (via an `AssumeTestRule`) that it is running on a release bundle. The `isReleaseBundle()` call is hardened to catch and log exceptions to avoid masking failures. The Setup Wizard is enabled for `EnterpriseDatabaseTest`, enterprise search modules are disabled for the run, testing licenses are excluded from the bundle, and the release repository and Git hash are pinned to the current release tool snapshot. `ClusterLicenseTest` is temporarily disabled because it has performance issues running on CI; these issues will be addressed in a future pull request.