### PR TITLE
LPD-94720 Fix test

### DIFF
--- a/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/internal/portlet/test/LayoutTypePortletImplStaticPortletsTest.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/internal/portlet/test/LayoutTypePortletImplStaticPortletsTest.java
@@ -105,16 +105,9 @@ public class LayoutTypePortletImplStaticPortletsTest
 	}
 
 	private LayoutTypePortlet _reloadLayoutTypePortlet() throws Exception {
-		Class<? extends LayoutTypePortlet> clazz =
-			(Class<LayoutTypePortlet>)layoutTypePortlet.getClass();
+		Class<?> clazz = layoutTypePortlet.getClass();
 
-		ClassLoader classLoader = clazz.getClassLoader();
-
-		Class<?> anonymousInnerClass = classLoader.loadClass(
-			clazz.getName() + "$1");
-
-		ClassLoader reloadURLClassLoader = new ReloadURLClassLoader(
-			clazz, anonymousInnerClass);
+		ClassLoader reloadURLClassLoader = new ReloadURLClassLoader(clazz);
 
 		Class<? extends LayoutTypePortlet> reloadedClass =
 			(Class<? extends LayoutTypePortlet>)reloadURLClassLoader.loadClass(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94720

## What Is Being Fixed

Two integration tests in `LayoutTypePortletImplStaticPortletsTest` failed with
`ClassNotFoundException` for `com.liferay.portal.model.impl.LayoutTypePortletImpl$1`.

## How It Is Being Fixed

LPD-78503 (0ed63c1189d18) removed the anonymous `PortletWrapper` subclass inside
`LayoutTypePortletImpl.getStaticPortlets`, so `LayoutTypePortletImpl$1` no longer exists. The
reference in `_reloadLayoutTypePortlet` was not updated alongside that change and now triggers
`ClassNotFoundException`.

The fix drops the `$1` reference; with no inner classes left in `LayoutTypePortletImpl`, the helper
only needs to reload the outer class.

## Why Are There No Tests?

The commit itself is the test fix — it restores the two existing integration tests that LPD-78503
broke.

## PR Check

**pr-check: PASS** — tested on `0bc7c20e72eb2a9831c805abbfbe7c52b3fba2c3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "0bc7c20e72eb2a9831c805abbfbe7c52b3fba2c3"} -->
