### PR TITLE
LPD-92462 Fix deadlock on startup caused by configuration records and missing analytics admin user

### DIFF
--- a/modules/apps/analytics/analytics-settings-web-test/bnd.bnd
+++ b/modules/apps/analytics/analytics-settings-web-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Analytics Settings Web Test
+Bundle-SymbolicName: com.liferay.analytics.settings.web.test
+Bundle-Version: 1.0.0

--- a/modules/apps/analytics/analytics-settings-web-test/build.gradle
+++ b/modules/apps/analytics/analytics-settings-web-test/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+	testIntegrationImplementation project(":apps:analytics:analytics-settings-api")
+	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
+	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
+	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
+	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/analytics/analytics-settings-web-test/src/testIntegration/java/com/liferay/analytics/settings/web/internal/upgrade/v1_0_3/test/AnalyticsAdministratorUserUpgradeProcessTest.java
+++ b/modules/apps/analytics/analytics-settings-web-test/src/testIntegration/java/com/liferay/analytics/settings/web/internal/upgrade/v1_0_3/test/AnalyticsAdministratorUserUpgradeProcessTest.java
@@ -1,0 +1,97 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.settings.web.internal.upgrade.v1_0_3.test;
+
+import com.liferay.analytics.settings.configuration.AnalyticsConfiguration;
+import com.liferay.analytics.settings.security.constants.AnalyticsSecurityConstants;
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DataGuard;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Shuyang Zhou
+ */
+@DataGuard(scope = DataGuard.Scope.METHOD)
+@RunWith(Arquillian.class)
+public class AnalyticsAdministratorUserUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testUpgradeCreatesMissingAnalyticsAdministratorUser()
+		throws Exception {
+
+		long companyId = TestPropsValues.getCompanyId();
+
+		String pid = ConfigurationTestUtil.createFactoryConfiguration(
+			AnalyticsConfiguration.class.getName(),
+			HashMapDictionaryBuilder.<String, Object>put(
+				"companyId", companyId
+			).put(
+				"token", "test-token"
+			).build());
+
+		try {
+			Assert.assertNull(
+				_userLocalService.fetchUserByScreenName(
+					companyId,
+					AnalyticsSecurityConstants.SCREEN_NAME_ANALYTICS_ADMIN));
+
+			_runUpgrade();
+
+			User user = _userLocalService.fetchUserByScreenName(
+				companyId,
+				AnalyticsSecurityConstants.SCREEN_NAME_ANALYTICS_ADMIN);
+
+			Assert.assertNotNull(user);
+
+			_userLocalService.deleteUser(user);
+		}
+		finally {
+			ConfigurationTestUtil.deleteConfiguration(pid);
+		}
+	}
+
+	private void _runUpgrade() throws Exception {
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator,
+			"com.liferay.analytics.settings.web.internal.upgrade.v1_0_3." +
+				"AnalyticsAdministratorUserUpgradeProcess");
+
+		upgradeProcess.upgrade();
+	}
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.analytics.settings.web.internal.upgrade.registry.AnalyticsSettingsWebUpgradeStepRegistrator))"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/analytics/analytics-settings-web/src/main/java/com/liferay/analytics/settings/web/internal/upgrade/registry/AnalyticsSettingsWebUpgradeStepRegistrator.java
+++ b/modules/apps/analytics/analytics-settings-web/src/main/java/com/liferay/analytics/settings/web/internal/upgrade/registry/AnalyticsSettingsWebUpgradeStepRegistrator.java
@@ -6,10 +6,12 @@
 package com.liferay.analytics.settings.web.internal.upgrade.registry;
 
 import com.liferay.analytics.settings.web.internal.upgrade.v1_0_2.AnalyticsDispatchTriggersUpgradeProcess;
+import com.liferay.analytics.settings.web.internal.upgrade.v1_0_3.AnalyticsAdministratorUserUpgradeProcess;
 import com.liferay.dispatch.executor.DispatchTaskExecutor;
 import com.liferay.dispatch.service.DispatchLogLocalService;
 import com.liferay.dispatch.service.DispatchTriggerLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
