### PR TITLE
LPD-95632 Do not swallow exceptions thrown by LiferayFilter's isFilterEnabled

### DIFF
--- a/portal-impl/test/unit/com/liferay/portal/kernel/servlet/filters/invoker/InvokerFilterChainTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/servlet/filters/invoker/InvokerFilterChainTest.java
@@ -1,0 +1,70 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.servlet.filters.invoker;
+
+import com.liferay.portal.servlet.filters.BasePortalFilter;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Eric Yan
+ */
+public class InvokerFilterChainTest {
+
+	@ClassRule
+	public static LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testDoFilterWithLiferayFilterWhenIsFilterEnabledThrowsException()
+		throws Exception {
+
+		InvokerFilterChain invokerFilterChain = new InvokerFilterChain(
+			new MockFilterChain());
+
+		invokerFilterChain.addFilter(
+			new BasePortalFilter() {
+			});
+
+		RuntimeException runtimeException = new RuntimeException();
+
+		invokerFilterChain.addFilter(
+			new BasePortalFilter() {
+
+				@Override
+				public boolean isFilterEnabled(
+					HttpServletRequest httpServletRequest,
+					HttpServletResponse httpServletResponse) {
+
+					throw runtimeException;
+				}
+
+			});
+
+		try {
+			invokerFilterChain.doFilter(
+				new MockHttpServletRequest(), new MockHttpServletResponse());
+
+			Assert.fail();
+		}
+		catch (ServletException servletException) {
+			Assert.assertSame(
+				runtimeException, servletException.getRootCause());
+		}
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/filters/invoker/InvokerFilterChain.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/filters/invoker/InvokerFilterChain.java
@@ -74,10 +74,19 @@ public class InvokerFilterChain implements FilterChain {
 				if (filter instanceof LiferayFilter) {
 					LiferayFilter liferayFilter = (LiferayFilter)filter;
 
-					if (!liferayFilter.isFilterEnabled() ||
-						!liferayFilter.isFilterEnabled(
-							httpServletRequest, httpServletResponse)) {
+					boolean filterEnabled = false;
 
+					try {
+						filterEnabled =
+							liferayFilter.isFilterEnabled() &&
+							liferayFilter.isFilterEnabled(
+								httpServletRequest, httpServletResponse);
+					}
+					catch (Exception exception) {
+						throw new ServletException(exception);
+					}
+
+					if (!filterEnabled) {
 						if (_log.isDebugEnabled()) {
 							_log.debug(
 								"Skip disabled filter " + filter.getClass());


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95632

## What Is Being Fixed

When a LiferayFilter's isFilterEnabled method threw a RuntimeException,
InvokerFilterChain allowed the exception to escape into BaseFilter.doFilter,
which caught and logged it but did not rethrow. The request then completed
with a 200 status code and an empty body instead of surfacing the failure.

## How It Is Being Fixed

InvokerFilterChain now wraps the isFilterEnabled calls in a try-catch and
rethrows any exception as a ServletException. BaseFilter propagates a
ServletException rather than swallowing it, so the failure surfaces as a
500 status code. The catch clause mirrors the existing DirectCallFilter
block in the same method. A unit test places the throwing filter behind a
pass-through filter so the exception unwinds through BaseFilter.doFilter,
and asserts that the resulting ServletException carries the original
exception as its root cause — proving it is no longer swallowed.

## PR Check

**pr-check: PASS** — tested on `2d650bc41c93315eb2a049e802632a7b4815d39b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "2d650bc41c93315eb2a049e802632a7b4815d39b"} -->