### PR TITLE
LPD-56169 Fix collection provider missing for related object definitions

### DIFF
--- a/cloud/helm/aws-infrastructure/templates/externalsecret-certificate.yaml
+++ b/cloud/helm/aws-infrastructure/templates/externalsecret-certificate.yaml
@@ -7,7 +7,7 @@
 {{- $fullSecretName := include "liferay.getFullCertificateSecretName" $secretName -}}
 {{- $k8sName := include "liferay.k8sFriendlyString" $secretName -}}
 {{- if not (hasKey $renderedSecrets $k8sName) }}
-{{- $_ := set $renderedSecrets $k8sName "true" -}}
+{{- $_ := set $renderedSecrets $k8sName "true" }}
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret

--- a/cloud/helm/aws-infrastructure/tests/elasticsearch_test.yaml
+++ b/cloud/helm/aws-infrastructure/tests/elasticsearch_test.yaml
@@ -1,0 +1,76 @@
+release:
+    name: my-release
+    namespace: my-namespace
+suite: Elasticsearch
+templates:
+    -   templates/elasticsearch.yaml
+tests:
+    -   asserts:
+            -   contains:
+                    any: true
+                    content:
+                        name: ES_SETTING_ONE
+                        value: one
+                    path: spec.nodeSets[0].podTemplate.spec.containers[0].env
+            -   contains:
+                    any: true
+                    content:
+                        name: ES_SETTING_TWO
+                        value: two
+                    path: spec.nodeSets[0].podTemplate.spec.containers[0].env
+        it: should append every custom env entry through the loop
+        set:
+            enabled: true
+            search.elasticsearch.customEnv:
+                x-extra:
+                    -   name: ES_SETTING_ONE
+                        value: one
+                    -   name: ES_SETTING_TWO
+                        value: two
+            search.elasticsearch.enabled: true
+    -   asserts:
+            -   contains:
+                    content:
+                        name: ES_JAVA_OPTS
+                        value: -Xms4g -Xmx4g
+                    path: spec.nodeSets[0].podTemplate.spec.containers[0].env
+        it: should apply the default JVM options when no custom env is configured
+        set:
+            enabled: true
+            search.elasticsearch.enabled: true
+    -   asserts:
+            -   equal:
+                    path: metadata.name
+                    value: custom-es
+        it: should name the Elasticsearch resource after the configured name override
+        set:
+            enabled: true
+            search.elasticsearch.enabled: true
+            search.elasticsearch.name: custom-es
+    -   asserts:
+            -   hasDocuments:
+                    count: 0
+        it: should omit the Elasticsearch resource when search is disabled by default
+    -   asserts:
+            -   hasDocuments:
+                    count: 0
+        it: should omit the Elasticsearch resource when the chart is disabled
+        set:
+            enabled: false
+            search.elasticsearch.enabled: true
+    -   asserts:
+            -   isKind:
+                    of: Elasticsearch
+            -   equal:
+                    path: metadata.name
+                    value: my-release-es
+            -   equal:
+                    path: spec.version
+                    value: 8.19.11
+            -   equal:
+                    path: spec.nodeSets[0].count
+                    value: 1
+        it: should render the Elasticsearch resource named after the release when search is enabled
+        set:
+            enabled: true
+            search.elasticsearch.enabled: true

--- a/cloud/helm/aws-infrastructure/tests/elasticsearch_test.yaml
+++ b/cloud/helm/aws-infrastructure/tests/elasticsearch_test.yaml
@@ -18,7 +18,7 @@ tests:
                         name: ES_SETTING_TWO
                         value: two
                     path: spec.nodeSets[0].podTemplate.spec.containers[0].env
-        it: appends every custom env entry through the loop
+        it: Appends every custom env entry through the loop
         set:
             enabled: true
             search.elasticsearch.customEnv:
@@ -34,7 +34,7 @@ tests:
                         name: ES_JAVA_OPTS
                         value: -Xms4g -Xmx4g
                     path: spec.nodeSets[0].podTemplate.spec.containers[0].env
-        it: applies the default JVM options when no custom env is configured
+        it: Applies the default JVM options when no custom env is configured
         set:
             enabled: true
             search.elasticsearch.enabled: true
@@ -42,7 +42,7 @@ tests:
             -   equal:
                     path: metadata.name
                     value: custom-es
-        it: names the Elasticsearch resource after the configured name override
+        it: Names the Elasticsearch resource after the configured name override
         set:
             enabled: true
             search.elasticsearch.enabled: true
@@ -50,11 +50,11 @@ tests:
     -   asserts:
             -   hasDocuments:
                     count: 0
-        it: omits the Elasticsearch resource when search is disabled by default
+        it: Omits the Elasticsearch resource when search is disabled by default
     -   asserts:
             -   hasDocuments:
                     count: 0
-        it: omits the Elasticsearch resource when the chart is disabled
+        it: Omits the Elasticsearch resource when the chart is disabled
         set:
             enabled: false
             search.elasticsearch.enabled: true
@@ -70,7 +70,7 @@ tests:
                     value: 8.19.11
             -   isKind:
                     of: Elasticsearch
-        it: renders the Elasticsearch resource named after the release when search is enabled
+        it: Renders the Elasticsearch resource named after the release when search is enabled
         set:
             enabled: true
             search.elasticsearch.enabled: true

--- a/cloud/helm/aws-infrastructure/tests/elasticsearch_test.yaml
+++ b/cloud/helm/aws-infrastructure/tests/elasticsearch_test.yaml
@@ -59,17 +59,17 @@ tests:
             enabled: false
             search.elasticsearch.enabled: true
     -   asserts:
-            -   isKind:
-                    of: Elasticsearch
             -   equal:
                     path: metadata.name
                     value: my-release-es
             -   equal:
-                    path: spec.version
-                    value: 8.19.11
-            -   equal:
                     path: spec.nodeSets[0].count
                     value: 1
+            -   equal:
+                    path: spec.version
+                    value: 8.19.11
+            -   isKind:
+                    of: Elasticsearch
         it: should render the Elasticsearch resource named after the release when search is enabled
         set:
             enabled: true

--- a/cloud/helm/aws-infrastructure/tests/elasticsearch_test.yaml
+++ b/cloud/helm/aws-infrastructure/tests/elasticsearch_test.yaml
@@ -18,7 +18,7 @@ tests:
                         name: ES_SETTING_TWO
                         value: two
                     path: spec.nodeSets[0].podTemplate.spec.containers[0].env
-        it: should append every custom env entry through the loop
+        it: appends every custom env entry through the loop
         set:
             enabled: true
             search.elasticsearch.customEnv:
@@ -34,7 +34,7 @@ tests:
                         name: ES_JAVA_OPTS
                         value: -Xms4g -Xmx4g
                     path: spec.nodeSets[0].podTemplate.spec.containers[0].env
-        it: should apply the default JVM options when no custom env is configured
+        it: applies the default JVM options when no custom env is configured
         set:
             enabled: true
             search.elasticsearch.enabled: true
@@ -42,7 +42,7 @@ tests:
             -   equal:
                     path: metadata.name
                     value: custom-es
-        it: should name the Elasticsearch resource after the configured name override
+        it: names the Elasticsearch resource after the configured name override
         set:
             enabled: true
             search.elasticsearch.enabled: true
@@ -50,11 +50,11 @@ tests:
     -   asserts:
             -   hasDocuments:
                     count: 0
-        it: should omit the Elasticsearch resource when search is disabled by default
+        it: omits the Elasticsearch resource when search is disabled by default
     -   asserts:
             -   hasDocuments:
                     count: 0
-        it: should omit the Elasticsearch resource when the chart is disabled
+        it: omits the Elasticsearch resource when the chart is disabled
         set:
             enabled: false
             search.elasticsearch.enabled: true
@@ -70,7 +70,7 @@ tests:
                     value: 8.19.11
             -   isKind:
                     of: Elasticsearch
-        it: should render the Elasticsearch resource named after the release when search is enabled
+        it: renders the Elasticsearch resource named after the release when search is enabled
         set:
             enabled: true
             search.elasticsearch.enabled: true

--- a/cloud/helm/aws-infrastructure/tests/externalsecret_certificate_test.yaml
+++ b/cloud/helm/aws-infrastructure/tests/externalsecret_certificate_test.yaml
@@ -16,7 +16,7 @@ tests:
                     count: 1
             -   isKind:
                     of: ExternalSecret
-        it: creates a certificate ExternalSecret keyed under the certificates path
+        it: Creates a certificate ExternalSecret keyed under the certificates path
         set:
             enabled: true
             endpoints:
@@ -30,7 +30,7 @@ tests:
     -   asserts:
             -   hasDocuments:
                     count: 2
-        it: creates one ExternalSecret per distinct certificate across endpoints
+        it: Creates one ExternalSecret per distinct certificate across endpoints
         set:
             enabled: true
             endpoints:
@@ -50,7 +50,7 @@ tests:
     -   asserts:
             -   hasDocuments:
                     count: 1
-        it: deduplicates a certificate referenced by more than one endpoint
+        it: Deduplicates a certificate referenced by more than one endpoint
         set:
             enabled: true
             endpoints:
@@ -70,7 +70,7 @@ tests:
     -   asserts:
             -   hasDocuments:
                     count: 0
-        it: omits the certificate ExternalSecret when no secret store is configured
+        it: Omits the certificate ExternalSecret when no secret store is configured
         set:
             enabled: true
             endpoints:

--- a/cloud/helm/aws-infrastructure/tests/externalsecret_certificate_test.yaml
+++ b/cloud/helm/aws-infrastructure/tests/externalsecret_certificate_test.yaml
@@ -1,4 +1,4 @@
-suite: certificate ExternalSecret
+suite: Certificate ExternalSecret
 templates:
     -   templates/externalsecret-certificate.yaml
 tests:

--- a/cloud/helm/aws-infrastructure/tests/externalsecret_certificate_test.yaml
+++ b/cloud/helm/aws-infrastructure/tests/externalsecret_certificate_test.yaml
@@ -16,7 +16,7 @@ tests:
                     count: 1
             -   isKind:
                     of: ExternalSecret
-        it: should create a certificate ExternalSecret keyed under the certificates path
+        it: creates a certificate ExternalSecret keyed under the certificates path
         set:
             enabled: true
             endpoints:
@@ -30,7 +30,7 @@ tests:
     -   asserts:
             -   hasDocuments:
                     count: 2
-        it: should create one ExternalSecret per distinct certificate across endpoints
+        it: creates one ExternalSecret per distinct certificate across endpoints
         set:
             enabled: true
             endpoints:
@@ -50,7 +50,7 @@ tests:
     -   asserts:
             -   hasDocuments:
                     count: 1