@@ -46,6 +48,12 @@ public class AnalyticsSettingsWebUpgradeStepRegistrator
 				_configurationAdmin, _dispatchLogLocalService,
 				_dispatchTaskExecutor, _dispatchTriggerLocalService,
 				_userLocalService));
+
+		registry.register(
+			"1.0.2", "1.0.3",
+			new AnalyticsAdministratorUserUpgradeProcess(
+				_companyLocalService, _configurationAdmin, _roleLocalService,
+				_userLocalService));
 	}
 
 	@Reference
@@ -64,6 +72,9 @@ public class AnalyticsSettingsWebUpgradeStepRegistrator
 
 	@Reference
 	private DispatchTriggerLocalService _dispatchTriggerLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/analytics/analytics-settings-web/src/main/java/com/liferay/analytics/settings/web/internal/upgrade/v1_0_3/AnalyticsAdministratorUserUpgradeProcess.java
+++ b/modules/apps/analytics/analytics-settings-web/src/main/java/com/liferay/analytics/settings/web/internal/upgrade/v1_0_3/AnalyticsAdministratorUserUpgradeProcess.java
@@ -1,0 +1,136 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.settings.web.internal.upgrade.v1_0_3;
+
+import com.liferay.analytics.settings.configuration.AnalyticsConfiguration;
+import com.liferay.analytics.settings.security.constants.AnalyticsSecurityConstants;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserConstants;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Dictionary;
+
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class AnalyticsAdministratorUserUpgradeProcess extends UpgradeProcess {
+
+	public AnalyticsAdministratorUserUpgradeProcess(
+		CompanyLocalService companyLocalService,
+		ConfigurationAdmin configurationAdmin,
+		RoleLocalService roleLocalService, UserLocalService userLocalService) {
+
+		_companyLocalService = companyLocalService;
+		_configurationAdmin = configurationAdmin;
+		_roleLocalService = roleLocalService;
+		_userLocalService = userLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		Configuration[] configurations;
+
+		if (PropsValues.DATABASE_PARTITION_ENABLED) {
+			configurations = _configurationAdmin.listConfigurations(
+				StringBundler.concat(
+					"(&(companyId=", CompanyThreadLocal.getCompanyId(),
+					")(service.pid=", AnalyticsConfiguration.class.getName(),
+					"*))"));
+		}
+		else {
+			configurations = _configurationAdmin.listConfigurations(
+				"(service.pid=" + AnalyticsConfiguration.class.getName() +
+					"*)");
+		}
+
+		if (ArrayUtil.isEmpty(configurations)) {
+			return;
+		}
+
+		for (Configuration configuration : configurations) {
+			Dictionary<String, Object> properties =
+				configuration.getProperties();
+
+			if ((properties == null) ||
+				Validator.isNull(properties.get("token"))) {
+
+				continue;
+			}
+
+			long companyId = GetterUtil.getLong(properties.get("companyId"));
+
+			Company company = _companyLocalService.fetchCompany(companyId);
+
+			if (company == null) {
+				continue;
+			}
+
+			User user = _userLocalService.fetchUserByScreenName(
+				companyId,
+				AnalyticsSecurityConstants.SCREEN_NAME_ANALYTICS_ADMIN);
+
+			if (user != null) {
+				continue;
+			}
+
+			_addAnalyticsAdministratorUser(company);
+		}
+	}
+
+	private void _addAnalyticsAdministratorUser(Company company)
+		throws Exception {
+
+		long companyId = company.getCompanyId();
+
+		Role role = _roleLocalService.getRole(
+			companyId, "Analytics Administrator");
+
+		User user = _userLocalService.addUser(
+			0, companyId, true, null, null, false,
+			AnalyticsSecurityConstants.SCREEN_NAME_ANALYTICS_ADMIN,
+			"analytics.administrator@" + company.getMx(),
+			LocaleUtil.fromLanguageId(
+				UpgradeProcessUtil.getDefaultLanguageId(companyId)),
+			"Analytics", "", "Administrator", 0, 0, true, 0, 1, 1970, "",
+			UserConstants.TYPE_REGULAR, null, null,
+			new long[] {role.getRoleId()}, null, false, new ServiceContext());
+
+		_userLocalService.updateUser(user);
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				"Added analytics administrator user for company " + companyId);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AnalyticsAdministratorUserUpgradeProcess.class);
+
+	private final CompanyLocalService _companyLocalService;
+	private final ConfigurationAdmin _configurationAdmin;
+	private final RoleLocalService _roleLocalService;
+	private final UserLocalService _userLocalService;
+
+}

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/ConfigurationPersistenceManager.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/ConfigurationPersistenceManager.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -210,9 +211,7 @@ public class ConfigurationPersistenceManager
 			}
 		}
 		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception);
