### PR TITLE
LPD-95821 Test DynamicQuery this, this_, and alias resolution

### DIFF
--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/DynamicQueryEntryTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/DynamicQueryEntryTest.java
@@ -450,41 +450,8 @@ public class DynamicQueryEntryTest {
 
 	@Test
 	public void testDynamicQueryWithAlias() {
-		Class<?> clazz = _dynamicQueryEntryLocalService.getClass();
-
-		DynamicQuery dynamicQuery = DynamicQueryFactoryUtil.forClass(
-			DynamicQueryEntry.class, "parent", clazz.getClassLoader());
-
-		dynamicQuery.add(RestrictionsFactoryUtil.eq("parent.name", "alpha"));
-
-		_testDynamicQuery(dynamicQuery, "alpha");
-
-		Property property = PropertyFactoryUtil.forName("parent.name");
-
-		dynamicQuery = DynamicQueryFactoryUtil.forClass(
-			DynamicQueryEntry.class, "parent", clazz.getClassLoader());
-
-		dynamicQuery.add(property.eq("alpha"));
-
-		_testDynamicQuery(dynamicQuery, "alpha");
-
-		dynamicQuery = DynamicQueryFactoryUtil.forClass(
-			DynamicQueryEntry.class, "child", clazz.getClassLoader());
-
-		dynamicQuery.add(
-			RestrictionsFactoryUtil.eqProperty("child.status", "status"));
-		dynamicQuery.add(RestrictionsFactoryUtil.eq("child.name", "alpha"));
-		dynamicQuery.setProjection(
-			ProjectionFactoryUtil.property("child.name"));
-
-		property = PropertyFactoryUtil.forName("name");
-
-		DynamicQuery parentDynamicQuery =
-			_dynamicQueryEntryLocalService.dynamicQuery();
-
-		parentDynamicQuery.add(property.eq(dynamicQuery));
-
-		_testDynamicQuery(parentDynamicQuery, "alpha");
+		_testDynamicQueryWithAlias(null);
+		_testDynamicQueryWithAlias(RandomTestUtil.randomString());
 	}
 
 	@Test
@@ -687,6 +654,149 @@ public class DynamicQueryEntryTest {
 					results.toString(), expectedResults[i], result);
 			}
 		}