-        it: should deduplicate a certificate referenced by more than one endpoint
+        it: deduplicates a certificate referenced by more than one endpoint
         set:
             enabled: true
             endpoints:
@@ -70,7 +70,7 @@ tests:
     -   asserts:
             -   hasDocuments:
                     count: 0
-        it: should omit the certificate ExternalSecret when no secret store is configured
+        it: omits the certificate ExternalSecret when no secret store is configured
         set:
             enabled: true
             endpoints:

--- a/cloud/helm/aws-infrastructure/tests/externalsecret_certificate_test.yaml
+++ b/cloud/helm/aws-infrastructure/tests/externalsecret_certificate_test.yaml
@@ -1,0 +1,82 @@
+suite: certificate ExternalSecret
+templates:
+    -   templates/externalsecret-certificate.yaml
+tests:
+    -   asserts:
+            -   hasDocuments:
+                    count: 1
+            -   isKind:
+                    of: ExternalSecret
+            -   equal:
+                    path: metadata.name
+                    value: web-cert
+            -   equal:
+                    path: spec.dataFrom[0].extract.key
+                    value: liferay/certificates/web-cert
+            -   equal:
+                    path: spec.secretStoreRef.name
+                    value: my-store
+        it: should create a certificate ExternalSecret keyed under the certificates path
+        set:
+            enabled: true
+            endpoints:
+                web:
+                    port: 443
+                    protocol: HTTPS
+                    tls:
+                        externalSecretNames:
+                            -   web-cert
+            secretStoreName: my-store
+    -   asserts:
+            -   hasDocuments:
+                    count: 2
+        it: should create one ExternalSecret per distinct certificate across endpoints
+        set:
+            enabled: true
+            endpoints:
+                admin:
+                    port: 8443
+                    protocol: HTTPS
+                    tls:
+                        externalSecretNames:
+                            -   admin-cert
+                web:
+                    port: 443
+                    protocol: HTTPS
+                    tls:
+                        externalSecretNames:
+                            -   web-cert
+            secretStoreName: my-store
+    -   asserts:
+            -   hasDocuments:
+                    count: 1
+        it: should deduplicate a certificate referenced by more than one endpoint
+        set:
+            enabled: true
+            endpoints:
+                admin:
+                    port: 8443
+                    protocol: HTTPS
+                    tls:
+                        externalSecretNames:
+                            -   shared-cert
+                web:
+                    port: 443
+                    protocol: HTTPS
+                    tls:
+                        externalSecretNames:
+                            -   shared-cert
+            secretStoreName: my-store
+    -   asserts:
+            -   hasDocuments:
+                    count: 0
+        it: should omit the certificate ExternalSecret when no secret store is configured
+        set:
+            enabled: true
+            endpoints:
+                web:
+                    port: 443
+                    protocol: HTTPS
+                    tls:
+                        externalSecretNames:
+                            -   web-cert

--- a/cloud/helm/aws-infrastructure/tests/externalsecret_certificate_test.yaml
+++ b/cloud/helm/aws-infrastructure/tests/externalsecret_certificate_test.yaml
@@ -3,10 +3,6 @@ templates:
     -   templates/externalsecret-certificate.yaml
 tests:
     -   asserts:
-            -   hasDocuments:
-                    count: 1
-            -   isKind:
-                    of: ExternalSecret
             -   equal:
                     path: metadata.name
                     value: web-cert
@@ -16,6 +12,10 @@ tests:
             -   equal:
                     path: spec.secretStoreRef.name
                     value: my-store
+            -   hasDocuments:
+                    count: 1
+            -   isKind:
+                    of: ExternalSecret
         it: should create a certificate ExternalSecret keyed under the certificates path
         set:
             enabled: true

--- a/cloud/helm/aws-infrastructure/tests/externalsecret_license_test.yaml
+++ b/cloud/helm/aws-infrastructure/tests/externalsecret_license_test.yaml
@@ -16,7 +16,7 @@ tests:
                     count: 1
             -   isKind:
                     of: ExternalSecret
-        it: creates a license ExternalSecret keyed under the licenses path
+        it: Creates a license ExternalSecret keyed under the licenses path
         set:
             enabled: true
             license.externalSecretName: my-license
@@ -25,7 +25,7 @@ tests:
     -   asserts:
             -   hasDocuments:
                     count: 0
-        it: omits the license ExternalSecret when the target secret name is missing
+        it: Omits the license ExternalSecret when the target secret name is missing
         set:
             enabled: true
             license.externalSecretName: my-license

--- a/cloud/helm/aws-infrastructure/tests/externalsecret_license_test.yaml
+++ b/cloud/helm/aws-infrastructure/tests/externalsecret_license_test.yaml
@@ -3,10 +3,6 @@ templates:
     -   templates/externalsecret-license.yaml
 tests:
     -   asserts:
-            -   hasDocuments:
-                    count: 1
-            -   isKind:
-                    of: ExternalSecret
             -   equal:
                     path: metadata.name
                     value: liferay-licenses-my-license
@@ -16,6 +12,10 @@ tests:
             -   equal:
                     path: spec.target.name
                     value: liferay-license
+            -   hasDocuments:
+                    count: 1
+            -   isKind:
+                    of: ExternalSecret
         it: should create a license ExternalSecret keyed under the licenses path
         set:
             enabled: true

--- a/cloud/helm/aws-infrastructure/tests/externalsecret_license_test.yaml
+++ b/cloud/helm/aws-infrastructure/tests/externalsecret_license_test.yaml
@@ -1,0 +1,32 @@
+suite: license ExternalSecret
+templates:
+    -   templates/externalsecret-license.yaml
+tests:
+    -   asserts:
+            -   hasDocuments:
+                    count: 1
+            -   isKind:
+                    of: ExternalSecret
+            -   equal:
+                    path: metadata.name
+                    value: liferay-licenses-my-license
+            -   equal:
+                    path: spec.data[0].remoteRef.key
+                    value: liferay/licenses/my-license
+            -   equal:
+                    path: spec.target.name
+                    value: liferay-license
+        it: should create a license ExternalSecret keyed under the licenses path
+        set:
+            enabled: true
+            license.externalSecretName: my-license
+            license.targetSecretName: liferay-license
+            secretStoreName: my-store
+    -   asserts:
+            -   hasDocuments:
+                    count: 0
+        it: should omit the license ExternalSecret when the target secret name is missing
+        set:
+            enabled: true
+            license.externalSecretName: my-license
+            secretStoreName: my-store

--- a/cloud/helm/aws-infrastructure/tests/externalsecret_license_test.yaml
+++ b/cloud/helm/aws-infrastructure/tests/externalsecret_license_test.yaml
@@ -16,7 +16,7 @@ tests:
                     count: 1
             -   isKind:
                     of: ExternalSecret
-        it: should create a license ExternalSecret keyed under the licenses path
+        it: creates a license ExternalSecret keyed under the licenses path
         set:
             enabled: true
             license.externalSecretName: my-license
@@ -25,7 +25,7 @@ tests:
     -   asserts:
             -   hasDocuments:
                     count: 0
-        it: should omit the license ExternalSecret when the target secret name is missing
+        it: omits the license ExternalSecret when the target secret name is missing
         set:
             enabled: true
             license.externalSecretName: my-license

--- a/cloud/helm/aws-infrastructure/tests/externalsecret_license_test.yaml
+++ b/cloud/helm/aws-infrastructure/tests/externalsecret_license_test.yaml
@@ -1,4 +1,4 @@
-suite: license ExternalSecret
+suite: License ExternalSecret
 templates:
     -   templates/externalsecret-license.yaml
 tests:

--- a/cloud/helm/aws-infrastructure/tests/gateway_test.yaml
+++ b/cloud/helm/aws-infrastructure/tests/gateway_test.yaml
@@ -9,7 +9,7 @@ tests:
         documentSelector:
             path: kind
             value: Gateway
-        it: adds one listener per endpoint plus the implicit http listener
+        it: Adds one listener per endpoint plus the implicit http listener
         set:
             enabled: true
             endpoints:
@@ -34,7 +34,7 @@ tests:
         documentSelector:
             path: kind
             value: Gateway
-        it: adds the implicit http listener when no endpoints are configured
+        it: Adds the implicit http listener when no endpoints are configured
         set:
             enabled: true
             gateway.className: eg
@@ -49,7 +49,7 @@ tests:
         documentSelector:
             path: kind
             value: Gateway
-        it: builds certificate references from the endpoint external secret names
+        it: Builds certificate references from the endpoint external secret names
         set:
             enabled: true
             endpoints:
@@ -73,7 +73,7 @@ tests:
         documentSelector:
             path: kind
             value: ClientTrafficPolicy
-        it: names the ClientTrafficPolicy after the gateway with an attachment suffix
+        it: Names the ClientTrafficPolicy after the gateway with an attachment suffix
         set:
             enabled: true
             gateway.className: eg
@@ -81,13 +81,13 @@ tests:
     -   asserts:
             -   hasDocuments:
                     count: 0
-        it: omits the gateway resources when no gateway class and name are configured
+        it: Omits the gateway resources when no gateway class and name are configured
         set:
             enabled: true
     -   asserts:
             -   hasDocuments:
                     count: 2
-        it: renders both a ClientTrafficPolicy and a Gateway when configured
+        it: Renders both a ClientTrafficPolicy and a Gateway when configured
         set:
             enabled: true
             gateway.className: eg

--- a/cloud/helm/aws-infrastructure/tests/gateway_test.yaml
+++ b/cloud/helm/aws-infrastructure/tests/gateway_test.yaml
@@ -9,7 +9,7 @@ tests:
         documentSelector:
             path: kind
             value: Gateway
-        it: should add one listener per endpoint plus the implicit http listener
+        it: adds one listener per endpoint plus the implicit http listener
         set:
             enabled: true
             endpoints:
@@ -34,7 +34,7 @@ tests:
         documentSelector:
             path: kind
             value: Gateway
-        it: should add the implicit http listener when no endpoints are configured
+        it: adds the implicit http listener when no endpoints are configured
         set:
             enabled: true
             gateway.className: eg
@@ -49,7 +49,7 @@ tests:
         documentSelector:
             path: kind
             value: Gateway
-        it: should build certificate references from the endpoint external secret names
+        it: builds certificate references from the endpoint external secret names
         set:
             enabled: true
             endpoints:
@@ -73,7 +73,7 @@ tests:
         documentSelector:
             path: kind
             value: ClientTrafficPolicy
-        it: should name the ClientTrafficPolicy after the gateway with an attachment suffix
+        it: names the ClientTrafficPolicy after the gateway with an attachment suffix
         set:
             enabled: true
             gateway.className: eg
@@ -81,13 +81,13 @@ tests:
     -   asserts:
             -   hasDocuments:
                     count: 0
