### PR TITLE
LPD-92363 Rebuild object definition indexes on startup

### DIFF
--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 124.0.1
+Bundle-Version: 124.1.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalService.java
@@ -365,6 +365,10 @@ public interface ObjectRelationshipLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<ObjectRelationship> getObjectRelationships(
+		long objectDefinitionId1, boolean reverse, String type);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<ObjectRelationship> getObjectRelationships(
 		long objectDefinitionId1, int start, int end);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -448,4 +452,4 @@ public interface ObjectRelationshipLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1607602875
+// LIFERAY-SERVICE-BUILDER-HASH:146478146

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalServiceUtil.java
@@ -466,6 +466,13 @@ public class ObjectRelationshipLocalServiceUtil {
 	}
 
 	public static List<ObjectRelationship> getObjectRelationships(
+		long objectDefinitionId1, boolean reverse, String type) {
+
+		return getService().getObjectRelationships(
+			objectDefinitionId1, reverse, type);
+	}
+
+	public static List<ObjectRelationship> getObjectRelationships(
 		long objectDefinitionId1, int start, int end) {
 
 		return getService().getObjectRelationships(
@@ -604,4 +611,4 @@ public class ObjectRelationshipLocalServiceUtil {
 			ObjectRelationshipLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2020516816
+// LIFERAY-SERVICE-BUILDER-HASH:-320288305

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalServiceWrapper.java
@@ -541,6 +541,15 @@ public class ObjectRelationshipLocalServiceWrapper
 
 	@Override
 	public java.util.List<com.liferay.object.model.ObjectRelationship>
+		getObjectRelationships(
+			long objectDefinitionId1, boolean reverse, String type) {
+
+		return _objectRelationshipLocalService.getObjectRelationships(
+			objectDefinitionId1, reverse, type);
+	}
+
+	@Override
+	public java.util.List<com.liferay.object.model.ObjectRelationship>
 		getObjectRelationships(long objectDefinitionId1, int start, int end) {
 
 		return _objectRelationshipLocalService.getObjectRelationships(
@@ -713,4 +722,4 @@ public class ObjectRelationshipLocalServiceWrapper
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1131588211
+// LIFERAY-SERVICE-BUILDER-HASH:1817623923

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/exception/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/exception/packageinfo
@@ -1,1 +1,1 @@
-version 35.3.0
+version 35.4.0

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
@@ -1,1 +1,1 @@
-version 85.1.0
+version 85.2.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/instance/lifecycle/UpdateObjectDefinitionIndexesPortalInstanceLifecycleListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/instance/lifecycle/UpdateObjectDefinitionIndexesPortalInstanceLifecycleListener.java
@@ -1,0 +1,129 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.instance.lifecycle;
+
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.internal.dao.db.ObjectDBManagerUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.petra.sql.dsl.DynamicObjectRelationshipMappingTable;
+import com.liferay.object.petra.sql.dsl.DynamicObjectRelationshipMappingTableFactory;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.petra.sql.dsl.Column;
+import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
+import com.liferay.portal.instance.lifecycle.EveryNodeEveryStartup;
+import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+import java.sql.Connection;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Yuri Monteiro
+ */
+@Component(service = PortalInstanceLifecycleListener.class)
+public class UpdateObjectDefinitionIndexesPortalInstanceLifecycleListener
+	extends BasePortalInstanceLifecycleListener
+	implements EveryNodeEveryStartup {
+
+	@Override
+	public void portalInstanceRegistered(Company company) throws Exception {
+		if (!PropsValues.DATABASE_INDEXES_UPDATE_ON_STARTUP) {
+			return;
+		}
+
+		try (Connection connection = DataAccess.getConnection()) {
+			for (ObjectDefinition objectDefinition :
+					_objectDefinitionLocalService.getObjectDefinitions(
+						company.getCompanyId(), true,
+						WorkflowConstants.STATUS_APPROVED)) {
+
+				if (objectDefinition.isUnmodifiableSystemObject()) {
+					continue;
+				}
+
+				try {
+					_updateObjectDefinitionIndexes(
+						connection, objectDefinition);
+				}
+				catch (Exception exception) {
+					_log.error(
+						"Unable to update indexes for " +
+							objectDefinition.getName(),
+						exception);
+				}
+			}
+		}
+	}
+
+	private void _updateObjectDefinitionIndexes(
+			Connection connection, ObjectDefinition objectDefinition)
+		throws Exception {
+
+		for (ObjectField objectField :
+				_objectFieldLocalService.getObjectFieldsByBusinessType(
+					objectDefinition.getObjectDefinitionId(),
+					ObjectFieldConstants.BUSINESS_TYPE_RELATIONSHIP)) {
+
+			ObjectDBManagerUtil.createIndexMetadata(
+				connection, objectField.getDBTableName(), false,
+				objectField.getDBColumnName());
+		}
+
+		for (ObjectRelationship objectRelationship :
+				_objectRelationshipLocalService.getObjectRelationships(
+					objectDefinition.getObjectDefinitionId(), false,
+					ObjectRelationshipConstants.TYPE_MANY_TO_MANY)) {
+
+			DynamicObjectRelationshipMappingTable
+				dynamicObjectRelationshipMappingTable =
+					DynamicObjectRelationshipMappingTableFactory.create(
+						objectRelationship);
+
+			Column<DynamicObjectRelationshipMappingTable, Long>
+				primaryKeyColumn1 =
+					dynamicObjectRelationshipMappingTable.
+						getPrimaryKeyColumn1();
+
+			ObjectDBManagerUtil.createIndexMetadata(
+				connection, objectRelationship.getDBTableName(), false,
+				primaryKeyColumn1.getName());
+
+			Column<DynamicObjectRelationshipMappingTable, Long>
+				primaryKeyColumn2 =
+					dynamicObjectRelationshipMappingTable.
+						getPrimaryKeyColumn2();
+
+			ObjectDBManagerUtil.createIndexMetadata(
+				connection, objectRelationship.getDBTableName(), false,
+				primaryKeyColumn2.getName());
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		UpdateObjectDefinitionIndexesPortalInstanceLifecycleListener.class);
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectFieldLocalService _objectFieldLocalService;
+
+	@Reference
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -816,6 +816,14 @@ public class ObjectRelationshipLocalServiceImpl
 
 	@Override
 	public List<ObjectRelationship> getObjectRelationships(
+		long objectDefinitionId1, boolean reverse, String type) {
+
+		return objectRelationshipPersistence.findByODI1_R_T(
+			objectDefinitionId1, reverse, type);
+	}
+
+	@Override
+	public List<ObjectRelationship> getObjectRelationships(
 		long objectDefinitionId1, int start, int end) {
 
 		return objectRelationshipPersistence.findByObjectDefinitionId1(

--- a/modules/apps/object/object-test/build.gradle
+++ b/modules/apps/object/object-test/build.gradle
@@ -75,6 +75,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-workflow:portal-workflow-api")
 	testIntegrationImplementation project(":apps:portal-workflow:portal-workflow-kaleo-api")
 	testIntegrationImplementation project(":apps:portal:portal-db-partition-test-util")
+	testIntegrationImplementation project(":apps:portal:portal-instance-lifecycle-api")
 	testIntegrationImplementation project(":apps:portal:portal-props-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-upload-test-util")

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/instance/lifecycle/test/UpdateObjectDefinitionIndexesPortalInstanceLifecycleListenerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/instance/lifecycle/test/UpdateObjectDefinitionIndexesPortalInstanceLifecycleListenerTest.java
@@ -1,0 +1,232 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.instance.lifecycle.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.petra.sql.dsl.DynamicObjectRelationshipMappingTable;
+import com.liferay.object.petra.sql.dsl.DynamicObjectRelationshipMappingTableFactory;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.object.test.util.ObjectRelationshipTestUtil;
+import com.liferay.petra.sql.dsl.Column;
+import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.IndexMetadata;
+import com.liferay.portal.kernel.dao.db.IndexMetadataFactoryUtil;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.sql.Connection;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Yuri Monteiro
+ */
+@RunWith(Arquillian.class)
+public class UpdateObjectDefinitionIndexesPortalInstanceLifecycleListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_originalDatabaseIndexesUpdateOnStartup =
+			PropsValues.DATABASE_INDEXES_UPDATE_ON_STARTUP;
+
+		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
+		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition();
+	}
+
+	@After
+	public void tearDown() {
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "DATABASE_INDEXES_UPDATE_ON_STARTUP",
+			_originalDatabaseIndexesUpdateOnStartup);
+	}
+
+	@Test
+	public void testPortalInstanceRegisteredWithDatabaseIndexesUpdateOnStartupDisabled()
+		throws Exception {
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "DATABASE_INDEXES_UPDATE_ON_STARTUP", false);
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, _objectDefinition1,
+				_objectDefinition2,
+				ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+				StringUtil.randomId(),
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		ObjectField objectField = _objectFieldLocalService.getObjectField(
+			objectRelationship.getObjectFieldId2());
+
+		String columnName = objectField.getDBColumnName();
+		String tableName = objectField.getDBTableName();
+
+		_dropIndex(columnName, tableName);
+
+		Assert.assertFalse(_hasIndex(columnName, tableName));
+
+		_portalInstanceLifecycleListener.portalInstanceRegistered(
+			_companyLocalService.getCompany(TestPropsValues.getCompanyId()));
+
+		Assert.assertFalse(_hasIndex(columnName, tableName));
+	}
+
+	@Test
+	public void testPortalInstanceRegisteredWithManyToManyObjectRelationship()
+		throws Exception {
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "DATABASE_INDEXES_UPDATE_ON_STARTUP", true);
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, _objectDefinition1,
+				_objectDefinition2,
+				ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+				StringUtil.randomId(),
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		DynamicObjectRelationshipMappingTable
+			dynamicObjectRelationshipMappingTable =
+				DynamicObjectRelationshipMappingTableFactory.create(
+					objectRelationship);
+
+		Column<DynamicObjectRelationshipMappingTable, Long> primaryKeyColumn1 =
+			dynamicObjectRelationshipMappingTable.getPrimaryKeyColumn1();
+		Column<DynamicObjectRelationshipMappingTable, Long> primaryKeyColumn2 =
+			dynamicObjectRelationshipMappingTable.getPrimaryKeyColumn2();
+
+		String tableName = objectRelationship.getDBTableName();
+
+		Assert.assertTrue(_hasIndex(primaryKeyColumn1.getName(), tableName));
+		Assert.assertTrue(_hasIndex(primaryKeyColumn2.getName(), tableName));
+
+		_dropIndex(primaryKeyColumn1.getName(), tableName);
+		_dropIndex(primaryKeyColumn2.getName(), tableName);
+
+		Assert.assertFalse(_hasIndex(primaryKeyColumn1.getName(), tableName));
+		Assert.assertFalse(_hasIndex(primaryKeyColumn2.getName(), tableName));
+
+		_portalInstanceLifecycleListener.portalInstanceRegistered(
+			_companyLocalService.getCompany(TestPropsValues.getCompanyId()));
+
+		Assert.assertTrue(_hasIndex(primaryKeyColumn1.getName(), tableName));
+		Assert.assertTrue(_hasIndex(primaryKeyColumn2.getName(), tableName));
+	}
+
+	@Test
+	public void testPortalInstanceRegisteredWithOneToManyObjectRelationship()
+		throws Exception {
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "DATABASE_INDEXES_UPDATE_ON_STARTUP", true);
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, _objectDefinition1,
+				_objectDefinition2,
+				ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+				StringUtil.randomId(),
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		ObjectField objectField = _objectFieldLocalService.getObjectField(
+			objectRelationship.getObjectFieldId2());
+
+		String columnName = objectField.getDBColumnName();
+		String tableName = objectField.getDBTableName();
+
+		Assert.assertTrue(_hasIndex(columnName, tableName));
+
+		_dropIndex(columnName, tableName);
+
+		Assert.assertFalse(_hasIndex(columnName, tableName));
+
+		_portalInstanceLifecycleListener.portalInstanceRegistered(
+			_companyLocalService.getCompany(TestPropsValues.getCompanyId()));
+
+		Assert.assertTrue(_hasIndex(columnName, tableName));
+	}
+
+	private void _dropIndex(String columnName, String tableName)
+		throws Exception {
+
+		IndexMetadata indexMetadata =
+			IndexMetadataFactoryUtil.createIndexMetadata(
+				false, tableName, columnName);
+
+		try (Connection connection = DataAccess.getConnection()) {
+			DB db = DBManagerUtil.getDB();
+
+			db.runSQL(connection, indexMetadata.getDropSQL());
+		}
+	}
+
+	private boolean _hasIndex(String columnName, String tableName)
+		throws Exception {
+
+		IndexMetadata indexMetadata =
+			IndexMetadataFactoryUtil.createIndexMetadata(
+				false, tableName, columnName);
+
+		try (Connection connection = DataAccess.getConnection()) {
+			DBInspector dbInspector = new DBInspector(connection);
+
+			return dbInspector.hasIndex(
+				tableName, indexMetadata.getIndexName());
+		}
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition1;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition2;
+
+	@Inject
+	private ObjectFieldLocalService _objectFieldLocalService;
+
+	@Inject
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	private boolean _originalDatabaseIndexesUpdateOnStartup;
+
+	@Inject(
+		filter = "component.name=com.liferay.object.internal.instance.lifecycle.UpdateObjectDefinitionIndexesPortalInstanceLifecycleListener"
+	)
+	private PortalInstanceLifecycleListener _portalInstanceLifecycleListener;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92363

## What Is Being Fixed

With `database.indexes.update.on.startup=true`, missing indexes on Object Definition and API Builder tables are not rebuilt on restart. `IndexUpdaterUtil` only replays each bundle's static `META-INF/sql/indexes.sql`, and Object Definition tables are created dynamically per company, so their indexes fall outside that pass.

## How It Is Being Fixed

A new `UpdateObjectDefinitionIndexesPortalInstanceLifecycleListener` in `object-service` runs on every node on startup, gated by `database.indexes.update.on.startup`. When the property is enabled, it iterates each company's modifiable Object Definitions and ensures the relationship foreign-key indexes (main and extension tables) and the many-to-many mapping-table indexes exist, reusing the idempotent `DBInspector.hasIndex` check with a single connection per company.

## PR Check

**pr-check: PASS** — tested on `f15f7b961b36f58aa22cecbf106908547a18f24c`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "f15f7b961b36f58aa22cecbf106908547a18f24c"} -->