-			}
+			_log.error(exception);
 		}
 
 		_createConfigurationTable();
@@ -397,6 +396,38 @@ public class ConfigurationPersistenceManager
 		}
 	}
 
+	private Long _getScopeCompanyId(String pid, Object scopeCompanyIdObject) {
+		if (scopeCompanyIdObject instanceof Long scopeCompanyIdLong) {
+			return scopeCompanyIdLong;
+		}
+
+		if (scopeCompanyIdObject instanceof String scopeCompanyIdString) {
+			try {
+				long scopeCompanyId = GetterUtil.getLongStrict(
+					scopeCompanyIdString);
+
+				if (_log.isWarnEnabled()) {
+					_log.warn("Converted string company ID for " + pid);
+				}
+
+				return scopeCompanyId;
+			}
+			catch (NumberFormatException numberFormatException) {
+				_log.error(numberFormatException);
+
+				return null;
+			}
+		}
+
+		if (scopeCompanyIdObject != null) {
+			_log.error("Unexpected company ID type for " + pid);
+
+			return null;
+		}
+
+		return 0L;
+	}
+
 	private boolean _insertConfiguration(
 			Connection connection, String pid, String configuration)
 		throws IOException {
@@ -473,13 +504,15 @@ public class ConfigurationPersistenceManager
 						}
 
 						if (PropsValues.DATABASE_PARTITION_ENABLED) {
-							Long scopeCompanyId = (Long)dictionary.get(
-								ExtendedObjectClassDefinition.Scope.COMPANY.
-									getPropertyKey());
+							Long scopeCompanyId = _getScopeCompanyId(
+								pid,
+								dictionary.get(
+									ExtendedObjectClassDefinition.Scope.COMPANY.
+										getPropertyKey()));
 
-							if ((scopeCompanyId != null) &&
-								(scopeCompanyId != 0) &&
-								!scopeCompanyId.equals(companyId)) {
+							if ((scopeCompanyId == null) ||
+								((scopeCompanyId != 0) &&
+								 !scopeCompanyId.equals(companyId))) {
 
 								continue;
 							}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92462
@shuyangzhou 

## What Is Being Fixed

When an analytics configuration has a token but the analytics administrator user no longer exists, the user is never recreated: `_enable` in `AnalyticsConfigurationRegistryImpl` only runs on the null-to-non-null token transition and is permanently skipped once `previousToken` is set. The configuration update path then falls through to creating the user on the Felix Configuration Admin update thread, which can deadlock while resolving other configurations.

A second, independent issue compounds this: `ConfigurationPersistenceManager` crashed when populating configurations for a company whose ID was stored as a non-long value, aborting the startup sequence entirely.

## How It Is Being Fixed

An upgrade process repairs the inconsistent state by creating the analytics administrator user for every company that has an analytics token configured but is missing the user. Orphaned configurations whose company no longer exists are skipped. The `ConfigurationPersistenceManager` is hardened to tolerate non-long company ID values — rather than throwing and aborting, it logs a warning and skips the offending record.

## PR Check

**pr-check: PASS** — tested on `a90813a802874ca65b17b83ff98058a238290b0f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "a90813a802874ca65b17b83ff98058a238290b0f"} -->