-        it: should omit the gateway resources when no gateway class and name are configured
+        it: omits the gateway resources when no gateway class and name are configured
         set:
             enabled: true
     -   asserts:
             -   hasDocuments:
                     count: 2
-        it: should render both a ClientTrafficPolicy and a Gateway when configured
+        it: renders both a ClientTrafficPolicy and a Gateway when configured
         set:
             enabled: true
             gateway.className: eg

--- a/cloud/helm/aws-infrastructure/tests/gateway_test.yaml
+++ b/cloud/helm/aws-infrastructure/tests/gateway_test.yaml
@@ -1,0 +1,94 @@
+suite: gateway
+templates:
+    -   templates/gateway.yaml
+tests:
+    -   asserts:
+            -   lengthEqual:
+                    count: 3
+                    path: spec.listeners
+        documentSelector:
+            path: kind
+            value: Gateway
+        it: should add one listener per endpoint plus the implicit http listener
+        set:
+            enabled: true
+            endpoints:
+                admin:
+                    port: 8443
+                    protocol: HTTPS
+                web:
+                    port: 443
+                    protocol: HTTPS
+            gateway.className: eg
+            gateway.name: liferay-gateway
+    -   asserts:
+            -   equal:
+                    path: metadata.name
+                    value: liferay-gateway
+            -   equal:
+                    path: spec.gatewayClassName
+                    value: eg
+            -   lengthEqual:
+                    count: 1
+                    path: spec.listeners
+        documentSelector:
+            path: kind
+            value: Gateway
+        it: should add the implicit http listener when no endpoints are configured
+        set:
+            enabled: true
+            gateway.className: eg
+            gateway.name: liferay-gateway
+    -   asserts:
+            -   contains:
+                    any: true
+                    content:
+                        kind: Secret
+                        name: web-cert
+                    path: spec.listeners[?(@.name=="web")].tls.certificateRefs
+        documentSelector:
+            path: kind
+            value: Gateway
+        it: should build certificate references from the endpoint external secret names
+        set:
+            enabled: true
+            endpoints:
+                web:
+                    port: 443
+                    protocol: HTTPS
+                    tls:
+                        externalSecretNames:
+                            -   web-cert
+            gateway.className: eg
+            gateway.name: liferay-gateway
+    -   asserts:
+            -   isKind:
+                    of: ClientTrafficPolicy
+            -   equal:
+                    path: metadata.name
+                    value: liferay-gateway-attachment
+            -   equal:
+                    path: spec.targetRefs[0].name
+                    value: liferay-gateway
+        documentSelector:
+            path: kind
+            value: ClientTrafficPolicy
+        it: should name the ClientTrafficPolicy after the gateway with an attachment suffix
+        set:
+            enabled: true
+            gateway.className: eg
+            gateway.name: liferay-gateway
+    -   asserts:
+            -   hasDocuments:
+                    count: 0
+        it: should omit the gateway resources when no gateway class and name are configured
+        set:
+            enabled: true
+    -   asserts:
+            -   hasDocuments:
+                    count: 2
+        it: should render both a ClientTrafficPolicy and a Gateway when configured
+        set:
+            enabled: true
+            gateway.className: eg
+            gateway.name: liferay-gateway

--- a/cloud/helm/aws-infrastructure/tests/gateway_test.yaml
+++ b/cloud/helm/aws-infrastructure/tests/gateway_test.yaml
@@ -1,4 +1,4 @@
-suite: gateway
+suite: Gateway
 templates:
     -   templates/gateway.yaml
 tests:

--- a/cloud/helm/aws-infrastructure/tests/gateway_test.yaml
+++ b/cloud/helm/aws-infrastructure/tests/gateway_test.yaml
@@ -62,14 +62,14 @@ tests:
             gateway.className: eg
             gateway.name: liferay-gateway
     -   asserts:
-            -   isKind:
-                    of: ClientTrafficPolicy
             -   equal:
                     path: metadata.name
                     value: liferay-gateway-attachment
             -   equal:
                     path: spec.targetRefs[0].name
                     value: liferay-gateway
+            -   isKind:
+                    of: ClientTrafficPolicy
         documentSelector:
             path: kind
             value: ClientTrafficPolicy

--- a/cloud/helm/aws-infrastructure/tests/liferayinfrastructure_test.yaml
+++ b/cloud/helm/aws-infrastructure/tests/liferayinfrastructure_test.yaml
@@ -16,13 +16,13 @@ tests:
                     count: 1
             -   isKind:
                     of: LiferayInfrastructure
-        it: should name the LiferayInfrastructure after the release
+        it: names the LiferayInfrastructure after the release
         set:
             enabled: true
     -   asserts:
             -   hasDocuments:
                     count: 0
-        it: should omit the LiferayInfrastructure when the chart is disabled
+        it: omits the LiferayInfrastructure when the chart is disabled
         set:
             enabled: false
     -   asserts:
@@ -35,7 +35,7 @@ tests:
             -   equal:
                     path: spec.region
                     value: us-east-1
-        it: should propagate the environment, project, and region into the spec
+        it: propagates the environment, project, and region into the spec
         set:
             environmentId: env-123
             projectId: proj-456
@@ -44,11 +44,11 @@ tests:
             -   equal:
                     path: spec.search.elasticsearch.enabled
                     value: false
-        it: should reflect the disabled Elasticsearch search engine by default
+        it: reflects the disabled Elasticsearch search engine by default
     -   asserts:
             -   equal:
                     path: spec.search.elasticsearch.enabled
                     value: true
-        it: should reflect the enabled Elasticsearch search engine when toggled on
+        it: reflects the enabled Elasticsearch search engine when toggled on
         set:
             search.elasticsearch.enabled: true

--- a/cloud/helm/aws-infrastructure/tests/liferayinfrastructure_test.yaml
+++ b/cloud/helm/aws-infrastructure/tests/liferayinfrastructure_test.yaml
@@ -6,16 +6,16 @@ templates:
     -   templates/liferayinfrastructure.yaml
 tests:
     -   asserts:
-            -   hasDocuments:
-                    count: 1
-            -   isKind:
-                    of: LiferayInfrastructure
             -   equal:
                     path: metadata.name
                     value: my-release
             -   equal:
                     path: metadata.namespace
                     value: my-namespace
+            -   hasDocuments:
+                    count: 1
+            -   isKind:
+                    of: LiferayInfrastructure
         it: should name the LiferayInfrastructure after the release
         set:
             enabled: true

--- a/cloud/helm/aws-infrastructure/tests/liferayinfrastructure_test.yaml
+++ b/cloud/helm/aws-infrastructure/tests/liferayinfrastructure_test.yaml
@@ -1,0 +1,54 @@
+release:
+    name: my-release
+    namespace: my-namespace
+suite: LiferayInfrastructure
+templates:
+    -   templates/liferayinfrastructure.yaml
+tests:
+    -   asserts:
+            -   hasDocuments:
+                    count: 1
+            -   isKind:
+                    of: LiferayInfrastructure
+            -   equal:
+                    path: metadata.name
+                    value: my-release
+            -   equal:
+                    path: metadata.namespace
+                    value: my-namespace
+        it: should name the LiferayInfrastructure after the release
+        set:
+            enabled: true
+    -   asserts:
+            -   hasDocuments:
+                    count: 0
+        it: should omit the LiferayInfrastructure when the chart is disabled
+        set:
+            enabled: false
+    -   asserts:
+            -   equal:
+                    path: spec.commonTags.EnvironmentId
+                    value: env-123
+            -   equal:
+                    path: spec.commonTags.ProjectId
+                    value: proj-456
+            -   equal:
+                    path: spec.region
+                    value: us-east-1
+        it: should propagate the environment, project, and region into the spec
+        set:
+            environmentId: env-123
+            projectId: proj-456
+            region: us-east-1
+    -   asserts:
+            -   equal:
+                    path: spec.search.elasticsearch.enabled
+                    value: false
+        it: should reflect the disabled Elasticsearch search engine by default
+    -   asserts:
+            -   equal:
+                    path: spec.search.elasticsearch.enabled
+                    value: true
+        it: should reflect the enabled Elasticsearch search engine when toggled on
+        set:
+            search.elasticsearch.enabled: true

--- a/cloud/helm/aws-infrastructure/tests/liferayinfrastructure_test.yaml
+++ b/cloud/helm/aws-infrastructure/tests/liferayinfrastructure_test.yaml
@@ -16,13 +16,13 @@ tests:
                     count: 1
             -   isKind:
                     of: LiferayInfrastructure
-        it: names the LiferayInfrastructure after the release
+        it: Names the LiferayInfrastructure after the release
         set:
             enabled: true
     -   asserts:
             -   hasDocuments:
                     count: 0
-        it: omits the LiferayInfrastructure when the chart is disabled
+        it: Omits the LiferayInfrastructure when the chart is disabled
         set:
             enabled: false
     -   asserts:
@@ -35,7 +35,7 @@ tests:
             -   equal:
                     path: spec.region
                     value: us-east-1
-        it: propagates the environment, project, and region into the spec
+        it: Propagates the environment, project, and region into the spec
         set:
             environmentId: env-123
             projectId: proj-456
@@ -44,11 +44,11 @@ tests:
             -   equal:
                     path: spec.search.elasticsearch.enabled
                     value: false
-        it: reflects the disabled Elasticsearch search engine by default
+        it: Reflects the disabled Elasticsearch search engine by default
     -   asserts:
             -   equal:
                     path: spec.search.elasticsearch.enabled
                     value: true
-        it: reflects the enabled Elasticsearch search engine when toggled on
+        it: Reflects the enabled Elasticsearch search engine when toggled on
         set:
             search.elasticsearch.enabled: true

--- a/cloud/helm/aws-marketplace/tests/marketplace_overrides_test.yaml
+++ b/cloud/helm/aws-marketplace/tests/marketplace_overrides_test.yaml
@@ -1,0 +1,37 @@
+suite: marketplace overrides
+templates:
+    -   charts/liferay-aws/charts/liferay-default/templates/workloads.yaml
+    -   charts/liferay-aws/charts/liferay-default/templates/configmap.yaml
+    -   charts/liferay-aws/charts/liferay-default/templates/liferay-init-scripts-cm.yaml
+tests:
+    -   asserts:
+            -   isKind:
+                    of: StatefulSet
+            -   equal:
+                    path: spec.template.spec.containers[0].image
+                    value: 709825985650.dkr.ecr.us-east-1.amazonaws.com/liferay/dxp:2025.q1.17-lts-slim
+        documentSelector:
+            path: kind
+            skipEmptyTemplates: true
+            value: StatefulSet
+        it: should deploy the AWS Marketplace ECR image by default
+    -   asserts:
+            -   equal:
+                    path: spec.template.spec.containers[0].image
+                    value: 709825985650.dkr.ecr.us-east-1.amazonaws.com/liferay/dxp:2025.q2.0
+        documentSelector:
+            path: kind
+            skipEmptyTemplates: true
+            value: StatefulSet
+        it: should honor an overridden image tag
+        set:
+            liferay-aws.liferay-default.image.tag: 2025.q2.0
+    -   asserts:
+            -   equal:
+                    path: metadata.labels.origin
+                    value: liferay-aws-marketplace
+        documentSelector:
+            path: kind
+            skipEmptyTemplates: true
+            value: StatefulSet
+        it: should label the StatefulSet with the liferay-aws-marketplace origin

