### PR TITLE
LPD-97635 Detect the search engine sidecar via SearchEngineInformation

### DIFF
--- a/modules/apps/server/server-admin-web/build.gradle
+++ b/modules/apps/server/server-admin-web/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 	compileOnly project(":apps:image:image-api")
 	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
-	compileOnly project(":apps:portal-search-elasticsearch8:portal-search-elasticsearch8-api")
+	compileOnly project(":apps:portal-search:portal-search-api")
 	compileOnly project(":apps:portal:portal-db-migration-schema-exporter-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")

--- a/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/production/readiness/ProductionReadinessCheckUtil.java
+++ b/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/production/readiness/ProductionReadinessCheckUtil.java
@@ -8,9 +8,9 @@ package com.liferay.server.admin.web.internal.production.readiness;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.configuration.module.configuration.ConfigurationProviderUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
-import com.liferay.portal.search.elasticsearch8.configuration.ElasticsearchConfiguration;
+import com.liferay.portal.search.engine.SearchEngineInformation;
 
 import java.io.File;
 
@@ -601,31 +601,20 @@ public class ProductionReadinessCheckUtil {
 	}
 
 	private static ProductionReadinessResult _checkSidecarDetection() {
-		boolean productionModeEnabled = false;
+		SearchEngineInformation searchEngineInformation =
+			_searchEngineInformationSnapshot.get();
 
-		try {
-			ElasticsearchConfiguration elasticsearchConfiguration =
-				ConfigurationProviderUtil.getSystemConfiguration(
-					ElasticsearchConfiguration.class);
-
-			productionModeEnabled =
-				elasticsearchConfiguration.productionModeEnabled();
-		}
-		catch (Exception exception) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(exception);
-			}
-		}
+		String vendorString = searchEngineInformation.getVendorString();
 
 		ProductionReadinessResult.Builder builder =
 			ProductionReadinessResult.builder(
 				"search-engine-connectivity-validation", "sidecar-detection");
 
-		if (productionModeEnabled) {
-			return builder.pass();
+		if (vendorString.contains("Sidecar")) {
+			return builder.fail();
 		}
 
-		return builder.fail();
+		return builder.pass();
 	}
 
 	private static MemoryUsage _getHeapMemoryUsage() {
@@ -811,5 +800,9 @@ public class ProductionReadinessCheckUtil {
 			"com.liferay.portal.store.gcs.GCSStore",
 			"com.liferay.portal.store.s3.IBMS3Store",
 			"com.liferay.portal.store.s3.S3Store");
+	private static final Snapshot<SearchEngineInformation>
+		_searchEngineInformationSnapshot = new Snapshot<>(
+			ProductionReadinessCheckUtil.class, SearchEngineInformation.class,
+			null, true);
 
 }

--- a/modules/apps/server/server-admin-web/src/test/java/com/liferay/server/admin/web/internal/production/readiness/ProductionReadinessCheckUtilTest.java
+++ b/modules/apps/server/server-admin-web/src/test/java/com/liferay/server/admin/web/internal/production/readiness/ProductionReadinessCheckUtilTest.java
@@ -5,7 +5,7 @@
 
 package com.liferay.server.admin.web.internal.production.readiness;
 
-import com.liferay.portal.configuration.module.configuration.ConfigurationProviderUtil;
+import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
@@ -17,10 +17,7 @@ import com.liferay.portal.kernel.util.ServerDetector;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
-import com.liferay.portal.search.elasticsearch8.configuration.ElasticsearchConfiguration;
-import com.liferay.portal.test.log.LogCapture;
-import com.liferay.portal.test.log.LogEntry;
-import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.search.engine.SearchEngineInformation;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.util.FastDateFormatFactoryImpl;
 
@@ -1066,28 +1063,31 @@ public class ProductionReadinessCheckUtilTest {
 	}
 
 	@Test
