### PR TITLE
LPD-96785 Apply a deterministic sort order in the projection tests

### DIFF
--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/DynamicQueryEntryTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/DynamicQueryEntryTest.java
@@ -493,21 +493,21 @@ public class DynamicQueryEntryTest {
 	@Test
 	public void testDynamicQueryWithProjection() {
 		_testDynamicQueryWithProjection(
-			ProjectionFactoryUtil.avg("amount"), 250.0);
+			null, ProjectionFactoryUtil.avg("amount"), 250.0);
 		_testDynamicQueryWithProjection(
-			ProjectionFactoryUtil.count("dynamicQueryEntryId"),
+			null, ProjectionFactoryUtil.count("dynamicQueryEntryId"),
 			Long.valueOf(_dynamicQueryEntries.size()));
 		_testDynamicQueryWithProjection(
-			ProjectionFactoryUtil.countDistinct("status"), 3L);
+			null, ProjectionFactoryUtil.countDistinct("status"), 3L);
 		_testDynamicQueryWithProjection(
-			ProjectionFactoryUtil.max("amount"), 400L);
+			null, ProjectionFactoryUtil.max("amount"), 400L);
 		_testDynamicQueryWithProjection(
-			ProjectionFactoryUtil.min("amount"), 100L);
+			null, ProjectionFactoryUtil.min("amount"), 100L);
 		_testDynamicQueryWithProjection(
-			ProjectionFactoryUtil.rowCount(),
+			null, ProjectionFactoryUtil.rowCount(),
 			Long.valueOf(_dynamicQueryEntries.size()));
 		_testDynamicQueryWithProjection(
-			ProjectionFactoryUtil.sum("amount"), 1000L);
+			null, ProjectionFactoryUtil.sum("amount"), 1000L);
 	}
 
 	@Test
@@ -517,14 +517,9 @@ public class DynamicQueryEntryTest {
 		projectionList.add(ProjectionFactoryUtil.count("dynamicQueryEntryId"));
 		projectionList.add(ProjectionFactoryUtil.groupProperty("status"));
 
-		DynamicQuery dynamicQuery =
-			_dynamicQueryEntryLocalService.dynamicQuery();
-
-		dynamicQuery.addOrder(OrderFactoryUtil.asc("status"));
-
 		_testDynamicQueryWithProjection(
-			projectionList, new Object[] {2L, 1}, new Object[] {1L, 2},
-			new Object[] {1L, 3});
+			OrderFactoryUtil.asc("status"), projectionList,
+			new Object[] {2L, 1}, new Object[] {1L, 2}, new Object[] {1L, 3});
 	}
 
 	@Test
@@ -537,19 +532,15 @@ public class DynamicQueryEntryTest {
 		projectionList.add(projection, "b");
 
 		_testDynamicQueryWithProjection(
-			projectionList, new Object[] {"alpha", "alpha"},
-			new Object[] {"beta", "beta"}, new Object[] {"gamma", "gamma"},
-			new Object[] {"delta", "delta"});
+			OrderFactoryUtil.asc("dynamicQueryEntryId"), projectionList,
+			new Object[] {"alpha", "alpha"}, new Object[] {"beta", "beta"},
+			new Object[] {"gamma", "gamma"}, new Object[] {"delta", "delta"});
 	}
 
 	@Test
 	public void testDynamicQueryWithProjectionSqlGroupProjection() {
-		DynamicQuery dynamicQuery =
-			_dynamicQueryEntryLocalService.dynamicQuery();
-
-		dynamicQuery.addOrder(OrderFactoryUtil.asc("status"));
-
 		_testDynamicQueryWithProjection(
+			OrderFactoryUtil.asc("status"),
 			ProjectionFactoryUtil.sqlGroupProjection(
 				"count(*) AS c, status AS s", "status", new String[] {"c", "s"},
 				new Type[] {Type.LONG, Type.INTEGER}),
@@ -558,12 +549,8 @@ public class DynamicQueryEntryTest {
 
 	@Test
 	public void testDynamicQueryWithProjectionSqlProjection() {
-		DynamicQuery dynamicQuery =
-			_dynamicQueryEntryLocalService.dynamicQuery();
-
-		dynamicQuery.addOrder(OrderFactoryUtil.asc("amount"));
-
 		_testDynamicQueryWithProjection(
+			OrderFactoryUtil.asc("amount"),
 			ProjectionFactoryUtil.sqlProjection(
 				"name AS sqlName", new String[] {"sqlName"},
 				new Type[] {Type.STRING}),
@@ -800,12 +787,16 @@ public class DynamicQueryEntryTest {
 	}
 
 	private void _testDynamicQueryWithProjection(
-		Projection projection, Object... expectedResults) {
+		Order order, Projection projection, Object... expectedResults) {
 
 		DynamicQuery dynamicQuery =
 			_dynamicQueryEntryLocalService.dynamicQuery();
 
 		dynamicQuery.setProjection(projection);
+
+		if (order != null) {
+			dynamicQuery.addOrder(order);
+		}
 
 		_testDynamicQuery(dynamicQuery, expectedResults);
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96785

## What Is Being Fixed

DynamicQueryEntryTest's multi-row projection tests compare query results by index but ran without an ORDER BY on the executed query, so they relied on the database returning rows in an unspecified order. On PostgreSQL the grouped projections come back via HashAggregate unsorted, so the by-index assertions fail; other databases happen to return them sorted, which hid the problem.

## How It Is Being Fixed

The grouped and multi-row tests each built a DynamicQuery, added an order to it, then discarded it and passed only the projection to _testDynamicQueryWithProjection, which built its own query without the order; one test had no order at all. This adds an Order parameter to _testDynamicQueryWithProjection and applies it to the query the helper actually executes. The grouped tests order by status, the group key, which is unique across the result rows; the multi-row per-entity tests order by dynamicQueryEntryId, which is unique and matches the insertion order the expected values assume. The helper skips the order when it is null so the single-row aggregate projections, which cannot carry an ORDER BY on a non-grouped column, keep passing null. This supersedes #10062, which fixed the same failure with a separate helper overload rather than one null-tolerant overload.

## Why Are There No Tests?

The change is confined to DynamicQueryEntryTest itself: it hardens existing integration tests to run deterministically across databases rather than changing product behavior, so there is no new production code to cover. DynamicQueryEntryTest was run three consecutive times and passed on every run.

## PR Check

**pr-check: PASS** — tested on `e3eb0a7f432ec9ad11ea7bc63ca75aae5311687f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "e3eb0a7f432ec9ad11ea7bc63ca75aae5311687f"} -->