--- a/cloud/helm/aws-marketplace/tests/marketplace_overrides_test.yaml
+++ b/cloud/helm/aws-marketplace/tests/marketplace_overrides_test.yaml
@@ -1,4 +1,4 @@
-suite: marketplace overrides
+suite: Marketplace Overrides
 templates:
     -   charts/liferay-aws/charts/liferay-default/templates/configmap.yaml
     -   charts/liferay-aws/charts/liferay-default/templates/liferay-init-scripts-cm.yaml

--- a/cloud/helm/aws-marketplace/tests/marketplace_overrides_test.yaml
+++ b/cloud/helm/aws-marketplace/tests/marketplace_overrides_test.yaml
@@ -14,7 +14,7 @@ tests:
             path: kind
             skipEmptyTemplates: true
             value: StatefulSet
-        it: deploys the AWS Marketplace ECR image by default
+        it: Deploys the AWS Marketplace ECR image by default
     -   asserts:
             -   equal:
                     path: spec.template.spec.containers[0].image
@@ -23,7 +23,7 @@ tests:
             path: kind
             skipEmptyTemplates: true
             value: StatefulSet
-        it: honors an overridden image tag
+        it: Honors an overridden image tag
         set:
             liferay-aws.liferay-default.image.tag: 2025.q2.0
     -   asserts:
@@ -34,4 +34,4 @@ tests:
             path: kind
             skipEmptyTemplates: true
             value: StatefulSet
-        it: labels the StatefulSet with the liferay-aws-marketplace origin
+        it: Labels the StatefulSet with the liferay-aws-marketplace origin

--- a/cloud/helm/aws-marketplace/tests/marketplace_overrides_test.yaml
+++ b/cloud/helm/aws-marketplace/tests/marketplace_overrides_test.yaml
@@ -14,7 +14,7 @@ tests:
             path: kind
             skipEmptyTemplates: true
             value: StatefulSet
-        it: should deploy the AWS Marketplace ECR image by default
+        it: deploys the AWS Marketplace ECR image by default
     -   asserts:
             -   equal:
                     path: spec.template.spec.containers[0].image
@@ -23,7 +23,7 @@ tests:
             path: kind
             skipEmptyTemplates: true
             value: StatefulSet
-        it: should honor an overridden image tag
+        it: honors an overridden image tag
         set:
             liferay-aws.liferay-default.image.tag: 2025.q2.0
     -   asserts:
@@ -34,4 +34,4 @@ tests:
             path: kind
             skipEmptyTemplates: true
             value: StatefulSet
-        it: should label the StatefulSet with the liferay-aws-marketplace origin
+        it: labels the StatefulSet with the liferay-aws-marketplace origin

--- a/cloud/helm/aws-marketplace/tests/marketplace_overrides_test.yaml
+++ b/cloud/helm/aws-marketplace/tests/marketplace_overrides_test.yaml
@@ -1,15 +1,15 @@
 suite: marketplace overrides
 templates:
-    -   charts/liferay-aws/charts/liferay-default/templates/workloads.yaml
     -   charts/liferay-aws/charts/liferay-default/templates/configmap.yaml
     -   charts/liferay-aws/charts/liferay-default/templates/liferay-init-scripts-cm.yaml
+    -   charts/liferay-aws/charts/liferay-default/templates/workloads.yaml
 tests:
     -   asserts:
-            -   isKind:
-                    of: StatefulSet
             -   equal:
                     path: spec.template.spec.containers[0].image
                     value: 709825985650.dkr.ecr.us-east-1.amazonaws.com/liferay/dxp:2025.q1.17-lts-slim
+            -   isKind:
+                    of: StatefulSet
         documentSelector:
             path: kind
             skipEmptyTemplates: true

--- a/cloud/helm/aws/tests/liferay_search_config_cm_test.yaml
+++ b/cloud/helm/aws/tests/liferay_search_config_cm_test.yaml
@@ -9,7 +9,7 @@ tests:
             -   matchRegex:
                     path: data["com.liferay.portal.bundle.blacklist.internal.configuration.BundleBlacklistConfiguration.config"]
                     pattern: "\"com.example.b\""
-        it: should append the portal bundle deny list entries through the loop
+        it: appends the portal bundle deny list entries through the loop
         set:
             liferay-default.portalBundleDenyList:
                 -   com.example.a
@@ -22,7 +22,7 @@ tests:
             -   matchRegex:
                     path: data["com.liferay.portal.bundle.blacklist.internal.configuration.BundleBlacklistConfiguration.config"]
                     pattern: com.liferay.portal.search.learning.to.rank.api
-        it: should blacklist the Elasticsearch bundles through the loop when the engine is opensearch
+        it: blacklists the Elasticsearch bundles through the loop when the engine is opensearch
         set:
             liferay-default.search.engine: opensearch
     -   asserts:
@@ -32,7 +32,7 @@ tests:
             -   matchRegex:
                     path: data["com.liferay.portal.search.elasticsearch8.configuration.ElasticsearchConfiguration.config"]
                     pattern: productionModeEnabled=B"true"
-        it: should render the Elasticsearch configuration when the engine is elasticsearch
+        it: renders the Elasticsearch configuration when the engine is elasticsearch
         set:
             liferay-default.portalBundleDenyList: []
             liferay-default.search.engine: elasticsearch
@@ -45,6 +45,6 @@ tests:
             -   matchRegex:
                     path: data["com.liferay.portal.search.opensearch2.configuration.OpenSearchConnectionConfiguration-REMOTE.config"]
                     pattern: active=B"true"
-        it: should render the OpenSearch configuration when the engine is opensearch
+        it: renders the OpenSearch configuration when the engine is opensearch
         set:
             liferay-default.search.engine: opensearch

--- a/cloud/helm/aws/tests/liferay_search_config_cm_test.yaml
+++ b/cloud/helm/aws/tests/liferay_search_config_cm_test.yaml
@@ -9,7 +9,7 @@ tests:
             -   matchRegex:
                     path: data["com.liferay.portal.bundle.blacklist.internal.configuration.BundleBlacklistConfiguration.config"]
                     pattern: "\"com.example.b\""
-        it: appends the portal bundle deny list entries through the loop
+        it: Appends the portal bundle deny list entries through the loop
         set:
             liferay-default.portalBundleDenyList:
                 -   com.example.a
@@ -22,7 +22,7 @@ tests:
             -   matchRegex:
                     path: data["com.liferay.portal.bundle.blacklist.internal.configuration.BundleBlacklistConfiguration.config"]
                     pattern: com.liferay.portal.search.learning.to.rank.api
-        it: blacklists the Elasticsearch bundles through the loop when the engine is opensearch
+        it: Blacklists the Elasticsearch bundles through the loop when the engine is opensearch
         set:
             liferay-default.search.engine: opensearch
     -   asserts:
@@ -32,7 +32,7 @@ tests:
             -   matchRegex:
                     path: data["com.liferay.portal.search.elasticsearch8.configuration.ElasticsearchConfiguration.config"]
                     pattern: productionModeEnabled=B"true"
-        it: renders the Elasticsearch configuration when the engine is elasticsearch
+        it: Renders the Elasticsearch configuration when the engine is elasticsearch
         set:
             liferay-default.portalBundleDenyList: []
             liferay-default.search.engine: elasticsearch
@@ -45,6 +45,6 @@ tests:
             -   matchRegex:
                     path: data["com.liferay.portal.search.opensearch2.configuration.OpenSearchConnectionConfiguration-REMOTE.config"]
                     pattern: active=B"true"
-        it: renders the OpenSearch configuration when the engine is opensearch
+        it: Renders the OpenSearch configuration when the engine is opensearch
         set:
             liferay-default.search.engine: opensearch

--- a/cloud/helm/aws/tests/liferay_search_config_cm_test.yaml
+++ b/cloud/helm/aws/tests/liferay_search_config_cm_test.yaml
@@ -1,0 +1,50 @@
+suite: search config configmap
+templates:
+    -   templates/liferay-search-config-cm.yaml
+tests:
+    -   asserts:
+            -   matchRegex:
+                    path: data["com.liferay.portal.bundle.blacklist.internal.configuration.BundleBlacklistConfiguration.config"]
+                    pattern: "\"com.example.a\""
+            -   matchRegex:
+                    path: data["com.liferay.portal.bundle.blacklist.internal.configuration.BundleBlacklistConfiguration.config"]
+                    pattern: "\"com.example.b\""
+        it: should append the portal bundle deny list entries through the loop
+        set:
+            liferay-default.portalBundleDenyList:
+                -   com.example.a
+                -   com.example.b
+            liferay-default.search.engine: elasticsearch
+    -   asserts:
+            -   matchRegex:
+                    path: data["com.liferay.portal.bundle.blacklist.internal.configuration.BundleBlacklistConfiguration.config"]
+                    pattern: com.liferay.portal.search.elasticsearch7.impl
+            -   matchRegex:
+                    path: data["com.liferay.portal.bundle.blacklist.internal.configuration.BundleBlacklistConfiguration.config"]
+                    pattern: com.liferay.portal.search.learning.to.rank.api
+        it: should blacklist the Elasticsearch bundles through the loop when the engine is opensearch
+        set:
+            liferay-default.search.engine: opensearch
+    -   asserts:
+            -   matchRegex:
+                    path: data["com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config"]
+                    pattern: operationMode="REMOTE"
+            -   matchRegex:
+                    path: data["com.liferay.portal.search.elasticsearch8.configuration.ElasticsearchConfiguration.config"]
+                    pattern: productionModeEnabled=B"true"
+        it: should render the Elasticsearch configuration when the engine is elasticsearch
+        set:
+            liferay-default.portalBundleDenyList: []
+            liferay-default.search.engine: elasticsearch
+    -   asserts:
+            -   isKind:
+                    of: ConfigMap
+            -   matchRegex:
+                    path: data["com.liferay.portal.search.opensearch2.configuration.OpenSearchConfiguration.config"]
+                    pattern: remoteClusterConnectionId="REMOTE"
+            -   matchRegex:
+                    path: data["com.liferay.portal.search.opensearch2.configuration.OpenSearchConnectionConfiguration-REMOTE.config"]
+                    pattern: active=B"true"
+        it: should render the OpenSearch configuration when the engine is opensearch
+        set:
+            liferay-default.search.engine: opensearch

