### PR TITLE
LPD-56169 Register collection providers for related object entries

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -288,6 +288,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		Map<Long, List<ObjectRelationship>> objectRelationshipsMap) {
 
 		if (objectDefinition.isUnmodifiableSystemObject()) {
+			_registerObjectRelationshipsRelatedInfoCollectionProviders(
+				objectDefinition, objectRelationshipsMap);
+
 			return Collections.emptyList();
 		}
 
@@ -544,18 +547,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 					objectDefinition, objectLayout.getObjectLayoutTabs());
 		}
 
-		List<ObjectRelationship> objectRelationships = null;
-
-		if (objectRelationshipsMap != null) {
-			objectRelationships = objectRelationshipsMap.getOrDefault(
-				objectDefinition.getObjectDefinitionId(),
-				Collections.emptyList());
-		}
-
-		_objectRelationshipLocalService.
-			registerObjectRelationshipsRelatedInfoCollectionProviders(
-				objectDefinition, _objectDefinitionLocalService,
-				objectRelationships);
+		_registerObjectRelationshipsRelatedInfoCollectionProviders(
+			objectDefinition, objectRelationshipsMap);
 
 		try {
 			if (ArrayUtil.isNotEmpty(
@@ -587,6 +580,24 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		return StringBundler.concat(
 			serviceRegistrationKey, StringPool.POUND,
 			objectRelationship.getObjectRelationshipId());
+	}
+
+	private void _registerObjectRelationshipsRelatedInfoCollectionProviders(
+		ObjectDefinition objectDefinition,
+		Map<Long, List<ObjectRelationship>> objectRelationshipsMap) {
+
+		List<ObjectRelationship> objectRelationships = null;
+
+		if (objectRelationshipsMap != null) {
+			objectRelationships = objectRelationshipsMap.getOrDefault(
+				objectDefinition.getObjectDefinitionId(),
+				Collections.emptyList());
+		}
+
+		_objectRelationshipLocalService.
+			registerObjectRelationshipsRelatedInfoCollectionProviders(
+				objectDefinition, _objectDefinitionLocalService,
+				objectRelationships);
 	}
 
 	private void _registerRootObjectLayoutTabScreenNavigationCategories(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -594,6 +594,10 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				Collections.emptyList());
 		}
 
+		if ((objectRelationships != null) && objectRelationships.isEmpty()) {
+			return;
+		}
+
 		_objectRelationshipLocalService.
 			registerObjectRelationshipsRelatedInfoCollectionProviders(
 				objectDefinition, _objectDefinitionLocalService,

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/BaseObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/BaseObjectRelationshipRelatedInfoCollectionProvider.java
@@ -13,16 +13,21 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.system.SystemObjectEntry;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.util.Collections;
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * @author Feliphe Marinho
@@ -47,23 +52,56 @@ public abstract class BaseObjectRelationshipRelatedInfoCollectionProvider
 	public InfoPage<ObjectEntry> getCollectionInfoPage(
 		CollectionQuery collectionQuery) {
 
-		Object relatedItem = collectionQuery.getRelatedItem();
-
-		if (!(relatedItem instanceof ObjectEntry)) {
-			return InfoPage.of(
-				Collections.emptyList(), collectionQuery.getPagination(), 0);
-		}
+		Pagination pagination = collectionQuery.getPagination();
 
 		try {
-			return getCollectionInfoPage(
-				(ObjectEntry)relatedItem, collectionQuery.getPagination());
+			Object relatedItem = collectionQuery.getRelatedItem();
+
+			if (relatedItem instanceof ObjectEntry) {
+				ObjectEntry objectEntry = (ObjectEntry)relatedItem;
+
+				return getCollectionInfoPage(
+					objectEntry.getGroupId(), pagination,
+					objectEntry.getObjectEntryId());
+			}
+
+			if (relatedItem instanceof SystemObjectEntry) {
+				SystemObjectEntry systemObjectEntry =
+					(SystemObjectEntry)relatedItem;
+
+				return getCollectionInfoPage(
+					systemObjectEntry.getGroupId(), pagination,
+					systemObjectEntry.getClassPK());
+			}
+
+			if (_objectDefinition1.isUnmodifiableSystemObject() &&
+				(relatedItem instanceof BaseModel)) {
+
+				long groupId = 0;
+
+				if (relatedItem instanceof GroupedModel) {
+					GroupedModel groupedModel = (GroupedModel)relatedItem;
+
+					groupId = groupedModel.getGroupId();
+				}
+
+				BaseModel<?> baseModel = (BaseModel<?>)relatedItem;
+
+				Map<String, Object> modelAttributes =
+					baseModel.getModelAttributes();
+
+				return getCollectionInfoPage(
+					groupId, pagination,
+					GetterUtil.getLong(
+						modelAttributes.get(
+							_objectDefinition1.getPKObjectFieldName())));
+			}
 		}
 		catch (PortalException portalException) {
 			_log.error(portalException);
 		}
 
-		return InfoPage.of(
-			Collections.emptyList(), collectionQuery.getPagination(), 0);
+		return InfoPage.of(Collections.emptyList(), pagination, 0);
 	}
 
 	@Override
@@ -110,7 +148,7 @@ public abstract class BaseObjectRelationshipRelatedInfoCollectionProvider
 	}
 
 	protected InfoPage<ObjectEntry> getCollectionInfoPage(
-			ObjectEntry objectEntry, Pagination pagination)
+			long groupId, Pagination pagination, long primaryKey)
 		throws PortalException {
 
 		return null;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ManyToManyObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ManyToManyObjectRelationshipRelatedInfoCollectionProvider.java
@@ -33,22 +33,18 @@ public class ManyToManyObjectRelationshipRelatedInfoCollectionProvider
 
 	@Override
 	protected InfoPage<ObjectEntry> getCollectionInfoPage(
-			ObjectEntry objectEntry, Pagination pagination)
+			long groupId, Pagination pagination, long primaryKey)
 		throws PortalException {
 
 		return InfoPage.of(
 			objectEntryLocalService.getManyToManyObjectEntries(
-				objectEntry.getGroupId(),
-				objectRelationship.getObjectRelationshipId(),
-				objectEntry.getObjectEntryId(), true,
-				objectRelationship.isReverse(), null, pagination.getStart(),
-				pagination.getEnd()),
+				groupId, objectRelationship.getObjectRelationshipId(),
+				primaryKey, true, objectRelationship.isReverse(), null,
+				pagination.getStart(), pagination.getEnd()),
 			pagination,
 			objectEntryLocalService.getManyToManyObjectEntriesCount(
-				objectEntry.getGroupId(),
-				objectRelationship.getObjectRelationshipId(),
-				objectEntry.getObjectEntryId(), true,
-				objectRelationship.isReverse(), null));
+				groupId, objectRelationship.getObjectRelationshipId(),
+				primaryKey, true, objectRelationship.isReverse(), null));
 	}
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/OneToManyObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/OneToManyObjectRelationshipRelatedInfoCollectionProvider.java
@@ -33,20 +33,18 @@ public class OneToManyObjectRelationshipRelatedInfoCollectionProvider
 
 	@Override
 	protected InfoPage<ObjectEntry> getCollectionInfoPage(
-			ObjectEntry objectEntry, Pagination pagination)
+			long groupId, Pagination pagination, long primaryKey)
 		throws PortalException {
 
 		return InfoPage.of(
 			objectEntryLocalService.getOneToManyObjectEntries(
-				objectEntry.getGroupId(),
-				objectRelationship.getObjectRelationshipId(), null, false,
-				objectEntry.getObjectEntryId(), true, null,
-				pagination.getStart(), pagination.getEnd(), null),
+				groupId, objectRelationship.getObjectRelationshipId(), null,
+				false, primaryKey, true, null, pagination.getStart(),
+				pagination.getEnd(), null),
 			pagination,
 			objectEntryLocalService.getOneToManyObjectEntriesCount(
-				objectEntry.getGroupId(),
-				objectRelationship.getObjectRelationshipId(), null,
-				objectEntry.getObjectEntryId(), true, null));
+				groupId, objectRelationship.getObjectRelationshipId(), null,
+				primaryKey, true, null));
 	}
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/RelatedInfoCollectionProviderFactory.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/RelatedInfoCollectionProviderFactory.java
@@ -30,9 +30,7 @@ public class RelatedInfoCollectionProviderFactory {
 			ObjectRelationship objectRelationship)
 		throws PortalException {
 
-		if (objectDefinition1.isUnmodifiableSystemObject() ||
-			objectDefinition2.isUnmodifiableSystemObject()) {
-
+		if (objectDefinition2.isUnmodifiableSystemObject()) {
 			return null;
 		}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -904,10 +904,12 @@ public class ObjectRelationshipLocalServiceImpl
 		ObjectDefinitionLocalService objectDefinitionLocalService,
 		List<ObjectRelationship> objectRelationships) {
 
+		long objectDefinitionId = objectDefinition1.getObjectDefinitionId();
+
 		if (objectRelationships == null) {
 			objectRelationships =
-				objectRelationshipLocalService.getObjectRelationships(
-					objectDefinition1.getObjectDefinitionId());
+				objectRelationshipLocalService.getAllObjectRelationships(
+					objectDefinitionId);
 		}
 
 		for (ObjectRelationship objectRelationship : objectRelationships) {
@@ -918,22 +920,37 @@ public class ObjectRelationshipLocalServiceImpl
 			}
 
 			try {
-				ObjectDefinition objectDefinition2 =
-					objectDefinitionLocalService.getObjectDefinition(
-						objectRelationship.getObjectDefinitionId2());
+				if (objectRelationship.getObjectDefinitionId1() ==
+						objectDefinitionId) {
 
-				_registerRelatedInfoItemCollectionProvider(
-					objectDefinition1, objectDefinition2, objectRelationship);
-
-				if (Objects.equals(
-						objectRelationship.getType(),
-						ObjectRelationshipConstants.TYPE_MANY_TO_MANY)) {
+					ObjectDefinition objectDefinition2 =
+						objectDefinitionLocalService.getObjectDefinition(
+							objectRelationship.getObjectDefinitionId2());
 
 					_registerRelatedInfoItemCollectionProvider(
-						objectDefinition2, objectDefinition1,
-						objectRelationshipLocalService.getObjectRelationship(
-							objectRelationship.getObjectDefinitionId2(),
-							objectRelationship.getName()));
+						objectDefinition1, objectDefinition2,
+						objectRelationship);
+
+					if (Objects.equals(
+							objectRelationship.getType(),
+							ObjectRelationshipConstants.TYPE_MANY_TO_MANY)) {
+
+						_registerRelatedInfoItemCollectionProvider(
+							objectDefinition2, objectDefinition1,
+							objectRelationshipLocalService.
+								getObjectRelationship(
+									objectRelationship.getObjectDefinitionId2(),
+									objectRelationship.getName()));
+					}
+				}
+				else if (!Objects.equals(
+							objectRelationship.getType(),
+							ObjectRelationshipConstants.TYPE_MANY_TO_MANY)) {
+
+					_registerRelatedInfoItemCollectionProvider(
+						objectDefinitionLocalService.getObjectDefinition(
+							objectRelationship.getObjectDefinitionId1()),
+						objectDefinition1, objectRelationship);
 				}
 			}
 			catch (PortalException portalException) {

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/info/collection/provider/test/OneToManyObjectRelationshipInfoCollectionProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/info/collection/provider/test/OneToManyObjectRelationshipInfoCollectionProviderTest.java
@@ -6,6 +6,9 @@
 package com.liferay.object.internal.info.collection.provider.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.commerce.product.model.CPDefinition;
+import com.liferay.commerce.product.service.CPDefinitionLocalService;
+import com.liferay.commerce.product.test.util.CPTestUtil;
 import com.liferay.info.collection.provider.CollectionQuery;
 import com.liferay.info.collection.provider.RelatedInfoItemCollectionProvider;
 import com.liferay.info.item.InfoItemServiceRegistry;
@@ -22,10 +25,10 @@ import com.liferay.object.relationship.util.ObjectRelationshipUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.object.system.SystemObjectEntry;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.object.test.util.ObjectRelationshipTestUtil;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -33,6 +36,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -41,7 +45,9 @@ import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import java.io.Serializable;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -137,7 +143,7 @@ public class OneToManyObjectRelationshipInfoCollectionProviderTest {
 
 		ObjectDefinition unmodifiableSystemObjectDefinition =
 			_objectDefinitionLocalService.fetchObjectDefinitionByClassName(
-				TestPropsValues.getCompanyId(), User.class.getName());
+				TestPropsValues.getCompanyId(), CPDefinition.class.getName());
 
 		ObjectRelationshipTestUtil.addObjectRelationship(
 			_objectRelationshipLocalService, _customObjectDefinition2,
@@ -153,17 +159,49 @@ public class OneToManyObjectRelationshipInfoCollectionProviderTest {
 
 		// Unmodifiable system object definition as parent
 
-		ObjectRelationshipTestUtil.addObjectRelationship(
-			_objectRelationshipLocalService, unmodifiableSystemObjectDefinition,
-			_customObjectDefinition2,
-			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
-			StringUtil.randomId(),
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService,
+				unmodifiableSystemObjectDefinition, _customObjectDefinition2,
+				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
+				StringUtil.randomId());
 
-		Assert.assertNull(
-			_infoItemServiceRegistry.getFirstInfoItemService(
-				RelatedInfoItemCollectionProvider.class,
-				unmodifiableSystemObjectDefinition.getClassName()));
+		CPDefinition cpDefinition = CPTestUtil.addCPDefinition(
+			_group.getGroupId());
+
+		try {
+			_assertCollectionInfoPage(
+				_customObjectDefinition2, unmodifiableSystemObjectDefinition,
+				cpDefinition,
+				_addObjectEntry(
+					_customObjectDefinition2, objectRelationship,
+					unmodifiableSystemObjectDefinition,
+					cpDefinition.getCProductId()),
+				_addObjectEntry(
+					_customObjectDefinition2, objectRelationship,
+					unmodifiableSystemObjectDefinition,
+					cpDefinition.getCProductId()));
+
+			long classPK = RandomTestUtil.randomLong();
+
+			_assertCollectionInfoPage(
+				_customObjectDefinition2, unmodifiableSystemObjectDefinition,
+				new SystemObjectEntry(
+					classPK, RandomTestUtil.randomString(),
+					Collections.emptyMap()),
+				_addObjectEntry(
+					_customObjectDefinition2, objectRelationship,
+					unmodifiableSystemObjectDefinition, classPK),
+				_addObjectEntry(
+					_customObjectDefinition2, objectRelationship,
+					unmodifiableSystemObjectDefinition, classPK));
+		}
+		finally {
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				objectRelationship);
+
+			_cpDefinitionLocalService.deleteCPDefinition(cpDefinition);
+		}
 	}
 
 	private ObjectEntry _addObjectEntry(ObjectDefinition objectDefinition)
@@ -183,8 +221,7 @@ public class OneToManyObjectRelationshipInfoCollectionProviderTest {
 	private ObjectEntry _addObjectEntry(
 			ObjectDefinition childObjectDefinition,
 			ObjectRelationship objectRelationship,
-			ObjectDefinition parentObjectDefinition,
-			ObjectEntry parentObjectEntry)
+			ObjectDefinition parentObjectDefinition, long parentPrimaryKey)
 		throws Exception {
 
 		return _objectEntryLocalService.addObjectEntry(
@@ -197,9 +234,49 @@ public class OneToManyObjectRelationshipInfoCollectionProviderTest {
 			).put(
 				ObjectRelationshipUtil.getObjectRelationshipFieldName(
 					parentObjectDefinition, objectRelationship.getName()),
-				parentObjectEntry.getObjectEntryId()
+				parentPrimaryKey
 			).build(),
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+	}
+
+	private void _assertCollectionInfoPage(
+		ObjectDefinition childObjectDefinition,
+		ObjectDefinition parentObjectDefinition, Object relatedItem,
+		ObjectEntry... expectedObjectEntries) {
+
+		List<RelatedInfoItemCollectionProvider>
+			relatedInfoItemCollectionProviders = ListUtil.filter(
+				_infoItemServiceRegistry.getAllInfoItemServices(
+					RelatedInfoItemCollectionProvider.class,
+					parentObjectDefinition.getClassName()),
+				relatedInfoItemCollectionProvider -> Objects.equals(
+					childObjectDefinition.getClassName(),
+					relatedInfoItemCollectionProvider.
+						getCollectionItemClassName()));
+
+		RelatedInfoItemCollectionProvider relatedInfoItemCollectionProvider =
+			relatedInfoItemCollectionProviders.get(0);
+
+		CollectionQuery collectionQuery = new CollectionQuery();
+
+		collectionQuery.setRelatedItemObject(relatedItem);
+
+		InfoPage collectionInfoPage =
+			relatedInfoItemCollectionProvider.getCollectionInfoPage(
+				collectionQuery);
+
+		Assert.assertEquals(
+			expectedObjectEntries.length, collectionInfoPage.getTotalCount());
+
+		List<ObjectEntry> objectEntries = collectionInfoPage.getPageItems();
+
+		Assert.assertEquals(
+			objectEntries.toString(), expectedObjectEntries.length,
+			objectEntries.size());
+
+		for (ObjectEntry expectedObjectEntry : expectedObjectEntries) {
+			Assert.assertTrue(objectEntries.contains(expectedObjectEntry));
+		}
 	}
 
 	private void _testOneToManyObjectRelationshipRelatedInfoCollectionProvider(
@@ -218,10 +295,10 @@ public class OneToManyObjectRelationshipInfoCollectionProviderTest {
 
 		ObjectEntry childObjectEntry1 = _addObjectEntry(
 			childObjectDefinition, objectRelationship, parentObjectDefinition,
-			parentObjectEntry);
+			parentObjectEntry.getObjectEntryId());
 		ObjectEntry childObjectEntry2 = _addObjectEntry(
 			childObjectDefinition, objectRelationship, parentObjectDefinition,
-			parentObjectEntry);
+			parentObjectEntry.getObjectEntryId());
 
 		RelatedInfoItemCollectionProvider relatedInfoItemCollectionProvider =
 			_infoItemServiceRegistry.getFirstInfoItemService(
@@ -249,6 +326,9 @@ public class OneToManyObjectRelationshipInfoCollectionProviderTest {
 		Assert.assertTrue(objectEntries.contains(childObjectEntry1));
 		Assert.assertTrue(objectEntries.contains(childObjectEntry2));
 	}
+
+	@Inject
+	private CPDefinitionLocalService _cpDefinitionLocalService;
 
 	@DeleteAfterTestRun
 	private ObjectDefinition _customObjectDefinition1;

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
@@ -894,6 +894,110 @@ public class ObjectRelationshipLocalServiceTest {
 			objectDefinition2.getClassName(),
 			relatedInfoItemCollectionProvider.getSourceItemClassName());
 
+		ObjectRelationship systemObjectRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				null, TestPropsValues.getUserId(),
+				_unmodifiableSystemObjectDefinition2.getObjectDefinitionId(),
+				_objectDefinition1.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				StringUtil.randomId(), false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+
+		relatedInfoItemCollectionProvider = serviceTrackerMap.getService(
+			_unmodifiableSystemObjectDefinition2.getClassName());
+
+		Assert.assertEquals(
+			_unmodifiableSystemObjectDefinition2.getClassName(),
+			relatedInfoItemCollectionProvider.getSourceItemClassName());
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			systemObjectRelationship);
+
+		ObjectDefinition childObjectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName());
+
+		ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				null, TestPropsValues.getUserId(),
+				_unmodifiableSystemObjectDefinition2.getObjectDefinitionId(),
+				childObjectDefinition.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				StringUtil.randomId(), false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+
+		Assert.assertNull(
+			serviceTrackerMap.getService(
+				_unmodifiableSystemObjectDefinition2.getClassName()));
+
+		childObjectDefinition =
+			_objectDefinitionLocalService.publishCustomObjectDefinition(
+				TestPropsValues.getUserId(),
+				childObjectDefinition.getObjectDefinitionId());
+
+		relatedInfoItemCollectionProvider = serviceTrackerMap.getService(
+			_unmodifiableSystemObjectDefinition2.getClassName());
+
+		Assert.assertEquals(
+			_unmodifiableSystemObjectDefinition2.getClassName(),
+			relatedInfoItemCollectionProvider.getSourceItemClassName());
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			objectRelationship);
+
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			childObjectDefinition);
+
+		childObjectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName());
+
+		ObjectDefinition parentObjectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName());
+
+		_objectRelationshipLocalService.addObjectRelationship(
+			null, TestPropsValues.getUserId(),
+			parentObjectDefinition.getObjectDefinitionId(),
+			childObjectDefinition.getObjectDefinitionId(), 0,
+			ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			StringUtil.randomId(), false,
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+
+		Assert.assertNull(
+			serviceTrackerMap.getService(
+				parentObjectDefinition.getClassName()));
+
+		parentObjectDefinition =
+			_objectDefinitionLocalService.publishCustomObjectDefinition(
+				TestPropsValues.getUserId(),
+				parentObjectDefinition.getObjectDefinitionId());
+
+		Assert.assertNull(
+			serviceTrackerMap.getService(
+				parentObjectDefinition.getClassName()));
+
+		childObjectDefinition =
+			_objectDefinitionLocalService.publishCustomObjectDefinition(
+				TestPropsValues.getUserId(),
+				childObjectDefinition.getObjectDefinitionId());
+
+		relatedInfoItemCollectionProvider = serviceTrackerMap.getService(
+			parentObjectDefinition.getClassName());
+
+		Assert.assertEquals(
+			parentObjectDefinition.getClassName(),
+			relatedInfoItemCollectionProvider.getSourceItemClassName());
+
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			childObjectDefinition);
+
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			parentObjectDefinition);
+
 		serviceTrackerMap.close();
 
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition1);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-56169

Resending because: https://github.com/brianchandotcom/liferay-portal/pull/177456

## What Is Being Fixed

The relationship collection provider was not available for related object entries. Two gaps caused this. First, registration only walked relationships where the object definition was on the first side, so the reverse (parent) side of a one-to-many relationship — the related object's entries — never had a collection provider registered. Second, unmodifiable system objects returned early during deployment and skipped relationship provider registration entirely, so relationships involving system objects had no provider at all.

## How It Is Being Fixed

The deployer now registers relationship collection providers for unmodifiable system objects instead of returning early, sharing a single helper between the system-object and regular deploy paths. The registration service queries all relationships of the object definition rather than only those where it is the first side, and registers the reverse provider for non-many-to-many relationships when the object definition is on the second side, making the provider available on related object entries. To avoid opening a no-op transaction per object definition at bulk deploy — now that system objects also take this path — registration is skipped when the prebuilt relationship list is empty, while null is still passed through on the single-deploy path so it queries its own relationships.

## PR Check

**pr-check: PASS** — tested on `b328ee3ed46e807b9a294847f53126a576b8595f`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "b328ee3ed46e807b9a294847f53126a576b8595f"} -->
