### PR TITLE
LPD-95334 Prevent cluster node shutdown hang when a queued send fails

### DIFF
--- a/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/BaseClusterChannel.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/BaseClusterChannel.java
@@ -35,7 +35,7 @@ public abstract class BaseClusterChannel implements ClusterChannel {
 		}
 
 		try {
-			_executorService.execute(() -> doSendMessage(message, null));
+			_executorService.execute(() -> _doSendMessage(message, null));
 		}
 		catch (RejectedExecutionException rejectedExecutionException) {
 			_log.error(
@@ -55,7 +55,7 @@ public abstract class BaseClusterChannel implements ClusterChannel {
 		}
 
 		try {
-			_executorService.execute(() -> doSendMessage(message, address));
+			_executorService.execute(() -> _doSendMessage(message, address));
 		}
 		catch (RejectedExecutionException rejectedExecutionException) {
 			_log.error(
@@ -68,6 +68,20 @@ public abstract class BaseClusterChannel implements ClusterChannel {
 
 	protected abstract void doSendMessage(
 		Serializable message, Address address);
+
+	private void _doSendMessage(Serializable message, Address address) {
+		try {
+			doSendMessage(message, address);
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					StringBundler.concat(
+						"Unable to send message ", message, " to ", address),
+					exception);
+			}
+		}
+	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		BaseClusterChannel.class);

--- a/modules/apps/portal/portal-cluster-multiple/src/test/java/com/liferay/portal/cluster/multiple/internal/BaseClusterChannelTest.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/test/java/com/liferay/portal/cluster/multiple/internal/BaseClusterChannelTest.java
@@ -1,0 +1,123 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.cluster.multiple.internal;
+
+import com.liferay.portal.kernel.cluster.Address;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.io.Serializable;
+
+import java.net.InetAddress;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Jiefeng Wu
+ */
+public class BaseClusterChannelTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testSendMulticastMessageWhenDoSendMessageFails()
+		throws Exception {
+
+		ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+		try {
+			CountDownLatch countDownLatch = new CountDownLatch(2);
+
+			List<Thread> threads = new CopyOnWriteArrayList<>();
+
+			AtomicInteger counter = new AtomicInteger();
+
+			BaseClusterChannel clusterChannel = new TestBaseClusterChannel(
+				executorService) {
+
+				@Override
+				protected void doSendMessage(
+					Serializable message, Address address) {
+
+					threads.add(Thread.currentThread());
+
+					countDownLatch.countDown();
+
+					if (counter.getAndIncrement() == 0) {
+						throw new RuntimeException(
+							"Simulated channel teardown failure");
+					}
+				}
+
+			};
+
+			try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+					BaseClusterChannel.class.getName(), LoggerTestUtil.WARN)) {
+
+				clusterChannel.sendMulticastMessage("message1");
+				clusterChannel.sendMulticastMessage("message2");
+
+				Assert.assertTrue(countDownLatch.await(1, TimeUnit.MINUTES));
+
+				Assert.assertEquals(threads.toString(), 2, threads.size());
+
+				Assert.assertSame(threads.get(0), threads.get(1));
+			}
+		}
+		finally {
+			executorService.shutdownNow();
+		}
+	}
+
+	private abstract static class TestBaseClusterChannel
+		extends BaseClusterChannel {
+
+		@Override
+		public void close() {
+		}
+
+		@Override
+		public InetAddress getBindInetAddress() {
+			return null;
+		}
+
+		@Override
+		public String getClusterName() {
+			return null;
+		}
+
+		@Override
+		public ClusterReceiver getClusterReceiver() {
+			return null;
+		}
+
+		@Override
+		public Address getLocalAddress() {
+			return null;
+		}
+
+		private TestBaseClusterChannel(ExecutorService executorService) {
+			super(executorService);
+		}
+
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95334

## What Is Being Fixed

BaseClusterChannel runs each send on a shared executor thread. While a cluster channel is shutting down, a send that is still queued can fire and fail (a JGroups channel rethrows the failure as it tears down). That failure was thrown straight out of the executor task, and an uncaught exception kills the worker thread that ran it. During a cluster node shutdown many queued sends failed at once, so many worker threads died together and contended on the shared stdout lock while printing their stack traces. That contention kept the forked node JVM from exiting, so the shutdown hung until the build was killed at its wall clock timeout (see ClusterGeneralTest timing out after 2 hours).

## How It Is Being Fixed

The queued send task is wrapped so a failing doSendMessage is caught and logged at WARN instead of propagating, keeping the worker thread alive so the node can shut down normally. A regression test, BaseClusterChannelTest.testSendMulticastMessageWhenDoSendMessageFails, uses a single thread executor and fails the first queued send, then asserts both sends run on the same worker thread — it fails against the unfixed code (the dying thread forces the second send onto a replacement) and passes once the task is wrapped. The expected WARN is routed through a LogCapture so it does not noise up the test output.

## PR Check

**pr-check: PASS** — tested on `2b32557e1983c8b2c1a03f18090db5e6ebac1f89`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "2b32557e1983c8b2c1a03f18090db5e6ebac1f89"} -->
