### PR TITLE
LPD-95260 Prevent ArrayUtil.sortedUnique from mutating the passed array

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/util/ArrayUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/ArrayUtil.java
@@ -1459,6 +1459,8 @@ public class ArrayUtil {
 			return array;
 		}
 
+		array = Arrays.copyOf(array, array.length);
+
 		Arrays.sort(array);
 
 		int index = 0;
@@ -1484,6 +1486,8 @@ public class ArrayUtil {
 		if (array.length < 2) {
 			return array;
 		}
+
+		array = Arrays.copyOf(array, array.length);
 
 		Arrays.sort(array);
 
@@ -1511,6 +1515,8 @@ public class ArrayUtil {
 			return array;
 		}
 
+		array = Arrays.copyOf(array, array.length);
+
 		Arrays.sort(array);
 
 		int index = 0;
@@ -1536,6 +1542,8 @@ public class ArrayUtil {
 		if (array.length < 2) {
 			return array;
 		}
+
+		array = Arrays.copyOf(array, array.length);
 
 		Arrays.sort(array);
 
@@ -1563,6 +1571,8 @@ public class ArrayUtil {
 			return array;
 		}
 
+		array = Arrays.copyOf(array, array.length);
+
 		Arrays.sort(array);
 
 		int index = 0;
@@ -1589,6 +1599,8 @@ public class ArrayUtil {
 			return array;
 		}
 
+		array = Arrays.copyOf(array, array.length);
+
 		Arrays.sort(array);
 
 		int index = 0;
@@ -1614,6 +1626,8 @@ public class ArrayUtil {
 		if (array.length < 2) {
 			return array;
 		}
+
+		array = Arrays.copyOf(array, array.length);
 
 		Arrays.sort(array, Comparator.nullsLast(Comparator.naturalOrder()));
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/ArrayUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/ArrayUtilTest.java
@@ -838,7 +838,10 @@ public class ArrayUtilTest {
 
 		byte[] sortedUniqueBytes = ArrayUtil.sortedUnique(bytes);
 
-		Assert.assertSame(bytes, sortedUniqueBytes);
+		Assert.assertNotSame(bytes, sortedUniqueBytes);
+
+		Assert.assertArrayEquals(new byte[] {2, 3, 1}, bytes);
+
 		Assert.assertArrayEquals(new byte[] {1, 2, 3}, sortedUniqueBytes);
 
 		bytes = new byte[] {2, 3, 1, 2, 3, 3, 1};
@@ -846,13 +849,19 @@ public class ArrayUtilTest {
 		sortedUniqueBytes = ArrayUtil.sortedUnique(bytes);
 
 		Assert.assertNotSame(bytes, sortedUniqueBytes);
+
+		Assert.assertArrayEquals(new byte[] {2, 3, 1, 2, 3, 3, 1}, bytes);
+
 		Assert.assertArrayEquals(new byte[] {1, 2, 3}, sortedUniqueBytes);
 
 		double[] doubles = {2.0, 3.0, 1.0};
 
 		double[] sortedUniqueDoubles = ArrayUtil.sortedUnique(doubles);
 
-		Assert.assertSame(doubles, sortedUniqueDoubles);
+		Assert.assertNotSame(doubles, sortedUniqueDoubles);
+
+		Assert.assertArrayEquals(new double[] {2.0, 3.0, 1.0}, doubles, 0.0001);
+
 		Assert.assertArrayEquals(
 			new double[] {1.0, 2.0, 3.0}, sortedUniqueDoubles, 0.0001);
 
@@ -861,6 +870,10 @@ public class ArrayUtilTest {
 		sortedUniqueDoubles = ArrayUtil.sortedUnique(doubles);
 
 		Assert.assertNotSame(doubles, sortedUniqueDoubles);
+
+		Assert.assertArrayEquals(
+			new double[] {2.0, 3.0, 1.0, 2.0, 3.0, 3.0, 1.0}, doubles, 0.0001);
+
 		Assert.assertArrayEquals(
 			new double[] {1.0, 2.0, 3.0}, sortedUniqueDoubles, 0.0001);
 
@@ -868,7 +881,11 @@ public class ArrayUtilTest {
 
 		float[] sortedUniqueFloats = ArrayUtil.sortedUnique(floats);
 
-		Assert.assertSame(floats, sortedUniqueFloats);
+		Assert.assertNotSame(floats, sortedUniqueFloats);
+
+		Assert.assertArrayEquals(
+			new float[] {2.0F, 3.0F, 1.0F}, floats, 0.0001F);
+
 		Assert.assertArrayEquals(
 			new float[] {1.0F, 2.0F, 3.0F}, sortedUniqueFloats, 0.0001F);
 
@@ -877,6 +894,11 @@ public class ArrayUtilTest {
 		sortedUniqueFloats = ArrayUtil.sortedUnique(floats);
 
 		Assert.assertNotSame(floats, sortedUniqueFloats);
+
+		Assert.assertArrayEquals(
+			new float[] {2.0F, 3.0F, 1.0F, 2.0F, 3.0F, 3.0F, 1.0F}, floats,
+			0.0001F);
+
 		Assert.assertArrayEquals(
 			new float[] {1.0F, 2.0F, 3.0F}, sortedUniqueFloats, 0.0001F);
 
@@ -884,7 +906,10 @@ public class ArrayUtilTest {
 
 		int[] sortedUniqueInts = ArrayUtil.sortedUnique(ints);
 
-		Assert.assertSame(ints, sortedUniqueInts);
+		Assert.assertNotSame(ints, sortedUniqueInts);
+
+		Assert.assertArrayEquals(new int[] {2, 3, 1}, ints);
+
 		Assert.assertArrayEquals(new int[] {1, 2, 3}, sortedUniqueInts);
 
 		ints = new int[] {2, 3, 1, 2, 3, 3, 1};
@@ -892,13 +917,19 @@ public class ArrayUtilTest {
 		sortedUniqueInts = ArrayUtil.sortedUnique(ints);
 
 		Assert.assertNotSame(ints, sortedUniqueInts);
+
+		Assert.assertArrayEquals(new int[] {2, 3, 1, 2, 3, 3, 1}, ints);
+
 		Assert.assertArrayEquals(new int[] {1, 2, 3}, sortedUniqueInts);
 
 		long[] longs = {2, 3, 1};
 
 		long[] sortedUniqueLongs = ArrayUtil.sortedUnique(longs);
 
-		Assert.assertSame(longs, sortedUniqueLongs);
+		Assert.assertNotSame(longs, sortedUniqueLongs);
+
+		Assert.assertArrayEquals(new long[] {2, 3, 1}, longs);
+
 		Assert.assertArrayEquals(new long[] {1, 2, 3}, sortedUniqueLongs);
 
 		longs = new long[] {2, 3, 1, 2, 3, 3, 1};
@@ -906,13 +937,19 @@ public class ArrayUtilTest {
 		sortedUniqueLongs = ArrayUtil.sortedUnique(longs);
 
 		Assert.assertNotSame(longs, sortedUniqueLongs);
+
+		Assert.assertArrayEquals(new long[] {2, 3, 1, 2, 3, 3, 1}, longs);
+
 		Assert.assertArrayEquals(new long[] {1, 2, 3}, sortedUniqueLongs);
 
 		short[] shorts = {2, 3, 1};
 
 		short[] sortedUniqueShorts = ArrayUtil.sortedUnique(shorts);
 
-		Assert.assertSame(shorts, sortedUniqueShorts);
+		Assert.assertNotSame(shorts, sortedUniqueShorts);
+
+		Assert.assertArrayEquals(new short[] {2, 3, 1}, shorts);
+
 		Assert.assertArrayEquals(new short[] {1, 2, 3}, sortedUniqueShorts);
 
 		shorts = new short[] {2, 3, 1, 2, 3, 3, 1};
@@ -920,13 +957,19 @@ public class ArrayUtilTest {
 		sortedUniqueShorts = ArrayUtil.sortedUnique(shorts);
 
 		Assert.assertNotSame(shorts, sortedUniqueShorts);
+
+		Assert.assertArrayEquals(new short[] {2, 3, 1, 2, 3, 3, 1}, shorts);
+
 		Assert.assertArrayEquals(new short[] {1, 2, 3}, sortedUniqueShorts);
 
 		String[] strings = {"world", "hello"};
 
 		String[] sortedUniqueStrings = ArrayUtil.sortedUnique(strings);
 
-		Assert.assertSame(strings, sortedUniqueStrings);
+		Assert.assertNotSame(strings, sortedUniqueStrings);
+
+		Assert.assertArrayEquals(new String[] {"world", "hello"}, strings);
+
 		Assert.assertArrayEquals(
 			new String[] {"hello", "world"}, sortedUniqueStrings);
 
@@ -935,6 +978,11 @@ public class ArrayUtilTest {
 		sortedUniqueStrings = ArrayUtil.sortedUnique(strings);
 
 		Assert.assertNotSame(strings, sortedUniqueStrings);
+
+		Assert.assertArrayEquals(
+			new String[] {"world", "hello", null, "hello", null, "world"},
+			strings);
+
 		Assert.assertArrayEquals(
 			new String[] {"hello", "world", null}, sortedUniqueStrings);
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95260

## What is this trying to solve?

Reported via customer issue LPP-64454: internal vocabularies stop appearing
when editing Web Content, until Liferay is restarted. The root cause is that
`ArrayUtil.sortedUnique` sorts the array it is given in place. Callers pass the
shared static constant `AssetVocabularyConstants.VISIBILITY_TYPES` (`{1, 0}`)
straight through `getGroupVocabularies` into the generated finder
`AssetVocabularyPersistenceImpl.findByG_V`. Under concurrency the in-place
sort/dedup races on that shared array and corrupts it to `{0, 0}`, dropping the
INTERNAL visibility type for every subsequent request.

## How am I fixing it?

All seven `sortedUnique` overloads now copy the array before sorting, so the
caller's array is never mutated. Fixing it in the shared utility addresses the
corruption at its source for every caller — including the generated Service
Builder persistence, which cannot be hand-edited — and removes the same latent
hazard for other callers that pass shared arrays (for example
`PropsValues.LOCALES`). This matches the approach the customer suggested.

## How can you verify that it works?

Run the included automated tests.

## PR Check

**pr-check: PASS** — tested on `dc151a28c3fe1f55f4ae05c913fe08661e72eb49`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "dc151a28c3fe1f55f4ae05c913fe08661e72eb49"} -->
