### PR TITLE
LPD-80796 Fix instance settings lost on restart after upgrade

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	compileOnly group: "com.liferay", name: "org.apache.commons.fileupload", version: "1.5.JAKARTA-LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay", name: "org.apache.cxf.core", version: "3.6.11.JAKARTA-LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay", name: "org.apache.cxf.rt.frontend.jaxrs", version: "3.6.11.JAKARTA-LIFERAY-PATCHED-1"
+	compileOnly group: "com.liferay", name: "org.apache.felix.configadmin", version: "1.9.26.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay", name: "org.osgi.service.http.whiteboard", version: "1.1.1.JAKARTA-LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay", name: "org.osgi.service.jaxrs", version: "1.0.0.JAKARTA-LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay", name: "org.springframework.tx", version: "6.2.9.LIFERAY-PATCHED-1"

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/upgrade/registry/VulcanImplUpgradeStepRegistrator.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/upgrade/registry/VulcanImplUpgradeStepRegistrator.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.vulcan.internal.upgrade.registry;
 
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.portal.vulcan.internal.upgrade.v1_0_1.VulcanCompanyConfigurationUpgradeProcess;
 
@@ -23,6 +24,8 @@ public class VulcanImplUpgradeStepRegistrator
 	@Override
 	public void register(Registry registry) {
 		registry.registerInitialization();
+
+		registry.register("0.0.1", "1.0.0", new DummyUpgradeStep());
 
 		registry.register(
 			"1.0.0", "1.0.1",

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/upgrade/registry/VulcanImplUpgradeStepRegistrator.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/upgrade/registry/VulcanImplUpgradeStepRegistrator.java
@@ -5,14 +5,11 @@
 
 package com.liferay.portal.vulcan.internal.upgrade.registry;
 
-import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.portal.vulcan.internal.upgrade.v1_0_1.VulcanCompanyConfigurationUpgradeProcess;
 
-import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Vendel Toreki
@@ -28,15 +25,7 @@ public class VulcanImplUpgradeStepRegistrator
 		registry.register("0.0.1", "1.0.0", new DummyUpgradeStep());
 
 		registry.register(
-			"1.0.0", "1.0.1",
-			new VulcanCompanyConfigurationUpgradeProcess(
-				_companyLocalService, _configurationAdmin));
+			"1.0.0", "1.0.1", new VulcanCompanyConfigurationUpgradeProcess());
 	}