--- a/cloud/helm/aws/tests/liferay_search_config_cm_test.yaml
+++ b/cloud/helm/aws/tests/liferay_search_config_cm_test.yaml
@@ -1,4 +1,4 @@
-suite: search config configmap
+suite: Search Config ConfigMap
 templates:
     -   templates/liferay-search-config-cm.yaml
 tests:

--- a/cloud/helm/aws/tests/liferay_search_env_cm_test.yaml
+++ b/cloud/helm/aws/tests/liferay_search_env_cm_test.yaml
@@ -1,4 +1,4 @@
-suite: search env configmap
+suite: Search Env ConfigMap
 templates:
     -   templates/liferay-search-env-cm.yaml
 tests:

--- a/cloud/helm/aws/tests/liferay_search_env_cm_test.yaml
+++ b/cloud/helm/aws/tests/liferay_search_env_cm_test.yaml
@@ -6,7 +6,7 @@ tests:
             -   equal:
                     path: data.LIFERAY_OPENSEARCH_ENABLED
                     value: "false"
-        it: should disable OpenSearch through the environment when the engine is elasticsearch
+        it: disables OpenSearch through the environment when the engine is elasticsearch
         set:
             liferay-default.portalBundleDenyList: []
             liferay-default.search.engine: elasticsearch
@@ -16,6 +16,6 @@ tests:
                     value: "true"
             -   isKind:
                     of: ConfigMap
-        it: should enable OpenSearch through the environment when the engine is opensearch
+        it: enables OpenSearch through the environment when the engine is opensearch
         set:
             liferay-default.search.engine: opensearch

--- a/cloud/helm/aws/tests/liferay_search_env_cm_test.yaml
+++ b/cloud/helm/aws/tests/liferay_search_env_cm_test.yaml
@@ -11,11 +11,11 @@ tests:
             liferay-default.portalBundleDenyList: []
             liferay-default.search.engine: elasticsearch
     -   asserts:
-            -   isKind:
-                    of: ConfigMap
             -   equal:
                     path: data.LIFERAY_OPENSEARCH_ENABLED
                     value: "true"
+            -   isKind:
+                    of: ConfigMap
         it: should enable OpenSearch through the environment when the engine is opensearch
         set:
             liferay-default.search.engine: opensearch

--- a/cloud/helm/aws/tests/liferay_search_env_cm_test.yaml
+++ b/cloud/helm/aws/tests/liferay_search_env_cm_test.yaml
@@ -1,0 +1,21 @@
+suite: search env configmap
+templates:
+    -   templates/liferay-search-env-cm.yaml
+tests:
+    -   asserts:
+            -   equal:
+                    path: data.LIFERAY_OPENSEARCH_ENABLED
+                    value: "false"
+        it: should disable OpenSearch through the environment when the engine is elasticsearch
+        set:
+            liferay-default.portalBundleDenyList: []
+            liferay-default.search.engine: elasticsearch
+    -   asserts:
+            -   isKind:
+                    of: ConfigMap
+            -   equal:
+                    path: data.LIFERAY_OPENSEARCH_ENABLED
+                    value: "true"
+        it: should enable OpenSearch through the environment when the engine is opensearch
+        set:
+            liferay-default.search.engine: opensearch

--- a/cloud/helm/aws/tests/liferay_search_env_cm_test.yaml
+++ b/cloud/helm/aws/tests/liferay_search_env_cm_test.yaml
@@ -6,7 +6,7 @@ tests:
             -   equal:
                     path: data.LIFERAY_OPENSEARCH_ENABLED
                     value: "false"
-        it: disables OpenSearch through the environment when the engine is elasticsearch
+        it: Disables OpenSearch through the environment when the engine is elasticsearch
         set:
             liferay-default.portalBundleDenyList: []
             liferay-default.search.engine: elasticsearch
@@ -16,6 +16,6 @@ tests:
                     value: "true"
             -   isKind:
                     of: ConfigMap
-        it: enables OpenSearch through the environment when the engine is opensearch
+        it: Enables OpenSearch through the environment when the engine is opensearch
         set:
             liferay-default.search.engine: opensearch

--- a/cloud/helm/aws/tests/triggerauthentication_test.yaml
+++ b/cloud/helm/aws/tests/triggerauthentication_test.yaml
@@ -8,6 +8,6 @@ tests:
                     value: aws
             -   isKind:
                     of: TriggerAuthentication
-        it: should render TriggerAuthentication with podIdentity.provider=aws when autoscaling is enabled
+        it: renders TriggerAuthentication with podIdentity.provider=aws when autoscaling is enabled
         set:
             liferay-default.autoscaling.enabled: true

--- a/cloud/helm/aws/tests/triggerauthentication_test.yaml
+++ b/cloud/helm/aws/tests/triggerauthentication_test.yaml
@@ -8,6 +8,6 @@ tests:
                     value: aws
             -   isKind:
                     of: TriggerAuthentication
-        it: renders TriggerAuthentication with podIdentity.provider=aws when autoscaling is enabled
+        it: Renders TriggerAuthentication with podIdentity.provider=aws when autoscaling is enabled
         set:
             liferay-default.autoscaling.enabled: true

--- a/cloud/helm/aws/tests/triggerauthentication_test.yaml
+++ b/cloud/helm/aws/tests/triggerauthentication_test.yaml
@@ -8,6 +8,6 @@ tests:
                     value: aws
             -   isKind:
                     of: TriggerAuthentication
-        it: renders TriggerAuthentication with podIdentity.provider=aws when autoscaling is enabled
+        it: should render TriggerAuthentication with podIdentity.provider=aws when autoscaling is enabled
         set:
             liferay-default.autoscaling.enabled: true

--- a/cloud/helm/gcp/tests/liferay-init-scripts-cm_test.yaml
+++ b/cloud/helm/gcp/tests/liferay-init-scripts-cm_test.yaml
@@ -8,4 +8,4 @@ tests:
                     value: liferay-init-scripts-gcp
             -   isKind:
                     of: ConfigMap
-        it: creates a ConfigMap named liferay-init-scripts-gcp
+        it: Creates a ConfigMap named liferay-init-scripts-gcp

--- a/modules/apps/commerce/commerce-fragment/commerce-fragment-impl/src/main/resources/META-INF/resources/js/account_selector/account_orders_data_set/props_transformers/PendingAccountOrdersFDSPropsTransformer.js
+++ b/modules/apps/commerce/commerce-fragment/commerce-fragment-impl/src/main/resources/META-INF/resources/js/account_selector/account_orders_data_set/props_transformers/PendingAccountOrdersFDSPropsTransformer.js
@@ -3,32 +3,51 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {commerceEvents} from 'commerce-frontend-js';
+
 import PendingOrderIdDataRenderer, {
 	wipeCurrencyAndNavigate,
 } from '../data_renderers/PendingOrderIdDataRenderer';
 
-const PendingOrdersFDSPropsTransformer = (props) => ({
-	...props,
-	customDataRenderers: {
-		pendingOrderIdDataRenderer: (itemProps) =>
-			PendingOrderIdDataRenderer({
-				...itemProps,
-				setCurrentOrderURL: props.additionalProps.setCurrentOrderURL,
-			}),
-	},
-	onActionDropdownItemClick: ({
-		action: {
-			data: {id: actionId},
-		},
-		itemData: cart,
-	}) => {
-		if (actionId === 'view') {
-			wipeCurrencyAndNavigate({
-				cart,
-				setCurrentOrderURL: props.additionalProps.setCurrentOrderURL,
-			});
+const PendingOrdersFDSPropsTransformer = (props) => {
+	let currentOrder;
+
+	const refreshDataSet = ({order} = {}) => {
+		if (!currentOrder || currentOrder.id !== order?.id) {
+			currentOrder = order;
+
+			Liferay.fire(commerceEvents.FDS_UPDATE_DISPLAY, {id: props.id});
 		}
-	},
-});
+	};
+
+	Liferay.on(commerceEvents.CURRENT_ORDER_UPDATED, refreshDataSet);
+	Liferay.on(commerceEvents.CURRENT_ORDER_DELETED, refreshDataSet);
+
+	return {
+		...props,
+		customDataRenderers: {
+			pendingOrderIdDataRenderer: (itemProps) =>
+				PendingOrderIdDataRenderer({
+					...itemProps,
+					setCurrentOrderURL:
+						props.additionalProps.setCurrentOrderURL,
+				}),
+		},
+		onActionDropdownItemClick: ({
+			action: {
+				data: {id: actionId},
+			},
+			itemData: cart,
+		}) => {
+			if (actionId === 'view') {
+				wipeCurrencyAndNavigate({
+					cart,
+					setCurrentOrderURL:
+						props.additionalProps.setCurrentOrderURL,
+				});
+			}
+		},
+	};
+};
 
 export default PendingOrdersFDSPropsTransformer;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -282,6 +282,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		Map<Long, List<ObjectRelationship>> objectRelationshipsMap) {
 
 		if (objectDefinition.isUnmodifiableSystemObject()) {
+			_registerObjectRelationshipsRelatedInfoCollectionProviders(
+				objectDefinition, objectRelationshipsMap);
+
 			return Collections.emptyList();
 		}
 
@@ -537,18 +540,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 					objectDefinition, objectLayout.getObjectLayoutTabs());
 		}
 