+	}
+
+	private void _testDynamicQueryWithAlias(String alias) {
+		Class<?> clazz = _dynamicQueryEntryLocalService.getClass();
+
+		// Test 1
+
+		DynamicQuery dynamicQuery = null;
+
+		if (alias == null) {
+			dynamicQuery = _dynamicQueryEntryLocalService.dynamicQuery();
+
+			dynamicQuery.add(RestrictionsFactoryUtil.eq("this.status", 1));
+		}
+		else {
+			dynamicQuery = DynamicQueryFactoryUtil.forClass(
+				DynamicQueryEntry.class, alias, clazz.getClassLoader());
+
+			dynamicQuery.add(RestrictionsFactoryUtil.eq(alias + ".status", 1));
+		}
+
+		dynamicQuery.addOrder(OrderFactoryUtil.asc("amount"));
+
+		_testDynamicQuery(dynamicQuery, "alpha", "gamma");
+
+		// Test 2
+
+		dynamicQuery = DynamicQueryFactoryUtil.forClass(
+			DynamicQueryEntry.class, "child", clazz.getClassLoader());
+
+		dynamicQuery.add(RestrictionsFactoryUtil.eq("child.name", "alpha"));
+		dynamicQuery.setProjection(
+			ProjectionFactoryUtil.property("child.name"));
+
+		DynamicQuery parentDynamicQuery = null;
+		Property property = null;
+
+		if (alias == null) {
+			dynamicQuery.add(
+				RestrictionsFactoryUtil.eqProperty(
+					"child.status", "this.status"));
+			dynamicQuery.add(
+				RestrictionsFactoryUtil.eqProperty(
+					"this.status", "child.status"));
+			dynamicQuery.add(
+				RestrictionsFactoryUtil.eqProperty(
+					"child.amount", "this.amount"));
+
+			parentDynamicQuery = _dynamicQueryEntryLocalService.dynamicQuery();
+			property = PropertyFactoryUtil.forName("name");
+		}
+		else {
+			dynamicQuery.add(
+				RestrictionsFactoryUtil.eqProperty(
+					"child.status", alias + ".status"));
+			dynamicQuery.add(
+				RestrictionsFactoryUtil.eqProperty(
+					alias + ".status", "child.status"));
+			dynamicQuery.add(
+				RestrictionsFactoryUtil.eqProperty(
+					"child.amount", alias + ".amount"));
+
+			parentDynamicQuery = DynamicQueryFactoryUtil.forClass(
+				DynamicQueryEntry.class, alias, clazz.getClassLoader());
+			property = PropertyFactoryUtil.forName(alias + ".name");
+		}
+
+		parentDynamicQuery.add(property.eq(dynamicQuery));
+
+		_testDynamicQuery(parentDynamicQuery, "alpha");
+
+		// Test 3
+
+		if (alias == null) {
+			dynamicQuery = _dynamicQueryEntryLocalService.dynamicQuery();
+		}
+		else {
+			dynamicQuery = DynamicQueryFactoryUtil.forClass(
+				DynamicQueryEntry.class, alias, clazz.getClassLoader());
+		}
+
+		dynamicQuery.add(
+			RestrictionsFactoryUtil.sqlRestriction(
+				"exists (select 1 from DynamicQueryEntry where status = " +
+					"this_.status and amount > this_.amount)"));
+
+		_testDynamicQuery(dynamicQuery, "alpha");
+
+		// Test 4
+
+		if (alias == null) {
+			dynamicQuery = _dynamicQueryEntryLocalService.dynamicQuery();
+		}
+		else {
+			dynamicQuery = DynamicQueryFactoryUtil.forClass(
+				DynamicQueryEntry.class, alias, clazz.getClassLoader());
+		}
+
+		dynamicQuery.add(
+			RestrictionsFactoryUtil.sqlRestriction(
+				"exists (select 1 from DynamicQueryEntry where status = " +
+					"this_.status and amount > ?)",
+				250L, Type.LONG));
+		dynamicQuery.addOrder(OrderFactoryUtil.asc("amount"));
+
+		_testDynamicQuery(dynamicQuery, "alpha", "gamma", "delta");
+
+		// Test 5
+
+		if (alias == null) {
+			dynamicQuery = _dynamicQueryEntryLocalService.dynamicQuery();
+		}
+		else {
+			dynamicQuery = DynamicQueryFactoryUtil.forClass(
+				DynamicQueryEntry.class, alias, clazz.getClassLoader());
+		}
+
+		dynamicQuery.setProjection(
+			ProjectionFactoryUtil.sqlProjection(
+				"(select count(*) from DynamicQueryEntry where status = " +
+					"this_.status) AS statusCount",
+				new String[] {"statusCount"}, new Type[] {Type.LONG}));
+		dynamicQuery.addOrder(OrderFactoryUtil.asc("amount"));
+
+		_testDynamicQuery(dynamicQuery, 2L, 1L, 2L, 1L);
+
+		// Test 6
+
+		if (alias == null) {
+			dynamicQuery = _dynamicQueryEntryLocalService.dynamicQuery();
+		}
+		else {
+			dynamicQuery = DynamicQueryFactoryUtil.forClass(
+				DynamicQueryEntry.class, alias, clazz.getClassLoader());
+		}
+
+		dynamicQuery.add(
+			RestrictionsFactoryUtil.sqlRestriction(
+				"exists (select 1 from DynamicQueryEntry where status = " +
+					"this_.status and amount > this_.amount)"));
+
+		Assert.assertEquals(
+			1L, _dynamicQueryEntryLocalService.dynamicQueryCount(dynamicQuery));
 	}
 
 	private void _testDynamicQueryWithProjection(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95821

## What Is Being Fixed

As part of the Hibernate 7.4 preparation and upgrade (LPD-70496), the service builder test bed lacked a regression guard for how DynamicQuery resolves entity-relative property references: the implicit `this` alias, the Hibernate-generated `this_` SQL alias, and an explicit caller-supplied alias. Without coverage, the upgrade could silently change how these references map to SQL.

## How It Is Being Fixed

`testDynamicQueryWithAlias` is reworked into a parameterized helper, `_testDynamicQueryWithAlias(String alias)`, run twice: once with a null alias to exercise the default path via `dynamicQuery()` (which resolves to `this` / `this_`), and once with a random alias via `DynamicQueryFactoryUtil.forClass`. The helper covers six cases — a property restriction with ordering, an `eqProperty` across an alias plus a subquery projection, a `sqlRestriction` referencing `this_`, a parameterized `sqlRestriction`, a `sqlProjection` referencing `this_`, and a `dynamicQueryCount`. Test data uses RandomTestUtil.

## PR Check

**pr-check: PASS** — tested on `b3372c83e0aa30d3267e68d4252c381c396dcbd3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "b3372c83e0aa30d3267e68d4252c381c396dcbd3"} -->
