### PR TITLE
LPD-96199 Display "Ignored" count in summary area

### DIFF
--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/js/production_readiness/components/SummaryHeader.tsx
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/js/production_readiness/components/SummaryHeader.tsx
@@ -7,11 +7,12 @@ import React from 'react';
 
 interface Props {
 	failed: number;
+	ignored: number;
 	passed: number;
 	total: number;
 }
 
-const SummaryHeader: React.FC<Props> = ({failed, passed, total}) => {
+const SummaryHeader: React.FC<Props> = ({failed, ignored, passed, total}) => {
 	return (
 		<div data-testid="production-readiness-summary">
 			<div className="small text-secondary text-uppercase">
@@ -48,8 +49,19 @@ const SummaryHeader: React.FC<Props> = ({failed, passed, total}) => {
 					{failed}
 				</span>
 
-				<span className="text-secondary">
+				<span className="mr-3 text-secondary">
 					{Liferay.Language.get('failed')}
+				</span>
+
+				<span
+					className="h2 mb-0 mr-1 text-secondary"
+					data-testid="production-readiness-count-ignored"
+				>
+					{ignored}
+				</span>
+
+				<span className="text-secondary">
+					{Liferay.Language.get('ignored')}
 				</span>
 			</div>
 		</div>

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/js/production_readiness/index.tsx
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/js/production_readiness/index.tsx
@@ -186,6 +186,7 @@ export function ProductionReadinessDashboard(
 			<div className="align-items-start d-flex justify-content-between mb-4">
 				<SummaryHeader
 					failed={failed}
+					ignored={ignored}
 					passed={passed}
 					total={failed + ignored + passed}
 				/>

--- a/modules/test/playwright/tests/server-admin-web/main/pages/ProductionReadinessPage.ts
+++ b/modules/test/playwright/tests/server-admin-web/main/pages/ProductionReadinessPage.ts
@@ -9,7 +9,7 @@ import {GlobalMenuPage} from '../../../../pages/product-navigation-applications-
 import {waitForPageToBeLoaded} from '../../../../utils/waitForPageToBeLoaded';
 
 type FilterLabel = 'All Validations' | 'Failed' | 'Ignored' | 'Passed';
-type SummaryLabel = 'Failed' | 'Passed' | 'Total';
+type SummaryLabel = 'Failed' | 'Ignored' | 'Passed' | 'Total';
 
 const FILTER_LABELS: FilterLabel[] = [
 	'All Validations',
@@ -82,13 +82,7 @@ export class ProductionReadinessPage {
 	}
 
 	async ignoredCount(): Promise<number> {
-		const [failed, passed, total] = await Promise.all([
-			this.summaryCount('Failed'),
-			this.summaryCount('Passed'),
-			this.summaryCount('Total'),
-		]);
-
-		return total - failed - passed;
+		return this.summaryCount('Ignored');
 	}
 
 	filterButton(label: FilterLabel): Locator {

--- a/modules/test/playwright/tests/server-admin-web/main/productionReadiness.spec.ts
+++ b/modules/test/playwright/tests/server-admin-web/main/productionReadiness.spec.ts
@@ -20,7 +20,12 @@ test(
 		});
 
 		await test.step('Check the inline summary counts', async () => {
-			for (const label of ['Failed', 'Passed', 'Total'] as const) {
+			for (const label of [
+				'Failed',
+				'Ignored',
+				'Passed',
+				'Total',
+			] as const) {
 				expect(
 					await productionReadinessPage.summaryCount(label)
 				).toBeGreaterThanOrEqual(0);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96199

## What Is Being Fixed

The Production Readiness dashboard UI needed to explicitly show the "Ignored" count in its summary header to provide a complete overview of the rules.

## How It Is Being Fixed

This PR updates the `SummaryHeader` component to display the "Ignored" count alongside the Failed, Passed, and Total counts. It also updates the Playwright test and `ProductionReadinessPage` object to verify the new UI element.

## PR Check

**pr-check: PASS** — tested on `2c7804c3519e33c6d745ab630e77fccc213cd88f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "2c7804c3519e33c6d745ab630e77fccc213cd88f"} -->
