### PR TITLE
LPD-97404 Do not swallow exceptions during virtual host URL processing a virtual host friendly URL

### DIFF
--- a/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/virtualhost/test/VirtualHostFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/virtualhost/test/VirtualHostFilterTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
@@ -28,6 +29,10 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PortalImpl;
 
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -44,6 +49,7 @@ import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockFilterConfig;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletContext;
 
 /**
  * @author Zsolt Oláh
@@ -97,7 +103,7 @@ public class VirtualHostFilterTest {
 					false)) {
 
 			MockHttpServletRequest mockHttpServletRequest = _processFilter(
-				null, StringPool.SLASH + RandomTestUtil.randomString());
+				null, StringPool.SLASH + RandomTestUtil.randomString(), null);
 
 			Assert.assertNull(
 				mockHttpServletRequest.getAttribute(
@@ -106,6 +112,36 @@ public class VirtualHostFilterTest {
 				mockHttpServletRequest.getAttribute(
 					WebKeys.GROUP_FRIENDLY_URL));
 		}
+	}
+
+	@Test(expected = SystemException.class)
+	public void testProcessFilterDoesNotSwallowException() {
+		_processFilter(
+			_publicLayoutSet, "/home",
+			new MockServletContext() {
+
+				@Override
+				public RequestDispatcher getRequestDispatcher(String path) {
+					return new RequestDispatcher() {
+
+						@Override
+						public void forward(
+							ServletRequest servletRequest,
+							ServletResponse servletResponse) {
+
+							throw new SystemException();
+						}
+
+						@Override
+						public void include(
+							ServletRequest servletRequest,
+							ServletResponse servletResponse) {
+						}
+
+					};
+				}
+
+			});
 	}
 
 	@Test
@@ -215,8 +251,8 @@ public class VirtualHostFilterTest {
 
 		MockHttpServletRequest mockHttpServletRequest = _processFilter(
 			_publicLayoutSet,
-			groupFriendlyURL + StringPool.SLASH +
-				RandomTestUtil.randomString());
+			groupFriendlyURL + StringPool.SLASH + RandomTestUtil.randomString(),
+			null);
 
 		Group group = (Group)mockHttpServletRequest.getAttribute(
 			WebKeys.FRIENDLY_URL_GROUP);
@@ -242,7 +278,8 @@ public class VirtualHostFilterTest {
 			MockHttpServletRequest mockHttpServletRequest = _processFilter(
 				null,
 				groupFriendlyURL + StringPool.SLASH +
-					RandomTestUtil.randomString());
+					RandomTestUtil.randomString(),
+				null);
 
 			Group group = (Group)mockHttpServletRequest.getAttribute(
 				WebKeys.FRIENDLY_URL_GROUP);
@@ -352,12 +389,12 @@ public class VirtualHostFilterTest {
 	}
 
 	private MockHttpServletRequest _processFilter(
-		LayoutSet layoutSet, String requestURI) {
+		LayoutSet layoutSet, String requestURI, ServletContext servletContext) {
 
 		MockHttpServletRequest mockHttpServletRequest =
 			_getMockHttpServletRequest(layoutSet, requestURI);
 
-		_virtualHostFilter.init(new MockFilterConfig());
+		_virtualHostFilter.init(new MockFilterConfig(servletContext));
 
 		ReflectionTestUtil.invoke(
 			_virtualHostFilter, "processFilter",

--- a/portal-impl/src/com/liferay/portal/servlet/filters/virtualhost/VirtualHostFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/virtualhost/VirtualHostFilter.java
@@ -325,119 +325,98 @@ public class VirtualHostFilter extends BasePortalFilter {
 
 		long companyId = CompanyThreadLocal.getCompanyId();
 
-		try {
-			Map<String, String[]> parameterMap =
-				httpServletRequest.getParameterMap();
+		Map<String, String[]> parameterMap =
+			httpServletRequest.getParameterMap();
 
-			String parameters = StringPool.BLANK;
+		String parameters = StringPool.BLANK;
 
-			if (!parameterMap.isEmpty()) {
-				parameters = HttpComponentsUtil.parameterMapToString(
-					parameterMap);
-			}
+		if (!parameterMap.isEmpty()) {
+			parameters = HttpComponentsUtil.parameterMapToString(parameterMap);
+		}
 
-			LastPath lastPath = new LastPath(
-				_originalContextPath, friendlyURL, parameters);
+		LastPath lastPath = new LastPath(
+			_originalContextPath, friendlyURL, parameters);
 
-			httpServletRequest.setAttribute(WebKeys.LAST_PATH, lastPath);
+		httpServletRequest.setAttribute(WebKeys.LAST_PATH, lastPath);
 
-			StringBundler sb = new StringBundler(5);
+		StringBundler sb = new StringBundler(5);
 
-			if (i18nLanguageId != null) {
-				sb.append(i18nLanguageId);
-			}
+		if (i18nLanguageId != null) {
+			sb.append(i18nLanguageId);
+		}
 
-			if (originalFriendlyURL.startsWith(
-					PropsValues.WIDGET_SERVLET_MAPPING)) {
+		if (originalFriendlyURL.startsWith(
+				PropsValues.WIDGET_SERVLET_MAPPING)) {
 
-				sb.append(PropsValues.WIDGET_SERVLET_MAPPING);
+			sb.append(PropsValues.WIDGET_SERVLET_MAPPING);
 
-				friendlyURL = StringUtil.replaceFirst(
-					friendlyURL, PropsValues.WIDGET_SERVLET_MAPPING,
-					StringPool.BLANK);
-			}
+			friendlyURL = StringUtil.replaceFirst(
+				friendlyURL, PropsValues.WIDGET_SERVLET_MAPPING,
+				StringPool.BLANK);
+		}
 
-			String groupFriendlyURL =
-				GroupFriendlyURLUtil.parseGroupFriendlyURL(friendlyURL);
+		String groupFriendlyURL = GroupFriendlyURLUtil.parseGroupFriendlyURL(
+			friendlyURL);
 
-			Group group = GroupFriendlyURLUtil.fetchFriendlyURLGroup(
-				companyId, groupFriendlyURL);
+		Group group = GroupFriendlyURLUtil.fetchFriendlyURLGroup(
+			companyId, groupFriendlyURL);
 
-			if ((group != null) &&
-				SiteVirtualHostUtil.isRestricted(group, httpServletRequest)) {
+		if ((group != null) &&
+			SiteVirtualHostUtil.isRestricted(group, httpServletRequest)) {
 
-				httpServletRequest.setAttribute(
-					WebKeys.SITE_VIRTUAL_HOST_RESTRICTED, Boolean.TRUE);
+			httpServletRequest.setAttribute(
+				WebKeys.SITE_VIRTUAL_HOST_RESTRICTED, Boolean.TRUE);
 
-				PortalUtil.sendError(
-					new NoSuchLayoutException(), httpServletRequest,
-					httpServletResponse);
+			PortalUtil.sendError(
+				new NoSuchLayoutException(), httpServletRequest,
+				httpServletResponse);
 
-				return;
-			}
+			return;
+		}
 
-			if (group != null) {
-				httpServletRequest.setAttribute(
-					WebKeys.FRIENDLY_URL_GROUP, group);
-				httpServletRequest.setAttribute(
-					WebKeys.GROUP_FRIENDLY_URL, groupFriendlyURL);
-			}
+		if (group != null) {
+			httpServletRequest.setAttribute(WebKeys.FRIENDLY_URL_GROUP, group);
+			httpServletRequest.setAttribute(
+				WebKeys.GROUP_FRIENDLY_URL, groupFriendlyURL);
+		}
 
-			if (!PropsValues.
-					LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED &&
-				!layoutSet.isPrivateLayout() && (group != null)) {
+		if (!PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING_ENABLED &&
+			!layoutSet.isPrivateLayout() && (group != null)) {
 
-				sb.append(_PUBLIC_GROUP_SERVLET_MAPPING);
-			}
-			else {
-				long plid = PortalUtil.getPlidFromFriendlyURL(
-					companyId, friendlyURL);
+			sb.append(_PUBLIC_GROUP_SERVLET_MAPPING);
+		}
+		else {
+			long plid = PortalUtil.getPlidFromFriendlyURL(
+				companyId, friendlyURL);
 
-				if (friendlyURL.equals(StringPool.SLASH) || (plid <= 0)) {
-					Group layoutSetGroup = layoutSet.getGroup();
+			if (friendlyURL.equals(StringPool.SLASH) || (plid <= 0)) {
+				Group layoutSetGroup = layoutSet.getGroup();
 
-					if (isDocumentFriendlyURL(
-							httpServletRequest, httpServletResponse,
-							layoutSetGroup.getGroupId(), friendlyURL)) {
+				if (isDocumentFriendlyURL(
+						httpServletRequest, httpServletResponse,
+						layoutSetGroup.getGroupId(), friendlyURL)) {
 
-						processFilter(
-							VirtualHostFilter.class.getName(),
-							httpServletRequest, httpServletResponse,
-							filterChain);
+					processFilter(
+						VirtualHostFilter.class.getName(), httpServletRequest,
+						httpServletResponse, filterChain);
 
-						return;
+					return;
+				}
+
+				if (Objects.equals(
+						layoutSetGroup.getGroupKey(),
+						PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME) &&
+					friendlyURL.equals(StringPool.SLASH) &&
+					!layoutSet.isPrivateLayout()) {
+
+					String homeURL = PortalUtil.getRelativeHomeURL(
+						httpServletRequest);
+
+					if (Validator.isNotNull(homeURL)) {
+						friendlyURL = homeURL;
 					}
 
-					if (Objects.equals(
-							layoutSetGroup.getGroupKey(),
-							PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME) &&
-						friendlyURL.equals(StringPool.SLASH) &&
-						!layoutSet.isPrivateLayout()) {
-
-						String homeURL = PortalUtil.getRelativeHomeURL(
-							httpServletRequest);
-
-						if (Validator.isNotNull(homeURL)) {
-							friendlyURL = homeURL;
-						}
-
-						if (friendlyURL.equals(StringPool.SLASH)) {
-							if (layoutSet.isPrivateLayout()) {
-								if (layoutSetGroup.isUser()) {
-									sb.append(_PRIVATE_USER_SERVLET_MAPPING);
-								}
-								else {
-									sb.append(_PRIVATE_GROUP_SERVLET_MAPPING);
-								}
-							}
-							else {
-								sb.append(_PUBLIC_GROUP_SERVLET_MAPPING);
-							}
-
-							sb.append(layoutSetGroup.getFriendlyURL());
-						}
-					}
-					else {
+					if (friendlyURL.equals(StringPool.SLASH)) {
 						if (layoutSet.isPrivateLayout()) {
 							if (layoutSetGroup.isUser()) {
 								sb.append(_PRIVATE_USER_SERVLET_MAPPING);
@@ -453,32 +432,40 @@ public class VirtualHostFilter extends BasePortalFilter {
 						sb.append(layoutSetGroup.getFriendlyURL());
 					}
 				}
+				else {
+					if (layoutSet.isPrivateLayout()) {
+						if (layoutSetGroup.isUser()) {
+							sb.append(_PRIVATE_USER_SERVLET_MAPPING);
+						}
+						else {
+							sb.append(_PRIVATE_GROUP_SERVLET_MAPPING);
+						}
+					}
+					else {
+						sb.append(_PUBLIC_GROUP_SERVLET_MAPPING);
+					}
+
+					sb.append(layoutSetGroup.getFriendlyURL());
+				}
 			}
-
-			String forwardURLString = friendlyURL;
-
-			if (sb.index() > 0) {
-				sb.append(friendlyURL);
-
-				forwardURLString = sb.toString();
-			}
-
-			if (_log.isDebugEnabled()) {
-				_log.debug("Forward to " + forwardURLString);
-			}
-
-			RequestDispatcher requestDispatcher =
-				_servletContext.getRequestDispatcher(forwardURLString);
-
-			requestDispatcher.forward(httpServletRequest, httpServletResponse);
 		}
-		catch (Exception exception) {
-			_log.error(exception);
 
-			processFilter(
-				VirtualHostFilter.class.getName(), httpServletRequest,
-				httpServletResponse, filterChain);
+		String forwardURLString = friendlyURL;
+
+		if (sb.index() > 0) {
+			sb.append(friendlyURL);
+
+			forwardURLString = sb.toString();
 		}
+
+		if (_log.isDebugEnabled()) {
+			_log.debug("Forward to " + forwardURLString);
+		}
+
+		RequestDispatcher requestDispatcher =
+			_servletContext.getRequestDispatcher(forwardURLString);
+
+		requestDispatcher.forward(httpServletRequest, httpServletResponse);
 	}
 
 	private String _findLanguageId(String friendlyURL) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97404

## What Is Being Fixed

VirtualHostFilter resolves a virtual host friendly URL to a layout and forwards the request to the
layout's URL. Part of that processing was wrapped in a `try/catch` that swallowed any exception by
logging it and continuing the filter chain with the unchanged request URI, which no servlet serves.
Any failure in that block therefore surfaced as a 404. Most visibly, when the database was
unavailable, the persistence layer threw a `SystemException` and an existing page returned a 404
instead of a 5xx.

On master the bug is masked by `PortalInstancesFilter`, which runs earlier: during a database outage
it typically fails first with a 500, so the `VirtualHostFilter` 404 is never observed. Removing the
`PortalInstancesFilter` mapping is therefore included in the steps to reproduce, so this issue can be
reliably observed.

## How It Is Being Fixed

Remove the `try/catch` so exceptions propagate, which is what the filter's other forward paths already
do. Because `processFilter` already declares `throws Exception` and LPD-96483 made `BaseFilter`
propagate those exceptions, the failure now reaches the container and surfaces as a 5xx rather than a
misleading 404. Other outcomes are unaffected, because they are produced downstream of this filter
rather than by the removed catch: a missing page still returns a 404, and restricted access is still
handled as before. The added test injects a `RequestDispatcher` whose `forward` throws a
`SystemException` and asserts it propagates instead of being swallowed.

## PR Check

**pr-check: PASS** — tested on `db27d821c36d0f17ef369afca227fc719914c836`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "db27d821c36d0f17ef369afca227fc719914c836"} -->
