### PR TITLE
LPD-94261 Fix @Retry to catch batched StaleStateException

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoInstanceLocalService.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoInstanceLocalService.java
@@ -377,7 +377,7 @@ public interface KaleoInstanceLocalService
 		properties = {
 			@Property(
 				name = ExceptionRetryAcceptor.EXCEPTION_NAME,
-				value = "org.hibernate.StaleObjectStateException"
+				value = "org.hibernate.StaleStateException"
 			)
 		}
 	)
@@ -401,4 +401,4 @@ public interface KaleoInstanceLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1052490119
+// LIFERAY-SERVICE-BUILDER-HASH:-980243224

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/resources/com/liferay/portal/workflow/kaleo/service/packageinfo
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/resources/com/liferay/portal/workflow/kaleo/service/packageinfo
@@ -1,1 +1,1 @@
-version 16.0.0
+version 16.0.1

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoInstanceLocalServiceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoInstanceLocalServiceImpl.java
@@ -439,7 +439,7 @@ public class KaleoInstanceLocalServiceImpl
 		properties = {
 			@Property(
 				name = ExceptionRetryAcceptor.EXCEPTION_NAME,
-				value = "org.hibernate.StaleObjectStateException"
+				value = "org.hibernate.StaleStateException"
 			)
 		}
 	)

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoInstanceLocalServiceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoInstanceLocalServiceTest.java
@@ -10,15 +10,27 @@ import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.blogs.service.BlogsEntryLocalService;
 import com.liferay.portal.kernel.exception.NoSuchWorkflowInstanceLinkException;
 import com.liferay.portal.kernel.model.WorkflowInstanceLink;
+import com.liferay.portal.kernel.security.auth.CompanyInheritableThreadLocalCallable;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.workflow.kaleo.model.KaleoInstance;
 import com.liferay.portal.workflow.kaleo.service.KaleoInstanceLocalService;
+
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.FutureTask;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -30,7 +42,8 @@ import org.junit.runner.RunWith;
  * @author Mateus Xavier
  */
 @RunWith(Arquillian.class)
-public class KaleoInstanceLocalServiceTest {
+public class KaleoInstanceLocalServiceTest
+	extends BaseKaleoLocalServiceTestCase {
 
 	@ClassRule
 	@Rule
@@ -62,6 +75,63 @@ public class KaleoInstanceLocalServiceTest {
 			() -> _workflowInstanceLinkLocalService.getWorkflowInstanceLink(
 				blogsEntry.getCompanyId(), blogsEntry.getGroupId(),
 				BlogsEntry.class.getName(), blogsEntry.getEntryId()));
+	}
+
+	@Test
+	public void testUpdateKaleoInstance() throws Exception {
+		KaleoInstance kaleoInstance = addKaleoInstance();
+
+		int threadCount = 5;
+
+		CyclicBarrier cyclicBarrier = new CyclicBarrier(threadCount);
+
+		List<FutureTask<KaleoInstance>> futureTasks = new ArrayList<>();
+
+		long kaleoInstanceId = kaleoInstance.getKaleoInstanceId();
+
+		for (int i = 0; i < threadCount; i++) {
+			FutureTask<KaleoInstance> futureTask = new FutureTask<>(
+				new CompanyInheritableThreadLocalCallable<>(
+					() -> {
+						cyclicBarrier.await();
+
+						return _kaleoInstanceLocalService.updateKaleoInstance(
+							kaleoInstanceId,
+							HashMapBuilder.<String, Serializable>put(
+								RandomTestUtil.randomString(),
+								RandomTestUtil.randomString()
+							).build());
+					}));
+
+			futureTasks.add(futureTask);
+		}
+
+		try (LogCapture logCapture1 = LoggerTestUtil.configureLog4JLogger(
+				"org.hibernate.engine.jdbc.batch.internal.BatchingBatch",
+				LoggerTestUtil.ERROR);
+			LogCapture logCapture2 = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.workflow.metrics.internal.petra.executor." +
+					"WorkflowMetricsPortalExecutor",
+				LoggerTestUtil.ERROR)) {
+
+			for (FutureTask<KaleoInstance> futureTask : futureTasks) {
+				Thread thread = new Thread(futureTask);
+
+				thread.start();
+			}
+
+			for (FutureTask<KaleoInstance> futureTask : futureTasks) {
+				futureTask.get();
+			}
+		}
+
+		long mvccVersion = kaleoInstance.getMvccVersion();
+
+		kaleoInstance = _kaleoInstanceLocalService.getKaleoInstance(
+			kaleoInstanceId);
+
+		Assert.assertEquals(
+			mvccVersion + threadCount, kaleoInstance.getMvccVersion());
 	}
 
 	@Inject


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94261

## What Is Being Fixed

`KaleoInstanceLocalService.updateKaleoInstance(long, Map)` was annotated with `@Retry` to handle optimistic locking failures, but the acceptor was configured to match `org.hibernate.StaleObjectStateException`. Under Hibernate batch mode (`batch_size > 0`), optimistic lock violations surface as the parent `StaleStateException` rather than the child class, so the retry was silently skipped for batched scenarios, allowing the original exception to propagate to callers.

## How It Is Being Fixed

The `@Retry` annotation's exception name is changed to `org.hibernate.StaleStateException`, which covers both batched and non-batched concurrent write conflicts. An integration test is added that uses a `CyclicBarrier` to force five threads to write concurrently against the same `KaleoInstance`, asserting that all updates commit successfully and that the MVCC version advances by the full thread count. The two `LogCapture` wrappers suppress `LogAssertionTestRule` from failing the test on expected batch ERROR logs.

## PR Check

**pr-check: PASS** — tested on `8adda8636f5c5ed67f3f267f9082c070cd918798`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "8adda8636f5c5ed67f3f267f9082c070cd918798"} -->