### PR TITLE
LPD-96859 Iteratively unwrap the ServiceWrapper chain in setUp

### DIFF
--- a/modules/apps/portal-security/portal-security-permission-test/src/testIntegration/java/com/liferay/portal/security/permission/test/ResourcePermissionLocalServiceConcurrentTest.java
+++ b/modules/apps/portal-security/portal-security-permission-test/src/testIntegration/java/com/liferay/portal/security/permission/test/ResourcePermissionLocalServiceConcurrentTest.java
@@ -89,15 +89,17 @@ public class ResourcePermissionLocalServiceConcurrentTest {
 			ProxyUtil.fetchInvocationHandler(
 				_resourcePermissionLocalService, AopInvocationHandler.class);
 
-		ServiceWrapper<ResourcePermissionLocalService>
-			resourcePermissionLocalServiceWrapper =
-				(ServiceWrapper<ResourcePermissionLocalService>)
-					aopInvocationHandler.getTarget();
+		Object target = aopInvocationHandler.getTarget();
+
+		while (target instanceof ServiceWrapper) {
+			ServiceWrapper<?> serviceWrapper = (ServiceWrapper<?>)target;
+
+			target = serviceWrapper.getWrappedService();
+		}
 
 		final ResourcePermissionLocalServiceImpl
 			resourcePermissionLocalServiceImpl =
-				(ResourcePermissionLocalServiceImpl)
-					resourcePermissionLocalServiceWrapper.getWrappedService();
+				(ResourcePermissionLocalServiceImpl)target;
 
 		final ResourcePermissionPersistence resourcePermissionPersistence =
 			resourcePermissionLocalServiceImpl.


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96859

## What Is Being Fixed

The integration test ResourcePermissionLocalServiceConcurrentTest failed on master with a ClassCastException in setUp. The test unwrapped the ResourcePermissionLocalService AOP target exactly one layer, assuming a single ServiceWrapper sat directly on ResourcePermissionLocalServiceImpl. After a second ServiceWrapper (KaleoTaskInstanceTokenResourcePermissionLocalServiceWrapper) was registered for the service, OSGi chained the wrappers, so the single getWrappedService() call returned the inner wrapper instead of the impl and the cast threw.

## How It Is Being Fixed

Instead of unwrapping a single layer, setUp now loops on getWrappedService() until the target is no longer a ServiceWrapper, then casts to ResourcePermissionLocalServiceImpl. This reaches the concrete implementation regardless of how many ServiceWrapper components OSGi has chained, so the test no longer breaks when additional wrappers are registered for the service.

## Why Are There No Tests?

This change fixes the existing integration test ResourcePermissionLocalServiceConcurrentTest; the corrected test passing is the coverage. The failure was reproduced before the change and verified passing after.

## PR Check

**pr-check: PASS** — tested on `4b63bad390f61195b29e0e02df7e071ed149455b`

| Validation | Result |
| --- | --- |
| Integration Test Compile | PASS |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "4b63bad390f61195b29e0e02df7e071ed149455b"} -->