-
-	@Reference
-	private CompanyLocalService _companyLocalService;
-
-	@Reference
-	private ConfigurationAdmin _configurationAdmin;
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/upgrade/v1_0_1/VulcanCompanyConfigurationUpgradeProcess.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/upgrade/v1_0_1/VulcanCompanyConfigurationUpgradeProcess.java
@@ -59,7 +59,7 @@ public class VulcanCompanyConfigurationUpgradeProcess extends UpgradeProcess {
 
 				Object value = dictionary.get("companyId");
 
-				if (value instanceof Long) {
+				if ((value == null) || (value instanceof Long)) {
 					continue;
 				}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/upgrade/v1_0_1/VulcanCompanyConfigurationUpgradeProcess.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/upgrade/v1_0_1/VulcanCompanyConfigurationUpgradeProcess.java
@@ -5,79 +5,83 @@
 
 package com.liferay.portal.vulcan.internal.upgrade.v1_0_1;
 
+import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
+import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
-import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.vulcan.internal.configuration.VulcanCompanyConfiguration;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
 
 import java.util.Dictionary;
 
-import org.osgi.service.cm.Configuration;
-import org.osgi.service.cm.ConfigurationAdmin;
+import org.apache.felix.cm.file.ConfigurationHandler;
 
 /**
  * @author Vendel Toreki
  */
 public class VulcanCompanyConfigurationUpgradeProcess extends UpgradeProcess {
 
-	public VulcanCompanyConfigurationUpgradeProcess(
-		CompanyLocalService companyLocalService,
-		ConfigurationAdmin configurationAdmin) {
-
-		_companyLocalService = companyLocalService;
-		_configurationAdmin = configurationAdmin;
-	}
-
 	@Override
 	protected void doUpgrade() throws Exception {
-		_companyLocalService.forEachCompany(
-			company -> _upgradeVulcanCompanyConfigurations(
-				company.getCompanyId()));
-	}
-
-	private void _upgradeVulcanCompanyConfigurations(long companyId)
-		throws Exception {
-
-		String factoryPid =
-			"com.liferay.portal.vulcan.internal.configuration." +
-				"VulcanCompanyConfiguration";
-
-		Configuration[] configurations = _configurationAdmin.listConfigurations(
-			StringBundler.concat(
-				"(&(",
-				ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
-				"=", companyId, ")(path=*)(service.factoryPid=", factoryPid,
-				"))"));
-
-		if (configurations == null) {
+		if (!hasTable("Configuration_")) {
 			return;
 		}
 
-		for (Configuration configuration : configurations) {
-			Dictionary<String, Object> dictionary =
-				configuration.getProperties();
+		try (Statement statement = connection.createStatement();
+			ResultSet resultSet = statement.executeQuery(
+				StringBundler.concat(
+					"select * from Configuration_ where configurationId LIKE ",
+					"'%", VulcanCompanyConfiguration.class.getName(), "%'"));
+			PreparedStatement preparedStatement =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection,
+					"update Configuration_ set dictionary = ? where " +
+						"configurationId = ?")) {
 
-			if ((dictionary == null) || dictionary.isEmpty()) {
-				continue;
+			while (resultSet.next()) {
+				String dictionaryString = resultSet.getString("dictionary");
+
+				if (Validator.isNull(dictionaryString)) {
+					continue;
+				}
+
+				Dictionary<String, Object> dictionary =
+					ConfigurationHandler.read(
+						new UnsyncByteArrayInputStream(
+							dictionaryString.getBytes(StringPool.UTF8)));
+
+				Object value = dictionary.get("companyId");
+
+				if (value instanceof Long) {
+					continue;
+				}
+
+				dictionary.put("companyId", GetterUtil.getLong(value));
+
+				UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
+					new UnsyncByteArrayOutputStream();
+
+				ConfigurationHandler.write(
+					unsyncByteArrayOutputStream, dictionary);
+
+				preparedStatement.setString(
+					1, unsyncByteArrayOutputStream.toString());
+
+				preparedStatement.setString(
+					2, resultSet.getString("configurationId"));
+
+				preparedStatement.addBatch();
 			}
 
-			Object value = dictionary.get(
-				ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey());
-
-			if ((value == null) || (value instanceof Long)) {
-				continue;
-			}
-
-			dictionary.put(
-				ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
-				GetterUtil.getLong(value));
-
-			configuration.update(dictionary);
+			preparedStatement.executeBatch();
 		}
 	}
-
-	private final CompanyLocalService _companyLocalService;
-	private final ConfigurationAdmin _configurationAdmin;
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/upgrade/v1_0_1/VulcanCompanyConfigurationUpgradeProcess.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/upgrade/v1_0_1/VulcanCompanyConfigurationUpgradeProcess.java
@@ -35,10 +35,12 @@ public class VulcanCompanyConfigurationUpgradeProcess extends UpgradeProcess {
 		}
 
 		try (Statement statement = connection.createStatement();
+
 			ResultSet resultSet = statement.executeQuery(
 				StringBundler.concat(
 					"select * from Configuration_ where configurationId LIKE ",
 					"'%", VulcanCompanyConfiguration.class.getName(), "%'"));
+
 			PreparedStatement preparedStatement =
 				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
 					connection,

--- a/modules/apps/portal-vulcan/portal-vulcan-test/build.gradle
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	testIntegrationImplementation group: "com.liferay", name: "jakarta.ws.rs", version: "3.1.0.LIFERAY-PATCHED-1"
 	testIntegrationImplementation group: "com.liferay", name: "org.apache.cxf.core", version: "3.6.11.JAKARTA-LIFERAY-PATCHED-1"
 	testIntegrationImplementation group: "com.liferay", name: "org.apache.cxf.rt.frontend.jaxrs", version: "3.6.11.JAKARTA-LIFERAY-PATCHED-1"
+	testIntegrationImplementation group: "com.liferay", name: "org.apache.felix.configadmin", version: "1.9.26.LIFERAY-PATCHED-1"
 	testIntegrationImplementation group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
 	testIntegrationImplementation group: "org.skyscreamer", name: "jsonassert", version: "1.2.3"
 	testIntegrationImplementation group: "org.springframework", name: "spring-test", version: "6.2.9"

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/upgrade/v1_0_1/test/VulcanCompanyConfigurationUpgradeProcessTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/upgrade/v1_0_1/test/VulcanCompanyConfigurationUpgradeProcessTest.java
@@ -6,10 +6,15 @@
 package com.liferay.portal.vulcan.internal.upgrade.v1_0_1.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
+import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.kernel.cache.CacheRegistryUtil;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -22,17 +27,22 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
 
-import java.util.Arrays;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
 import java.util.Dictionary;
 
+import org.apache.felix.cm.file.ConfigurationHandler;
+
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.osgi.service.cm.Configuration;
-import org.osgi.service.cm.ConfigurationAdmin;
 
 /**
  * @author Vendel Toreki
@@ -47,49 +57,70 @@ public class VulcanCompanyConfigurationUpgradeProcessTest {
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
 
-	@Test
-	public void testUpgradeConfigurationCompanyIds() throws Exception {
-		String factoryPid =
-			"com.liferay.portal.vulcan.internal.configuration." +
-				"VulcanCompanyConfiguration";
+	@Before
+	public void setUp() throws Exception {
+		UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
+			new UnsyncByteArrayOutputStream();
 
-		Configuration configuration =
-			_configurationAdmin.createFactoryConfiguration(
-				factoryPid, StringPool.QUESTION);
-
-		long companyId = TestPropsValues.getCompanyId();
-		String path = RandomTestUtil.randomString();
-
-		configuration.update(
+		ConfigurationHandler.write(
+			unsyncByteArrayOutputStream,
 			HashMapDictionaryBuilder.<String, Object>put(
 				ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
-				String.valueOf(companyId)
+				String.valueOf(TestPropsValues.getCompanyId())
 			).put(
-				"path", path
+				"path", RandomTestUtil.randomString()
 			).build());
 
+		try (Connection connection = DataAccess.getConnection();
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"insert into Configuration_ (configurationId, dictionary) " +
+					"values(?, ?)")) {
+
+			preparedStatement.setString(1, _CONFIGURATION_ID);
+			preparedStatement.setString(
+				2, unsyncByteArrayOutputStream.toString());
+
+			preparedStatement.execute();
+		}
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		DB db = DBManagerUtil.getDB();
+
+		db.runSQL(
+			"delete from Configuration_ where configurationId ='" +
+				_CONFIGURATION_ID + "'");
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
 		_runUpgrade();
 
-		Configuration[] configurations = _configurationAdmin.listConfigurations(
-			StringBundler.concat(
-				"(&(",
-				ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
-				"=", companyId, ")(path=", path, ")(service.factoryPid=",
-				factoryPid, "))"));
+		try (Connection connection = DataAccess.getConnection();
+			Statement statement = connection.createStatement();
+			ResultSet resultSet = statement.executeQuery(
+				StringBundler.concat(
+					"select dictionary from Configuration_ where ",
+					"configurationId = '", _CONFIGURATION_ID, "'"))) {
 
-		Assert.assertEquals(
-			Arrays.toString(configurations), 1, configurations.length);
+			if (resultSet.next()) {
+				String dictionaryString = resultSet.getString("dictionary");
 
-		configuration = configurations[0];
+				Dictionary<String, Object> dictionary =
+					ConfigurationHandler.read(
+						new UnsyncByteArrayInputStream(
+							dictionaryString.getBytes(StringPool.UTF8)));
 
-		Dictionary<String, Object> dictionary = configuration.getProperties();
+				Object value = dictionary.get(
+					ExtendedObjectClassDefinition.Scope.COMPANY.
+						getPropertyKey());
 
-		Object value = dictionary.get(
-			ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey());
+				Assert.assertTrue(value instanceof Long);
 
-		Assert.assertTrue(value instanceof Long);
-
-		Assert.assertEquals(companyId, value);
+				Assert.assertEquals(TestPropsValues.getCompanyId(), value);
+			}
+		}
 	}
 
 	private void _runUpgrade() throws Exception {
@@ -103,12 +134,14 @@ public class VulcanCompanyConfigurationUpgradeProcessTest {
 		CacheRegistryUtil.clear();
 	}
 
-	@Inject
-	private ConfigurationAdmin _configurationAdmin;
+	private static final String _CONFIGURATION_ID =
+		"com.liferay.portal.vulcan.internal.configuration." +
+			"VulcanCompanyConfiguration.scoped~" +
+				RandomTestUtil.randomString();
 
 	@Inject(
 		filter = "(&(component.name=com.liferay.portal.vulcan.internal.upgrade.registry.VulcanImplUpgradeStepRegistrator))"
 	)
-	private UpgradeStepRegistrator _upgradeStepRegistrator;
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/upgrade/v1_0_1/test/VulcanCompanyConfigurationUpgradeProcessTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/upgrade/v1_0_1/test/VulcanCompanyConfigurationUpgradeProcessTest.java
@@ -72,6 +72,7 @@ public class VulcanCompanyConfigurationUpgradeProcessTest {
 			).build());
 
 		try (Connection connection = DataAccess.getConnection();
+
 			PreparedStatement preparedStatement = connection.prepareStatement(
 				"insert into Configuration_ (configurationId, dictionary) " +
 					"values(?, ?)")) {
@@ -98,7 +99,9 @@ public class VulcanCompanyConfigurationUpgradeProcessTest {
 		_runUpgrade();
 
 		try (Connection connection = DataAccess.getConnection();
+
 			Statement statement = connection.createStatement();
+
 			ResultSet resultSet = statement.executeQuery(
 				StringBundler.concat(
 					"select dictionary from Configuration_ where ",
@@ -142,6 +145,6 @@ public class VulcanCompanyConfigurationUpgradeProcessTest {
 	@Inject(
 		filter = "(&(component.name=com.liferay.portal.vulcan.internal.upgrade.registry.VulcanImplUpgradeStepRegistrator))"
 	)
-	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -776,6 +776,11 @@ public class PortalUpgradeProcessRegistryImpl
 			new Version(38, 5, 0),
 			UpgradeProcessFactory.addColumns(
 				"Layout", "styleBookEntryScopeERC VARCHAR(75) null"));
+
+		upgradeVersionTreeMap.put(
+			new Version(38, 6, 0),
+			UpgradeModulesFactory.create(
+				new String[] {"com.liferay.portal.vulcan.impl"}, null));
 	}
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-80796

## What Is Being Fixed

After upgrading to 2025.Q4.0+, instance-scoped Vulcan settings were lost on the next server restart. The company-scoped `VulcanCompanyConfiguration` entries in the `Configuration_` table stored their `companyId` as a `String` instead of a `Long`. When database partitioning is active, this incorrect data type prevented the configuration from being resolved on restart, so the settings appeared to vanish.

## How It Is Being Fixed

An upgrade step corrects the stored `companyId` data type for every affected `VulcanCompanyConfiguration` entry. Because `ConfigurationAdmin` cannot return the incorrect data (and does not read updated values back) under database partitioning, the upgrade is implemented in plain SQL: it reads each `Configuration_` row for the factory, deserializes the dictionary with Felix's `ConfigurationHandler`, rewrites `companyId` to a `Long` when it is not already one, and writes the dictionary back through a batched update. The step is registered as a `1.0.0` -> `1.0.1` upgrade (preceded by the required `0.0.1` -> `1.0.0` initialization) and the module is wired into the portal upgrade flow at version `38.6.0`. Entries whose `companyId` is not set are skipped rather than failing.

This fix depends on LPD-92462, which was resolved recently. With that change in place, the batched SQL update runs without causing deadlocks in certain scenarios.

## PR Check

**pr-check: PASS** — tested on `122cc83183121141f20ea760f417a8f123428f8c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "122cc83183121141f20ea760f417a8f123428f8c"} -->