-		List<ObjectRelationship> objectRelationships = null;
-
-		if (objectRelationshipsMap != null) {
-			objectRelationships = objectRelationshipsMap.getOrDefault(
-				objectDefinition.getObjectDefinitionId(),
-				Collections.emptyList());
-		}
-
-		_objectRelationshipLocalService.
-			registerObjectRelationshipsRelatedInfoCollectionProviders(
-				objectDefinition, _objectDefinitionLocalService,
-				objectRelationships);
+		_registerObjectRelationshipsRelatedInfoCollectionProviders(
+			objectDefinition, objectRelationshipsMap);
 
 		try {
 			if (ArrayUtil.isNotEmpty(
@@ -580,6 +573,24 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		return StringBundler.concat(
 			serviceRegistrationKey, StringPool.POUND,
 			objectRelationship.getObjectRelationshipId());
+	}
+
+	private void _registerObjectRelationshipsRelatedInfoCollectionProviders(
+		ObjectDefinition objectDefinition,
+		Map<Long, List<ObjectRelationship>> objectRelationshipsMap) {
+
+		List<ObjectRelationship> objectRelationships = null;
+
+		if (objectRelationshipsMap != null) {
+			objectRelationships = objectRelationshipsMap.getOrDefault(
+				objectDefinition.getObjectDefinitionId(),
+				Collections.emptyList());
+		}
+
+		_objectRelationshipLocalService.
+			registerObjectRelationshipsRelatedInfoCollectionProviders(
+				objectDefinition, _objectDefinitionLocalService,
+				objectRelationships);
 	}
 
 	private void _registerRootObjectLayoutTabScreenNavigationCategories(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/BaseObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/BaseObjectRelationshipRelatedInfoCollectionProvider.java
@@ -13,16 +13,21 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.system.SystemObjectEntry;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.util.Collections;
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * @author Feliphe Marinho
@@ -47,23 +52,56 @@ public abstract class BaseObjectRelationshipRelatedInfoCollectionProvider
 	public InfoPage<ObjectEntry> getCollectionInfoPage(
 		CollectionQuery collectionQuery) {
 
-		Object relatedItem = collectionQuery.getRelatedItem();
-
-		if (!(relatedItem instanceof ObjectEntry)) {
-			return InfoPage.of(
-				Collections.emptyList(), collectionQuery.getPagination(), 0);
-		}
+		Pagination pagination = collectionQuery.getPagination();
 
 		try {
-			return getCollectionInfoPage(
-				(ObjectEntry)relatedItem, collectionQuery.getPagination());
+			Object relatedItem = collectionQuery.getRelatedItem();
+
+			if (relatedItem instanceof ObjectEntry) {
+				ObjectEntry objectEntry = (ObjectEntry)relatedItem;
+
+				return getCollectionInfoPage(
+					objectEntry.getGroupId(), pagination,
+					objectEntry.getObjectEntryId());
+			}
+
+			if (relatedItem instanceof SystemObjectEntry) {
+				SystemObjectEntry systemObjectEntry =
+					(SystemObjectEntry)relatedItem;
+
+				return getCollectionInfoPage(
+					systemObjectEntry.getGroupId(), pagination,
+					systemObjectEntry.getClassPK());
+			}
+
+			if (_objectDefinition1.isUnmodifiableSystemObject() &&
+				(relatedItem instanceof BaseModel)) {
+
+				long groupId = 0;
+
+				if (relatedItem instanceof GroupedModel) {
+					GroupedModel groupedModel = (GroupedModel)relatedItem;
+
+					groupId = groupedModel.getGroupId();
+				}
+
+				BaseModel<?> baseModel = (BaseModel<?>)relatedItem;
+
+				Map<String, Object> modelAttributes =
+					baseModel.getModelAttributes();
+
+				return getCollectionInfoPage(
+					groupId, pagination,
+					GetterUtil.getLong(
+						modelAttributes.get(
+							_objectDefinition1.getPKObjectFieldName())));
+			}
 		}
 		catch (PortalException portalException) {
 			_log.error(portalException);
 		}
 
-		return InfoPage.of(
-			Collections.emptyList(), collectionQuery.getPagination(), 0);
+		return InfoPage.of(Collections.emptyList(), pagination, 0);
 	}
 
 	@Override
@@ -110,7 +148,7 @@ public abstract class BaseObjectRelationshipRelatedInfoCollectionProvider
 	}
 
 	protected InfoPage<ObjectEntry> getCollectionInfoPage(
-			ObjectEntry objectEntry, Pagination pagination)
+			long groupId, Pagination pagination, long primaryKey)
 		throws PortalException {
 
 		return null;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ManyToManyObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ManyToManyObjectRelationshipRelatedInfoCollectionProvider.java
@@ -33,22 +33,18 @@ public class ManyToManyObjectRelationshipRelatedInfoCollectionProvider
 
 	@Override
 	protected InfoPage<ObjectEntry> getCollectionInfoPage(
-			ObjectEntry objectEntry, Pagination pagination)
+			long groupId, Pagination pagination, long primaryKey)
 		throws PortalException {
 
 		return InfoPage.of(
 			objectEntryLocalService.getManyToManyObjectEntries(
-				objectEntry.getGroupId(),
-				objectRelationship.getObjectRelationshipId(),
-				objectEntry.getObjectEntryId(), true,
-				objectRelationship.isReverse(), null, pagination.getStart(),
-				pagination.getEnd()),
+				groupId, objectRelationship.getObjectRelationshipId(),
+				primaryKey, true, objectRelationship.isReverse(), null,
+				pagination.getStart(), pagination.getEnd()),
 			pagination,
 			objectEntryLocalService.getManyToManyObjectEntriesCount(
-				objectEntry.getGroupId(),
-				objectRelationship.getObjectRelationshipId(),
-				objectEntry.getObjectEntryId(), true,
-				objectRelationship.isReverse(), null));
+				groupId, objectRelationship.getObjectRelationshipId(),
+				primaryKey, true, objectRelationship.isReverse(), null));
 	}
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/OneToManyObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/OneToManyObjectRelationshipRelatedInfoCollectionProvider.java
@@ -33,20 +33,18 @@ public class OneToManyObjectRelationshipRelatedInfoCollectionProvider
 
 	@Override
 	protected InfoPage<ObjectEntry> getCollectionInfoPage(
-			ObjectEntry objectEntry, Pagination pagination)
+			long groupId, Pagination pagination, long primaryKey)
 		throws PortalException {
 
 		return InfoPage.of(
 			objectEntryLocalService.getOneToManyObjectEntries(
-				objectEntry.getGroupId(),
-				objectRelationship.getObjectRelationshipId(), null, false,
-				objectEntry.getObjectEntryId(), true, null,
-				pagination.getStart(), pagination.getEnd(), null),
+				groupId, objectRelationship.getObjectRelationshipId(), null,
+				false, primaryKey, true, null, pagination.getStart(),
+				pagination.getEnd(), null),
 			pagination,
 			objectEntryLocalService.getOneToManyObjectEntriesCount(
-				objectEntry.getGroupId(),
-				objectRelationship.getObjectRelationshipId(), null,
-				objectEntry.getObjectEntryId(), true, null));
+				groupId, objectRelationship.getObjectRelationshipId(), null,
+				primaryKey, true, null));
 	}
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/RelatedInfoCollectionProviderFactory.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/RelatedInfoCollectionProviderFactory.java
@@ -30,9 +30,7 @@ public class RelatedInfoCollectionProviderFactory {
 			ObjectRelationship objectRelationship)
 		throws PortalException {
 
-		if (objectDefinition1.isUnmodifiableSystemObject() ||
-			objectDefinition2.isUnmodifiableSystemObject()) {
-
+		if (objectDefinition2.isUnmodifiableSystemObject()) {
 			return null;
 		}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -904,10 +904,12 @@ public class ObjectRelationshipLocalServiceImpl
 		ObjectDefinitionLocalService objectDefinitionLocalService,
 		List<ObjectRelationship> objectRelationships) {
 
+		long objectDefinitionId = objectDefinition1.getObjectDefinitionId();
+
 		if (objectRelationships == null) {
 			objectRelationships =
-				objectRelationshipLocalService.getObjectRelationships(
-					objectDefinition1.getObjectDefinitionId());
+				objectRelationshipLocalService.getAllObjectRelationships(
+					objectDefinitionId);
 		}
 
 		for (ObjectRelationship objectRelationship : objectRelationships) {
@@ -918,22 +920,37 @@ public class ObjectRelationshipLocalServiceImpl
 			}
 
 			try {
-				ObjectDefinition objectDefinition2 =
-					objectDefinitionLocalService.getObjectDefinition(
-						objectRelationship.getObjectDefinitionId2());
+				if (objectRelationship.getObjectDefinitionId1() ==
+						objectDefinitionId) {
 
-				_registerRelatedInfoItemCollectionProvider(
-					objectDefinition1, objectDefinition2, objectRelationship);
-
-				if (Objects.equals(
-						objectRelationship.getType(),
-						ObjectRelationshipConstants.TYPE_MANY_TO_MANY)) {
+					ObjectDefinition objectDefinition2 =
+						objectDefinitionLocalService.getObjectDefinition(
+							objectRelationship.getObjectDefinitionId2());
 
 					_registerRelatedInfoItemCollectionProvider(
-						objectDefinition2, objectDefinition1,
-						objectRelationshipLocalService.getObjectRelationship(
-							objectRelationship.getObjectDefinitionId2(),
-							objectRelationship.getName()));
+						objectDefinition1, objectDefinition2,
+						objectRelationship);
+
+					if (Objects.equals(
+							objectRelationship.getType(),
+							ObjectRelationshipConstants.TYPE_MANY_TO_MANY)) {
+
+						_registerRelatedInfoItemCollectionProvider(
+							objectDefinition2, objectDefinition1,
+							objectRelationshipLocalService.
+								getObjectRelationship(
+									objectRelationship.getObjectDefinitionId2(),
+									objectRelationship.getName()));
+					}
+				}
+				else if (!Objects.equals(
+							objectRelationship.getType(),
+							ObjectRelationshipConstants.TYPE_MANY_TO_MANY)) {
+
+					_registerRelatedInfoItemCollectionProvider(
+						objectDefinitionLocalService.getObjectDefinition(
+							objectRelationship.getObjectDefinitionId1()),
+						objectDefinition1, objectRelationship);
 				}
 			}
 			catch (PortalException portalException) {

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/info/collection/provider/test/OneToManyObjectRelationshipInfoCollectionProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/info/collection/provider/test/OneToManyObjectRelationshipInfoCollectionProviderTest.java
@@ -6,6 +6,9 @@
 package com.liferay.object.internal.info.collection.provider.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.commerce.product.model.CPDefinition;
+import com.liferay.commerce.product.service.CPDefinitionLocalService;
+import com.liferay.commerce.product.test.util.CPTestUtil;
 import com.liferay.info.collection.provider.CollectionQuery;
 import com.liferay.info.collection.provider.RelatedInfoItemCollectionProvider;
 import com.liferay.info.item.InfoItemServiceRegistry;
@@ -22,10 +25,10 @@ import com.liferay.object.relationship.util.ObjectRelationshipUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.object.system.SystemObjectEntry;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.object.test.util.ObjectRelationshipTestUtil;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -33,6 +36,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -41,7 +45,9 @@ import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import java.io.Serializable;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -135,9 +141,12 @@ public class OneToManyObjectRelationshipInfoCollectionProviderTest {
 
 		// Unmodifiable system object definition as child
 
+		CPDefinition cpDefinition = CPTestUtil.addCPDefinition(
+			_group.getGroupId());
+
 		ObjectDefinition unmodifiableSystemObjectDefinition =
 			_objectDefinitionLocalService.fetchObjectDefinitionByClassName(
-				TestPropsValues.getCompanyId(), User.class.getName());
+				TestPropsValues.getCompanyId(), CPDefinition.class.getName());
 
 		ObjectRelationshipTestUtil.addObjectRelationship(
 			_objectRelationshipLocalService, _customObjectDefinition2,
@@ -153,17 +162,46 @@ public class OneToManyObjectRelationshipInfoCollectionProviderTest {
 
 		// Unmodifiable system object definition as parent
 
-		ObjectRelationshipTestUtil.addObjectRelationship(
-			_objectRelationshipLocalService, unmodifiableSystemObjectDefinition,
-			_customObjectDefinition2,
-			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
-			StringUtil.randomId(),
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService,
+				unmodifiableSystemObjectDefinition, _customObjectDefinition2,
+				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
+				StringUtil.randomId());
 
-		Assert.assertNull(
-			_infoItemServiceRegistry.getFirstInfoItemService(
-				RelatedInfoItemCollectionProvider.class,
-				unmodifiableSystemObjectDefinition.getClassName()));
+		try {
+			_assertCollectionInfoPage(
+				_customObjectDefinition2, unmodifiableSystemObjectDefinition,
+				cpDefinition,
+				_addObjectEntry(
+					_customObjectDefinition2, objectRelationship,
+					unmodifiableSystemObjectDefinition,
+					cpDefinition.getCProductId()),
+				_addObjectEntry(
+					_customObjectDefinition2, objectRelationship,
+					unmodifiableSystemObjectDefinition,
+					cpDefinition.getCProductId()));
+
+			long classPK = RandomTestUtil.randomLong();
+
+			_assertCollectionInfoPage(
+				_customObjectDefinition2, unmodifiableSystemObjectDefinition,
+				new SystemObjectEntry(
+					classPK, RandomTestUtil.randomString(),
+					Collections.emptyMap()),
+				_addObjectEntry(
+					_customObjectDefinition2, objectRelationship,
+					unmodifiableSystemObjectDefinition, classPK),
+				_addObjectEntry(
+					_customObjectDefinition2, objectRelationship,
+					unmodifiableSystemObjectDefinition, classPK));
+		}
+		finally {
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				objectRelationship);
+
+			_cpDefinitionLocalService.deleteCPDefinition(cpDefinition);
+		}
 	}
 
 	private ObjectEntry _addObjectEntry(ObjectDefinition objectDefinition)
@@ -183,8 +221,7 @@ public class OneToManyObjectRelationshipInfoCollectionProviderTest {
 	private ObjectEntry _addObjectEntry(
 			ObjectDefinition childObjectDefinition,
 			ObjectRelationship objectRelationship,
-			ObjectDefinition parentObjectDefinition,
-			ObjectEntry parentObjectEntry)
+			ObjectDefinition parentObjectDefinition, long parentPrimaryKey)
 		throws Exception {
 
 		return _objectEntryLocalService.addObjectEntry(
@@ -197,9 +234,49 @@ public class OneToManyObjectRelationshipInfoCollectionProviderTest {
 			).put(
 				ObjectRelationshipUtil.getObjectRelationshipFieldName(
 					parentObjectDefinition, objectRelationship.getName()),
-				parentObjectEntry.getObjectEntryId()
+				parentPrimaryKey
 			).build(),
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+	}
+
+	private void _assertCollectionInfoPage(
+		ObjectDefinition childObjectDefinition,
+		ObjectDefinition parentObjectDefinition, Object relatedItem,
+		ObjectEntry... expectedObjectEntries) {
+
+		List<RelatedInfoItemCollectionProvider>
+			relatedInfoItemCollectionProviders = ListUtil.filter(
+				_infoItemServiceRegistry.getAllInfoItemServices(
+					RelatedInfoItemCollectionProvider.class,
+					parentObjectDefinition.getClassName()),
+				relatedInfoItemCollectionProvider -> Objects.equals(
+					childObjectDefinition.getClassName(),
+					relatedInfoItemCollectionProvider.
+						getCollectionItemClassName()));
+
+		RelatedInfoItemCollectionProvider relatedInfoItemCollectionProvider =
+			relatedInfoItemCollectionProviders.get(0);
+
+		CollectionQuery collectionQuery = new CollectionQuery();
+
+		collectionQuery.setRelatedItemObject(relatedItem);
+
+		InfoPage collectionInfoPage =
+			relatedInfoItemCollectionProvider.getCollectionInfoPage(
+				collectionQuery);
+
+		Assert.assertEquals(
+			expectedObjectEntries.length, collectionInfoPage.getTotalCount());
+
+		List<ObjectEntry> objectEntries = collectionInfoPage.getPageItems();
+
+		Assert.assertEquals(
+			objectEntries.toString(), expectedObjectEntries.length,
+			objectEntries.size());
+
+		for (ObjectEntry expectedObjectEntry : expectedObjectEntries) {
+			Assert.assertTrue(objectEntries.contains(expectedObjectEntry));
+		}
 	}
 
 	private void _testOneToManyObjectRelationshipRelatedInfoCollectionProvider(
@@ -218,10 +295,10 @@ public class OneToManyObjectRelationshipInfoCollectionProviderTest {
 
 		ObjectEntry childObjectEntry1 = _addObjectEntry(
 			childObjectDefinition, objectRelationship, parentObjectDefinition,
-			parentObjectEntry);
+			parentObjectEntry.getObjectEntryId());
 		ObjectEntry childObjectEntry2 = _addObjectEntry(
 			childObjectDefinition, objectRelationship, parentObjectDefinition,
-			parentObjectEntry);
+			parentObjectEntry.getObjectEntryId());
 
 		RelatedInfoItemCollectionProvider relatedInfoItemCollectionProvider =
 			_infoItemServiceRegistry.getFirstInfoItemService(
@@ -249,6 +326,9 @@ public class OneToManyObjectRelationshipInfoCollectionProviderTest {
 		Assert.assertTrue(objectEntries.contains(childObjectEntry1));
 		Assert.assertTrue(objectEntries.contains(childObjectEntry2));
 	}
+
+	@Inject
+	private CPDefinitionLocalService _cpDefinitionLocalService;
 
 	@DeleteAfterTestRun
 	private ObjectDefinition _customObjectDefinition1;

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
@@ -894,6 +894,110 @@ public class ObjectRelationshipLocalServiceTest {
 			objectDefinition2.getClassName(),
 			relatedInfoItemCollectionProvider.getSourceItemClassName());
 
+		ObjectRelationship systemObjectRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				null, TestPropsValues.getUserId(),
+				_unmodifiableSystemObjectDefinition2.getObjectDefinitionId(),
+				_objectDefinition1.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				StringUtil.randomId(), false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+
+		relatedInfoItemCollectionProvider = serviceTrackerMap.getService(
+			_unmodifiableSystemObjectDefinition2.getClassName());
+
+		Assert.assertEquals(
+			_unmodifiableSystemObjectDefinition2.getClassName(),
+			relatedInfoItemCollectionProvider.getSourceItemClassName());
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			systemObjectRelationship);
+
+		ObjectDefinition childObjectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName());
+
+		ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				null, TestPropsValues.getUserId(),
+				_unmodifiableSystemObjectDefinition2.getObjectDefinitionId(),
+				childObjectDefinition.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				StringUtil.randomId(), false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+
+		Assert.assertNull(
+			serviceTrackerMap.getService(
+				_unmodifiableSystemObjectDefinition2.getClassName()));
+
+		childObjectDefinition =
+			_objectDefinitionLocalService.publishCustomObjectDefinition(
+				TestPropsValues.getUserId(),
+				childObjectDefinition.getObjectDefinitionId());
+
+		relatedInfoItemCollectionProvider = serviceTrackerMap.getService(
+			_unmodifiableSystemObjectDefinition2.getClassName());
+
+		Assert.assertEquals(
+			_unmodifiableSystemObjectDefinition2.getClassName(),
+			relatedInfoItemCollectionProvider.getSourceItemClassName());
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			objectRelationship);
+
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			childObjectDefinition);
+
+		childObjectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName());
+
+		ObjectDefinition parentObjectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName());
+
+		_objectRelationshipLocalService.addObjectRelationship(
+			null, TestPropsValues.getUserId(),
+			parentObjectDefinition.getObjectDefinitionId(),
+			childObjectDefinition.getObjectDefinitionId(), 0,
+			ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			StringUtil.randomId(), false,
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+
+		Assert.assertNull(
+			serviceTrackerMap.getService(
+				parentObjectDefinition.getClassName()));
+
+		parentObjectDefinition =
+			_objectDefinitionLocalService.publishCustomObjectDefinition(
+				TestPropsValues.getUserId(),
+				parentObjectDefinition.getObjectDefinitionId());
+
+		Assert.assertNull(
+			serviceTrackerMap.getService(
+				parentObjectDefinition.getClassName()));
+
+		childObjectDefinition =
+			_objectDefinitionLocalService.publishCustomObjectDefinition(
+				TestPropsValues.getUserId(),
+				childObjectDefinition.getObjectDefinitionId());
+
+		relatedInfoItemCollectionProvider = serviceTrackerMap.getService(
+			parentObjectDefinition.getClassName());
+
+		Assert.assertEquals(
+			parentObjectDefinition.getClassName(),
+			relatedInfoItemCollectionProvider.getSourceItemClassName());
+
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			childObjectDefinition);
+
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			parentObjectDefinition);
+
 		serviceTrackerMap.close();
 
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition1);

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewStructureUsagesDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewStructureUsagesDisplayContext.java
@@ -132,12 +132,9 @@ public class ViewStructureUsagesDisplayContext {
 				_language.get(_httpServletRequest, "permissions"), "get", null,
 				"modal-permissions"),
 			new FDSActionDropdownItem(
-				_language.get(
-					_httpServletRequest,
-					"are-you-sure-you-want-to-delete-this-entry"),
 				null, "trash", "delete",
-				_language.get(_httpServletRequest, "delete"), "delete",
-				"delete", "headless"));
+				_language.get(_httpServletRequest, "delete"), null, "delete",
+				null));
 	}
 
 	private static final String _STATUSES = StringUtil.merge(

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/StructureUsagesFDSPropsTransformer.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/StructureUsagesFDSPropsTransformer.ts
@@ -4,9 +4,11 @@
  */
 
 import {IInternalRenderer} from '@liferay/frontend-data-set-web';
+import {sub} from 'frontend-js-web';
 
 import StatusLabel from '../../common/components/StatusLabel';
 import {getScopeExternalReferenceCode} from '../../common/utils/getScopeExternalReferenceCode';
+import confirmAndDeleteEntryAction from './actions/confirmAndDeleteEntryAction';
 import AuthorRenderer from './cell_renderers/AuthorRenderer';
 import SpaceRendererWithCache from './cell_renderers/SpaceRendererWithCache';
 import TypeRenderer from './cell_renderers/TypeRenderer';
@@ -48,5 +50,38 @@ export default function StructureUsagesFDSPropsTransformer({
 			],
 		},
 		hideManagementBarInEmptyState: true,
+		onActionDropdownItemClick({
+			action,
+			event,
+			itemData,
+			loadData,
+		}: {
+			action: {data: {id: string}};
+			event: Event;
+			itemData: {
+				embedded: {
+					actions: {delete: {href: string; method: string}};
+				};
+				title: string;
+			};
+			loadData: () => void;
+		}) {
+			if (action?.data?.id === 'delete') {
+				event?.preventDefault();
+
+				confirmAndDeleteEntryAction({
+					bodyHTML: Liferay.Language.get(
+						'are-you-sure-you-want-to-delete-this-entry'
+					),
+					deleteAction: itemData.embedded.actions.delete,
+					loadData,
+					successMessage: sub(
+						Liferay.Language.get('x-was-successfully-deleted'),
+						`<strong>${Liferay.Util.escapeHTML(itemData.title)}</strong>`
+					),
+					title: Liferay.Language.get('delete-entry'),
+				});
+			}
+		},
 	};
 }

