### PR TITLE
LPD-95334 Keep a failing cluster task from killing its worker thread

### DIFF
--- a/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/BaseClusterChannel.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/BaseClusterChannel.java
@@ -35,7 +35,7 @@ public abstract class BaseClusterChannel implements ClusterChannel {
 		}
 
 		try {
-			_executorService.execute(() -> doSendMessage(message, null));
+			_executorService.execute(() -> _doSendMessage(message, null));
 		}
 		catch (RejectedExecutionException rejectedExecutionException) {
 			_log.error(
@@ -55,7 +55,7 @@ public abstract class BaseClusterChannel implements ClusterChannel {
 		}
 
 		try {
-			_executorService.execute(() -> doSendMessage(message, address));
+			_executorService.execute(() -> _doSendMessage(message, address));
 		}
 		catch (RejectedExecutionException rejectedExecutionException) {
 			_log.error(
@@ -68,6 +68,20 @@ public abstract class BaseClusterChannel implements ClusterChannel {
 
 	protected abstract void doSendMessage(
 		Serializable message, Address address);
+
+	private void _doSendMessage(Serializable message, Address address) {
+		try {
+			doSendMessage(message, address);
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					StringBundler.concat(
+						"Unable to send message ", message, " to ", address),
+					exception);
+			}
+		}
+	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		BaseClusterChannel.class);

--- a/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/BaseClusterReceiver.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/BaseClusterReceiver.java
@@ -185,6 +185,17 @@ public abstract class BaseClusterReceiver implements ClusterReceiver {
 	protected abstract void doReceive(
 		Object messagePayload, Address srcAddress);
 
+	private void _run(Runnable runnable) {
+		try {
+			runnable.run();
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to run cluster receiver task", exception);
+			}
+		}
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		BaseClusterReceiver.class);
 
@@ -199,7 +210,7 @@ public abstract class BaseClusterReceiver implements ClusterReceiver {
 
 		@Override
 		public void run() {
-			doAddressesUpdated(_oldAddresses, _newAddresses);
+			_run(() -> doAddressesUpdated(_oldAddresses, _newAddresses));
 		}
 
 		private AddressesUpdatedRunnable(
@@ -218,8 +229,9 @@ public abstract class BaseClusterReceiver implements ClusterReceiver {
 
 		@Override
 		public void run() {
-			doCoordinatorAddressUpdated(
-				_oldCoordinatorAddress, _newCoordinatorAddress);
+			_run(
+				() -> doCoordinatorAddressUpdated(
+					_oldCoordinatorAddress, _newCoordinatorAddress));
 		}
 
 		private CoordinatorAddressUpdatedRunnable(
@@ -238,7 +250,7 @@ public abstract class BaseClusterReceiver implements ClusterReceiver {
 
 		@Override
 		public void run() {
-			doReceive(_messagePayload, _srcAddress);
+			_run(() -> doReceive(_messagePayload, _srcAddress));
 		}
 
 		private ReceiveRunnable(Object messagePayload, Address srcAddress) {

--- a/modules/apps/portal/portal-cluster-multiple/src/test/java/com/liferay/portal/cluster/multiple/internal/BaseClusterChannelTest.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/test/java/com/liferay/portal/cluster/multiple/internal/BaseClusterChannelTest.java
@@ -1,0 +1,123 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.cluster.multiple.internal;
+
+import com.liferay.portal.kernel.cluster.Address;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.io.Serializable;
+
+import java.net.InetAddress;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Jiefeng Wu
+ */
+public class BaseClusterChannelTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testSendMulticastMessageWhenDoSendMessageFails()
+		throws Exception {
+
+		ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+		try {
+			CountDownLatch countDownLatch = new CountDownLatch(2);
+
+			List<Thread> threads = new CopyOnWriteArrayList<>();
+
+			AtomicInteger atomicInteger = new AtomicInteger();
+
+			BaseClusterChannel baseClusterChannel = new TestBaseClusterChannel(
+				executorService) {
+
+				@Override
+				protected void doSendMessage(
+					Serializable message, Address address) {
+
+					threads.add(Thread.currentThread());
+
+					countDownLatch.countDown();
+
+					if (atomicInteger.getAndIncrement() == 0) {
+						throw new RuntimeException(
+							"Simulated channel teardown failure");
+					}
+				}
+
+			};
+
+			try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+					BaseClusterChannel.class.getName(), LoggerTestUtil.WARN)) {
+
+				baseClusterChannel.sendMulticastMessage("message1");
+				baseClusterChannel.sendMulticastMessage("message2");
+
+				Assert.assertTrue(countDownLatch.await(1, TimeUnit.MINUTES));
+
+				Assert.assertEquals(threads.toString(), 2, threads.size());
+
+				Assert.assertSame(threads.get(0), threads.get(1));
+			}
+		}
+		finally {
+			executorService.shutdownNow();
+		}
+	}
+
+	private abstract static class TestBaseClusterChannel
+		extends BaseClusterChannel {
+
+		@Override
+		public void close() {
+		}
+
+		@Override
+		public InetAddress getBindInetAddress() {
+			return null;
+		}
+
+		@Override
+		public String getClusterName() {
+			return null;
+		}
+
+		@Override
+		public ClusterReceiver getClusterReceiver() {
+			return null;
+		}
+
+		@Override
+		public Address getLocalAddress() {
+			return null;
+		}
+
+		private TestBaseClusterChannel(ExecutorService executorService) {
+			super(executorService);
+		}
+
+	}
+
+}

--- a/modules/apps/portal/portal-cluster-multiple/src/test/java/com/liferay/portal/cluster/multiple/internal/BaseClusterReceiverTest.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/test/java/com/liferay/portal/cluster/multiple/internal/BaseClusterReceiverTest.java
@@ -1,0 +1,158 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.cluster.multiple.internal;
+
+import com.liferay.portal.kernel.cluster.Address;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Jiefeng Wu
+ */
+public class BaseClusterReceiverTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testAddressesUpdatedWhenDoAddressesUpdatedFails()
+		throws Exception {
+
+		_assertTaskFailureDoesNotKillWorkerThread(
+			baseClusterReceiver -> {
+				baseClusterReceiver.addressesUpdated(Collections.emptyList());
+				baseClusterReceiver.addressesUpdated(Collections.emptyList());
+				baseClusterReceiver.addressesUpdated(Collections.emptyList());
+			});
+	}
+
+	@Test
+	public void testCoordinatorAddressUpdatedWhenDoCoordinatorAddressUpdatedFails()
+		throws Exception {
+
+		_assertTaskFailureDoesNotKillWorkerThread(
+			baseClusterReceiver -> {
+				baseClusterReceiver.coordinatorAddressUpdated(
+					new TestAddress(1));
+				baseClusterReceiver.coordinatorAddressUpdated(
+					new TestAddress(2));
+				baseClusterReceiver.coordinatorAddressUpdated(
+					new TestAddress(3));
+			});
+	}
+
+	@Test
+	public void testReceiveWhenDoReceiveFails() throws Exception {
+		_assertTaskFailureDoesNotKillWorkerThread(
+			baseClusterReceiver -> {
+				baseClusterReceiver.receive("message1", null);
+				baseClusterReceiver.receive("message2", null);
+			});
+	}
+
+	private void _assertTaskFailureDoesNotKillWorkerThread(
+			Consumer<BaseClusterReceiver> baseClusterReceiverConsumer)
+		throws Exception {
+
+		ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+		try {
+			List<Thread> threads = new CopyOnWriteArrayList<>();
+
+			AtomicInteger atomicInteger = new AtomicInteger();
+
+			CountDownLatch countDownLatch = new CountDownLatch(2);
+
+			BaseClusterReceiver baseClusterReceiver =
+				new TestBaseClusterReceiver(
+					executorService, threads, atomicInteger, countDownLatch);
+
+			baseClusterReceiver.openLatch();
+
+			try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+					BaseClusterReceiver.class.getName(), LoggerTestUtil.WARN)) {
+
+				baseClusterReceiverConsumer.accept(baseClusterReceiver);
+
+				Assert.assertTrue(countDownLatch.await(1, TimeUnit.MINUTES));
+
+				Assert.assertEquals(threads.toString(), 2, threads.size());
+
+				Assert.assertSame(threads.get(0), threads.get(1));
+			}
+		}
+		finally {
+			executorService.shutdownNow();
+		}
+	}
+
+	private static class TestBaseClusterReceiver extends BaseClusterReceiver {
+
+		@Override
+		protected void doAddressesUpdated(
+			List<Address> oldAddresses, List<Address> newAddresses) {
+
+			_runTask();
+		}
+
+		@Override
+		protected void doCoordinatorAddressUpdated(
+			Address oldCoordinatorAddress, Address newCoordinatorAddress) {
+
+			_runTask();
+		}
+
+		@Override
+		protected void doReceive(Object messagePayload, Address srcAddress) {
+			_runTask();
+		}
+
+		private TestBaseClusterReceiver(
+			ExecutorService executorService, List<Thread> threads,
+			AtomicInteger atomicInteger, CountDownLatch countDownLatch) {
+
+			super(executorService);
+
+			_threads = threads;
+			_atomicInteger = atomicInteger;
+			_countDownLatch = countDownLatch;
+		}
+
+		private void _runTask() {
+			_threads.add(Thread.currentThread());
+
+			_countDownLatch.countDown();
+
+			if (_atomicInteger.getAndIncrement() == 0) {
+				throw new RuntimeException("Simulated receiver task failure");
+			}
+		}
+
+		private final AtomicInteger _atomicInteger;
+		private final CountDownLatch _countDownLatch;
+		private final List<Thread> _threads;
+
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95334

## What Is Being Fixed

BaseClusterChannel and BaseClusterReceiver run each send and each receiver callback on a shared executor thread. When a task throws — a send still queued while the channel shuts down, or a receive / addresses-updated / coordinator-address-updated callback failing — the exception propagates out of the executor task and kills the worker thread that ran it. At shutdown many such tasks fail at once, and each dead worker's uncaught exception is dumped to System.err, where printStackTrace holds the stream monitor across a per-line autoflush, so the dumps convoy on that one lock and stall shutdown until the build times out.

## How It Is Being Fixed

The fix catches the exception inside the task so the worker thread stays alive and the JVM default handler — and its System.err dump — is never reached. BaseClusterChannel wraps doSendMessage in a private _doSendMessage that catches and reports through a single Log4J warn. BaseClusterReceiver routes its three callbacks through one private _run method with the same catch-and-report. Log4J writes each event under one appender lock instead of System.err's line-by-line autoflush, so simultaneous failures no longer convoy. Two unit tests reproduce the root cause deterministically: each runs tasks on a single-thread executor, makes the first fail, and asserts the later tasks run on the same thread — which only holds if the worker survived the first failure.

## PR Check

**pr-check: PASS** — tested on `9320cb1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "9320cb1a105445b62a334c7732fa0e92b3395b85"} -->
