### PR TITLE
LPD-96785 Apply a deterministic sort order in projection tests

### DIFF
--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/DynamicQueryEntryTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/DynamicQueryEntryTest.java
@@ -517,14 +517,9 @@ public class DynamicQueryEntryTest {
 		projectionList.add(ProjectionFactoryUtil.count("dynamicQueryEntryId"));
 		projectionList.add(ProjectionFactoryUtil.groupProperty("status"));
 
-		DynamicQuery dynamicQuery =
-			_dynamicQueryEntryLocalService.dynamicQuery();
-
-		dynamicQuery.addOrder(OrderFactoryUtil.asc("status"));
-
 		_testDynamicQueryWithProjection(
-			projectionList, new Object[] {2L, 1}, new Object[] {1L, 2},
-			new Object[] {1L, 3});
+			projectionList, OrderFactoryUtil.asc("status"),
+			new Object[] {2L, 1}, new Object[] {1L, 2}, new Object[] {1L, 3});
 	}
 
 	@Test
@@ -544,16 +539,12 @@ public class DynamicQueryEntryTest {
 
 	@Test
 	public void testDynamicQueryWithProjectionSqlGroupProjection() {
-		DynamicQuery dynamicQuery =
-			_dynamicQueryEntryLocalService.dynamicQuery();
-
-		dynamicQuery.addOrder(OrderFactoryUtil.asc("status"));
-
 		_testDynamicQueryWithProjection(
 			ProjectionFactoryUtil.sqlGroupProjection(
 				"count(*) AS c, status AS s", "status", new String[] {"c", "s"},
 				new Type[] {Type.LONG, Type.INTEGER}),
-			new Object[] {2L, 1}, new Object[] {1L, 2}, new Object[] {1L, 3});
+			OrderFactoryUtil.asc("status"), new Object[] {2L, 1},
+			new Object[] {1L, 2}, new Object[] {1L, 3});
 	}
 
 	@Test
@@ -806,6 +797,18 @@ public class DynamicQueryEntryTest {
 			_dynamicQueryEntryLocalService.dynamicQuery();
 
 		dynamicQuery.setProjection(projection);
+
+		_testDynamicQuery(dynamicQuery, expectedResults);
+	}
+
+	private void _testDynamicQueryWithProjection(
+		Projection projection, Order order, Object... expectedResults) {
+
+		DynamicQuery dynamicQuery =
+			_dynamicQueryEntryLocalService.dynamicQuery();
+
+		dynamicQuery.setProjection(projection);
+		dynamicQuery.addOrder(order);
 
 		_testDynamicQuery(dynamicQuery, expectedResults);
 	}

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/DynamicQueryEntryTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/DynamicQueryEntryTest.java
@@ -532,9 +532,9 @@ public class DynamicQueryEntryTest {
 		projectionList.add(projection, "b");
 
 		_testDynamicQueryWithProjection(
-			projectionList, new Object[] {"alpha", "alpha"},
-			new Object[] {"beta", "beta"}, new Object[] {"gamma", "gamma"},
-			new Object[] {"delta", "delta"});
+			projectionList, OrderFactoryUtil.asc("dynamicQueryEntryId"),
+			new Object[] {"alpha", "alpha"}, new Object[] {"beta", "beta"},
+			new Object[] {"gamma", "gamma"}, new Object[] {"delta", "delta"});
 	}
 
 	@Test
@@ -549,16 +549,12 @@ public class DynamicQueryEntryTest {
 
 	@Test
 	public void testDynamicQueryWithProjectionSqlProjection() {
-		DynamicQuery dynamicQuery =
-			_dynamicQueryEntryLocalService.dynamicQuery();
-
-		dynamicQuery.addOrder(OrderFactoryUtil.asc("amount"));
-
 		_testDynamicQueryWithProjection(
 			ProjectionFactoryUtil.sqlProjection(
 				"name AS sqlName", new String[] {"sqlName"},
 				new Type[] {Type.STRING}),
-			"alpha", "beta", "gamma", "delta");
+			OrderFactoryUtil.asc("dynamicQueryEntryId"), "alpha", "beta",
+			"gamma", "delta");
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96785

## What Is Being Fixed

DynamicQueryEntryTest's grouped-projection tests
(testDynamicQueryWithProjectionGroupProperty and
testDynamicQueryWithProjectionSqlGroupProjection) compare projection results
by row index, but execute a GROUP BY with no ORDER BY, so they depend on the
database's unspecified row order. The order-adding calls the tests already had
were applied to a discarded DynamicQuery and never reached the executed query.
On PostgreSQL the grouped query uses a HashAggregate plan and returns the rows
unsorted, so the by-index assertion fails; other databases happen to return
them sorted and pass. This is not a Hibernate 7 regression: it reproduces on
clean master (Hibernate 5) and fails only on the PostgreSQL batch (~75 upstream
master builds), while mysql, mariadb, sqlserver, db2, oracle, and hypersonic
all pass.

## How It Is Being Fixed

Add a _testDynamicQueryWithProjection(Projection, Order, Object...) overload
that applies the order to the query that actually executes, and route the
multi-row projection tests through it. The grouped tests order by status, which
is unique after GROUP BY status; the other multi-row projection tests
(ReusedProjectionInstance, SqlProjection) order by the dynamicQueryEntryId
primary key so they no longer rely on incidental insertion order.

The original no-order overload is kept for the 7 single-row aggregate
projections (avg, count, countDistinct, max, min, rowCount, sum). Forcing an
order into that shared method would break them: an aggregate-only query has no
GROUP BY, so ORDER BY on a plain column makes PostgreSQL reject the statement
with org.hibernate.exception.SQLGrammarException ("column must appear in the
GROUP BY clause or be used in an aggregate function"). That is a runtime error,
not an assertion failure, so a single always-add-order method cannot serve both
the aggregate and the multi-row callers; the explicit-Order overload is used
only where a GROUP BY or plain column makes the order legal.

## Why Are There No Tests?

This change only modifies existing integration tests to make their assertions
deterministic; it touches no production code, so no new tests are added.

## PR Check

**pr-check: PASS** — tested on `e6a2d2d6c16c71dcb380955907b1e44ccc94495c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "e6a2d2d6c16c71dcb380955907b1e44ccc94495c"} -->