--- a/modules/test/playwright/tests/commerce/commerce-site-initializer/main/commerceBaseFragments.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-site-initializer/main/commerceBaseFragments.spec.ts
@@ -13,6 +13,7 @@ import {loginTest} from '../../../../fixtures/loginTest';
 import {pageEditorPagesTest} from '../../../../fixtures/pageEditorPagesTest';
 import {systemSettingsPageTest} from '../../../../fixtures/systemSettingsPageTest';
 import {liferayConfig} from '../../../../liferay.config';
+import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
 import {getRandomInt} from '../../../../utils/getRandomInt';
 import getRandomString from '../../../../utils/getRandomString';
 import performLogin, {performLogout} from '../../../../utils/performLogin';
@@ -35,35 +36,86 @@ export const test = mergeTests(
 
 test(
 	'Commerce Classic Header main fragment is correctly displayed',
-	{tag: ['@LPD-23780']},
-	async ({apiHelpers, page, pageEditorPage}) => {
-		test.setTimeout(120000);
+	{tag: ['@LPD-23780', '@LPD-94883']},
+	async ({
+		apiHelpers,
+		commerceThemeClassicCatalogPage,
+		page,
+		pageEditorPage,
+	}) => {
+		test.setTimeout(180000);
 
 		const {site} = await classicCommerceSetUp(
 			apiHelpers,
 			`classic-commerce`
 		);
 
-		await page.goto(`/web${site.friendlyUrlPath}?p_l_mode=edit`, {
-			waitUntil: 'networkidle',
+		await test.step('Publish the Commerce Classic Master and verify the header fragments are displayed', async () => {
+			await page.goto(`/web${site.friendlyUrlPath}?p_l_mode=edit`, {
+				waitUntil: 'networkidle',
+			});
+
+			await pageEditorPage.goToSidebarTab('Page Design Options');
+
+			await page.getByLabel('Commerce Classic Master').click();
+			await page.getByLabel('Publish', {exact: true}).click();
+
+			await expect(
+				page.locator(
+					'.lfr-layout-structure-item-commerce-account-selector-fragments-account-selector-fragment'
+				)
+			).toBeVisible();
+			await expect(
+				page.locator(
+					'.lfr-layout-structure-item-commerce-cart-fragments-mini-cart'
+				)
+			).toBeVisible();
+			await expect(
+				page.locator('header .portlet-search-bar')
+			).toBeVisible();
 		});
 
-		await pageEditorPage.goToSidebarTab('Page Design Options');
+		await test.step('The account selector order list refreshes when a new order is created', async () => {
+			await apiHelpers.headlessAdminUser.postAccount({
+				name: getRandomString(),
+				type: 'business',
+			});
 
-		await page.getByLabel('Commerce Classic Master').click();
-		await page.getByLabel('Publish', {exact: true}).click();
+			await page.goto(`/web${site.friendlyUrlPath}/catalog`, {
+				waitUntil: 'networkidle',
+			});
 
-		await expect(
-			page.locator(
-				'.lfr-layout-structure-item-commerce-account-selector-fragments-account-selector-fragment'
-			)
-		).toBeVisible();
-		await expect(
-			page.locator(
-				'.lfr-layout-structure-item-commerce-cart-fragments-mini-cart'
-			)
-		).toBeVisible();
-		await expect(page.locator('header .portlet-search-bar')).toBeVisible();
+			await commerceThemeClassicCatalogPage
+				.productCardAddToCartButton('Wear Sensors')
+				.click();
+
+			await page.waitForLoadState('networkidle');
+
+			const triggerOrderId = page.locator(
+				'.btn-account-selector .order-id'
+			);
+
+			await expect(triggerOrderId).toBeVisible();
+
+			const orderId = await triggerOrderId.innerText();
+
+			const accountSelectorDropdownMenu = page.locator(
+				'[id$="-account-selector-dropdown-menu"]'
+			);
+
+			await clickAndExpectToBeVisible({
+				target: accountSelectorDropdownMenu,
+				trigger: page.locator('.account-selector-cta-container'),
+			});
+
+			await expect(
+				accountSelectorDropdownMenu
+					.locator(
+						'.lfr-layout-structure-item-com-liferay-commerce-fragment-internal-renderer-pendingaccountordersdatasetfragmentrenderer'
+					)
+					.getByText(orderId)
+			).toBeVisible();
+		});
 	}
 );
 

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/keyboard.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/keyboard.spec.ts
@@ -578,7 +578,7 @@ test(
 
 		// Check drag preview label
 
-		expect(
+		await expect(
 			page.locator('.page-editor__keyboard-movement-preview__content')
 		).toHaveText('2 Items');
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/structures.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/structures.spec.ts
@@ -732,13 +732,13 @@ test(
 );
 
 test(
-	'Basic Web Content usages list includes assets that use the structure',
-	{tag: '@LPD-89302'},
+	'View Usages lists the assets using the structure and deletes them with the CMS confirmation modal',
+	{tag: ['@LPD-89302', '@LPD-89560']},
 	async ({apiHelpers, page, structuresPage}) => {
 		const applicationName = 'cms/basic-web-contents';
 		const title = `Content ${getRandomString()}`;
 
-		const objectEntry = await apiHelpers.objectEntry.postObjectEntry(
+		await apiHelpers.objectEntry.postObjectEntry(
 			{
 				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
 				title,
@@ -747,53 +747,22 @@ test(
 			'Default'
 		);
 
-		try {
-			await structuresPage.goto();
+		// Open the usages list of the structure
 
-			await structuresPage.execItemAction({
-				action: 'View Usages',
-				filter: 'Basic Web Content',
-			});
+		await structuresPage.goto();
 
+		await structuresPage.execItemAction({
+			action: 'View Usages',
+			filter: 'Basic Web Content',
+		});
+
+		await test.step('Usages list includes the asset', async () => {
 			await page.locator('.fds').waitFor();
 
 			await expect(page.getByRole('row', {name: title})).toBeVisible();
-		}
-		finally {
-			await apiHelpers.objectEntry.deleteObjectEntry(
-				applicationName,
-				String(objectEntry.id)
-			);
-		}
-	}
-);
+		});
 
-test(
-	'View Usages delete action opens the CMS confirmation modal instead of a native confirm dialog',
-	{tag: '@LPD-89560'},
-	async ({apiHelpers, page, structuresPage}) => {
-		const applicationName = 'cms/basic-web-contents';
-		const title = `Content ${getRandomString()}`;
-
-		const objectEntry = await apiHelpers.objectEntry.postObjectEntry(
-			{
-				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
-				title,
-			},
-			applicationName,
-			'Default'
-		);
-
-		try {
-
-			// Open the usages list of the structure
-
-			await structuresPage.goto();
-
-			await structuresPage.execItemAction({
-				action: 'View Usages',
-				filter: 'Basic Web Content',
-			});
+		await test.step('Delete shows the CMS confirmation modal', async () => {
 
 			// Open the delete action of the usage entry
 
@@ -819,13 +788,7 @@ test(
 			await waitForAlert(page, `${title} was successfully deleted`, {
 				type: 'success',
 			});
-		}
-		finally {
-			await apiHelpers.objectEntry.deleteObjectEntry(
-				applicationName,
-				String(objectEntry.id)
-			);
-		}
+		});
 	}
 );
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/structures.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/structures.spec.ts
@@ -769,6 +769,67 @@ test(
 );
 
 test(
+	'View Usages delete action opens the CMS confirmation modal instead of a native confirm dialog',
+	{tag: '@LPD-89560'},
+	async ({apiHelpers, page, structuresPage}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const title = `Content ${getRandomString()}`;
+
+		const objectEntry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title,
+			},
+			applicationName,
+			'Default'
+		);
+
+		try {
+
+			// Open the usages list of the structure
+
+			await structuresPage.goto();
+
+			await structuresPage.execItemAction({
+				action: 'View Usages',
+				filter: 'Basic Web Content',
+			});
+
+			// Open the delete action of the usage entry
+
+			await structuresPage.dataSetFragmentPage.execItemAction({
+				action: 'Delete',
+				filter: title,
+			});
+
+			// The CMS confirmation modal must appear instead of a native
+			// confirm dialog
+
+			await expect(
+				page.getByText('Are you sure you want to delete this entry?')
+			).toBeVisible();
+
+			// Confirm the deletion
+
+			await page
+				.locator('.liferay-modal')
+				.getByRole('button', {exact: true, name: 'Delete'})
+				.click();
+
+			await waitForAlert(page, `${title} was successfully deleted`, {
+				type: 'success',
+			});
+		}
+		finally {
+			await apiHelpers.objectEntry.deleteObjectEntry(
+				applicationName,
+				String(objectEntry.id)
+			);
+		}
+	}
+);
+
+test(
 	'Permissions of a Content Structure can be modified',
 	{tag: '@LPD-89302'},
 	async ({apiHelpers, page, structuresPage}) => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-56169

## What Is Being Fixed

When a child object definition was published after its parent in a 1:M or M2M relationship, the `RelatedInfoItemCollectionProvider` was not registered for the child side. As a result, the provider was not visible in Display Page Templates for related object entries.

## How It Is Being Fixed

`registerObjectRelationshipsRelatedInfoCollectionProviders` in `ObjectRelationshipLocalServiceImpl` now calls `getAllObjectRelationships` in the single-deploy path — the path triggered by `publishCustomObjectDefinition` and `deployObjectDefinition`. This method returns all relationships where the definition is on either the id1 (parent) or id2 (child) side, ensuring providers are registered in both cases. The prior two-loop structure was simplified to a single loop branching on which side the current definition occupies. At bulk deploy (boot), the caller still passes a pre-built list, so no per-definition query is added at startup.

## PR Check

**pr-check: PASS** — tested on `b73987a97b7eab0b4c329f785cf7eb15f3ea3409`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b73987a97b7eab0b4c329f785cf7eb15f3ea3409"} -->