-	public void testCheckSidecarDetectionProductionModeDisabledFail()
+	public void testCheckSidecarDetectionSidecarDetectedFail()
 		throws Exception {
 
-		try (MockedStatic<ConfigurationProviderUtil>
-				configurationProviderUtilMockedStatic = Mockito.mockStatic(
-					ConfigurationProviderUtil.class)) {
+		SearchEngineInformation searchEngineInformation = Mockito.mock(
+			SearchEngineInformation.class);
 
-			ElasticsearchConfiguration elasticsearchConfiguration =
-				Mockito.mock(ElasticsearchConfiguration.class);
+		Mockito.when(
+			searchEngineInformation.getVendorString()
+		).thenReturn(
+			"Elasticsearch (Sidecar)"
+		);
 
-			Mockito.when(
-				elasticsearchConfiguration.productionModeEnabled()
-			).thenReturn(
-				false
-			);
+		Snapshot<SearchEngineInformation> snapshot = Mockito.mock(
+			Snapshot.class);
 
-			configurationProviderUtilMockedStatic.when(
-				() -> ConfigurationProviderUtil.getSystemConfiguration(
-					ElasticsearchConfiguration.class)
-			).thenReturn(
-				elasticsearchConfiguration
-			);
+		Mockito.when(
+			snapshot.get()
+		).thenReturn(
+			searchEngineInformation
+		);
+
+		try (AutoCloseable closeable =
+				ReflectionTestUtil.setFieldValueWithAutoCloseable(
+					ProductionReadinessCheckUtil.class,
+					"_searchEngineInformationSnapshot", snapshot)) {
 
 			ProductionReadinessResult productionReadinessResult =
 				ReflectionTestUtil.invoke(
@@ -1101,28 +1101,31 @@ public class ProductionReadinessCheckUtilTest {
 	}
 
 	@Test
-	public void testCheckSidecarDetectionProductionModeEnabledPass()
+	public void testCheckSidecarDetectionSidecarNotDetectedPass()
 		throws Exception {
 
-		try (MockedStatic<ConfigurationProviderUtil>
-				configurationProviderUtilMockedStatic = Mockito.mockStatic(
-					ConfigurationProviderUtil.class)) {
+		SearchEngineInformation searchEngineInformation = Mockito.mock(
+			SearchEngineInformation.class);
 
-			ElasticsearchConfiguration elasticsearchConfiguration =
-				Mockito.mock(ElasticsearchConfiguration.class);
+		Mockito.when(
+			searchEngineInformation.getVendorString()
+		).thenReturn(
+			"Elasticsearch"
+		);
 
-			Mockito.when(
-				elasticsearchConfiguration.productionModeEnabled()
-			).thenReturn(
-				true
-			);
+		Snapshot<SearchEngineInformation> snapshot = Mockito.mock(
+			Snapshot.class);
 
-			configurationProviderUtilMockedStatic.when(
-				() -> ConfigurationProviderUtil.getSystemConfiguration(
-					ElasticsearchConfiguration.class)
-			).thenReturn(
-				elasticsearchConfiguration
-			);
+		Mockito.when(
+			snapshot.get()
+		).thenReturn(
+			searchEngineInformation
+		);
+
+		try (AutoCloseable closeable =
+				ReflectionTestUtil.setFieldValueWithAutoCloseable(
+					ProductionReadinessCheckUtil.class,
+					"_searchEngineInformationSnapshot", snapshot)) {
 
 			ProductionReadinessResult productionReadinessResult =
 				ReflectionTestUtil.invoke(
@@ -1132,44 +1135,6 @@ public class ProductionReadinessCheckUtilTest {
 			Assert.assertTrue(productionReadinessResult.isPass());
 			Assert.assertEquals(
 				"sidecar-detection", productionReadinessResult.getKey());
-		}
-	}
-
-	@Test
-	public void testCheckSidecarDetectionUnreadableConfigurationFail()
-		throws Exception {
-
-		try (MockedStatic<ConfigurationProviderUtil>
-				configurationProviderUtilMockedStatic = Mockito.mockStatic(
-					ConfigurationProviderUtil.class);
-			LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				ProductionReadinessCheckUtil.class.getName(),
-				LoggerTestUtil.WARN)) {
-
-			configurationProviderUtilMockedStatic.when(
-				() -> ConfigurationProviderUtil.getSystemConfiguration(
-					ElasticsearchConfiguration.class)
-			).thenThrow(
-				new RuntimeException()
-			);
-
-			ProductionReadinessResult productionReadinessResult =
-				ReflectionTestUtil.invoke(
-					ProductionReadinessCheckUtil.class,
-					"_checkSidecarDetection", new Class<?>[0]);
-
-			Assert.assertFalse(productionReadinessResult.isPass());
-			Assert.assertEquals(
-				"sidecar-detection", productionReadinessResult.getKey());
-
-			List<LogEntry> logEntries = logCapture.getLogEntries();
-
-			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
-
-			LogEntry logEntry = logEntries.get(0);
-
-			Assert.assertTrue(
-				logEntry.getThrowable() instanceof RuntimeException);
 		}
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97635

## What Is Being Fixed

The `server-admin-web` module could not resolve when the `elasticsearch8` module was absent (for example on an OpenSearch deployment), failing with "Could not resolve module com.liferay.server.admin.web due to unresolved requirement elasticsearch8". The production-readiness sidecar-detection check compiled against `ElasticsearchConfiguration` from `portal-search-elasticsearch8-api`, forcing a hard dependency on a search engine implementation that is not always present.

## How It Is Being Fixed

The sidecar-detection check no longer reads `ElasticsearchConfiguration`. It now obtains the active engine's vendor string from the engine-agnostic `SearchEngineInformation` service, resolved through a `Snapshot`, and fails the check when that vendor string reports a sidecar. The build dependency on `portal-search-elasticsearch8-api` is replaced with `portal-search-api`, so the module resolves regardless of which search engine is installed. The unit tests were updated to mock `SearchEngineInformation` instead of `ElasticsearchConfiguration`.

## PR Check

**pr-check: PASS** — tested on `519ced6ff49a55af07db722e79e90a1e63631ff0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "519ced6ff49a55af07db722e79e90a1e63631ff0"} -->
