### PR TITLE
LPD-89421 Update license integration tests after KeyGenerator change

### DIFF
--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BannedKeyLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BannedKeyLicenseTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.test.log.LogEntry;
 
@@ -31,10 +32,13 @@ import org.junit.runner.RunWith;
 public class BannedKeyLicenseTest extends BaseLicenseTestCase {
 
 	@BeforeClass
-	public static void setUpClass() {
-		Class<?> clazz = getValidateClass();
+	public static void setUpClass() throws Exception {
+		ClassLoader classLoader = PortalClassLoaderUtil.getClassLoader();
 
-		for (Method method : clazz.getDeclaredMethods()) {
+		Class<?> keyGeneratorClass = classLoader.loadClass(
+			getProperty("key.generator.class"));
+
+		for (Method method : keyGeneratorClass.getDeclaredMethods()) {
 			Class<?>[] parameterTypes = method.getParameterTypes();
 
 			if ((parameterTypes.length == 1) &&
@@ -48,7 +52,9 @@ public class BannedKeyLicenseTest extends BaseLicenseTestCase {
 			}
 		}
 
-		for (Field field : clazz.getDeclaredFields()) {
+		Class<?> validateClass = getValidateClass();
+
+		for (Field field : validateClass.getDeclaredFields()) {
 			if (Set.class.isAssignableFrom(field.getType())) {
 				field.setAccessible(true);
 

--- a/release.properties
+++ b/release.properties
@@ -152,7 +152,7 @@
 ##
 
     release.tool.dir=ext/7.4.x
-    release.tool.sha=62f5e8be196f686f53bae2bda5bd09c8333663e1
+    release.tool.sha=1ba75a177ad35ab8e77c3a4ccc3555c9acf88d47
 
 ##
 ## Sonatype


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89421

Companion PR: <https://github.com/tinatian/liferay-release-tool-ee/pull/145>

## What Is Being Fixed

LPD-89421 migrated the `encrypt(Map<String, String> properties)` method from `KeyValidator.java` into `KeyGenerator.java`, which `BannedKeyLicenseTest.java` relies on.

## How It Is Being Fixed

The `setUpClass` method now loads the `KeyGenerator` class through `PortalClassLoaderUtil` using the new `key.generator.class` test property and reflects on it to find the `encrypt(Map<String, String> properties)` method. The companion commit bumps `release.tool.sha` so the portal pulls in the matching change on the liferay-release-tool-ee side.

## PR Check

**pr-check: PASS** — tested on `ea1267650d61762f7a09cb79d793d2dcd41962f0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "ea1267650d61762f7a09cb79d793d2dcd41962f0"} -->