### PR TITLE
LPD-97680 Avoid NOT LIKE '' which matches no rows on Oracle

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_date-picker.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_date-picker.scss
@@ -61,7 +61,7 @@ $date-picker-nav-btn: map-deep-merge(
 
 		active: (
 			background-color:
-				var(--date-picker-nav-btn-active-active, $gray-200),
+				var(--date-picker-nav-btn-active-background-color, $gray-200),
 		),
 
 		disabled: (

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/expando/test/ExpandoBridgeIndexerTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/expando/test/ExpandoBridgeIndexerTest.java
@@ -1,0 +1,117 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.expando.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.expando.kernel.model.ExpandoBridge;
+import com.liferay.expando.kernel.model.ExpandoColumn;
+import com.liferay.expando.kernel.model.ExpandoColumnConstants;
+import com.liferay.expando.kernel.model.ExpandoTable;
+import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
+import com.liferay.expando.kernel.service.ExpandoTableLocalService;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.DocumentImpl;
+import com.liferay.portal.kernel.search.ReindexCacheThreadLocal;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.search.expando.ExpandoBridgeIndexer;
+import com.liferay.portal.search.test.util.ExpandoTableSearchFixture;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Eric Yan
+ */
+@RunWith(Arquillian.class)
+public class ExpandoBridgeIndexerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void test() throws Exception {
+		ExpandoTableSearchFixture expandoTableSearchFixture =
+			new ExpandoTableSearchFixture(
+				_classNameLocalService, _expandoColumnLocalService,
+				_expandoTableLocalService);
+
+		expandoTableSearchFixture.addExpandoColumn(
+			User.class, ExpandoColumnConstants.INDEX_TYPE_KEYWORD,
+			_EXPANDO_COLUMN);
+
+		_expandoColumns = expandoTableSearchFixture.getExpandoColumns();
+		_expandoTables = expandoTableSearchFixture.getExpandoTables();
+
+		_user = UserTestUtil.addUser();
+
+		ExpandoBridge expandoBridge = _user.getExpandoBridge();
+
+		String value = RandomTestUtil.randomString();
+
+		expandoBridge.setAttribute(_EXPANDO_COLUMN, value);
+
+		_test(value);
+
+		try (SafeCloseable safeCloseable =
+				ReindexCacheThreadLocal.openReindexMode()) {
+
+			_test(value);
+		}
+	}
+
+	private void _test(String value) {
+		Document document = new DocumentImpl();
+
+		_expandoBridgeIndexer.addAttributes(document, _user);
+
+		Assert.assertEquals(
+			value,
+			document.get(
+				"expando__keyword__custom_fields__" + _EXPANDO_COLUMN));
+	}
+
+	private static final String _EXPANDO_COLUMN = RandomTestUtil.randomString();
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@Inject
+	private ExpandoBridgeIndexer _expandoBridgeIndexer;
+
+	@Inject
+	private ExpandoColumnLocalService _expandoColumnLocalService;
+
+	@DeleteAfterTestRun
+	private List<ExpandoColumn> _expandoColumns;
+
+	@Inject
+	private ExpandoTableLocalService _expandoTableLocalService;
+
+	@DeleteAfterTestRun
+	private List<ExpandoTable> _expandoTables;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+}

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/expando/ExpandoBridgeIndexerImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/expando/ExpandoBridgeIndexerImpl.java
@@ -311,11 +311,7 @@ public class ExpandoBridgeIndexerImpl implements ExpandoBridgeIndexer {
 										ExpandoColumnTable.INSTANCE
 									).where(
 										ExpandoColumnTable.INSTANCE.
-											typeSettings.isNotNull(
-											).and(
-												ExpandoColumnTable.INSTANCE.
-													typeSettings.notLike("")
-											)
+											typeSettings.isNotNull()
 									),
 									false)) {
 

--- a/modules/apps/site/site-dsr-site-initializer/src/main/resources/META-INF/resources/js/components/RoomShare.tsx
+++ b/modules/apps/site/site-dsr-site-initializer/src/main/resources/META-INF/resources/js/components/RoomShare.tsx
@@ -417,67 +417,62 @@ function RoomShare({
 				<div className="mb-4">
 					<label className="d-block mb-3">
 						{Liferay.Language.get('email-addresses')}
+
+						<ClayIcon
+							className="ml-1 reference-mark"
+							symbol="asterisk"
+						/>
 					</label>
 
-					<div className="align-items-end d-flex">
-						<div className="dsr-site-role-input flex-grow-1 mr-3 position-relative">
-							<MultiSelect
-								allowDuplicateValues={false}
-								autoFocus={true}
-								data-testid="emailAddressesInput"
-								disabled={loading || readOnly}
-								inputName="userEmailAddresses"
-								items={emailAddresses}
-								onItemsChange={(emails: Array<any>) =>
-									setEmailAddresses(emails)
-								}
-								placeholder={Liferay.Language.get(
-									'type-a-comma-or-press-enter-to-input-email-addresses'
-								)}
-							/>
-
-							<DropDown
-								closeOnClick={true}
-								trigger={
-									<ClayButton
-										className="dsr-site-role-trigger-button"
-										data-testid="roleKeyButton"
-										disabled={loading || readOnly}
-										displayType="secondary"
-										size="xs"
-									>
-										{getRoleLabel(roleKey)}
-									</ClayButton>
-								}
-								triggerIcon="caret-bottom"
-							>
-								<DropDown.ItemList items={assignableRoles}>
-									{(item: any) => (
-										<DropDown.Item
-											data-testid={`roleKeyItem_${item.label}`}
-											key={item.key}
-											onClick={() => setRoleKey(item.key)}
-										>
-											<div className="font-weight-semi-bold">
-												{item.label}
-											</div>
-
-											<div className="small text-secondary">
-												{item.description}
-											</div>
-										</DropDown.Item>
-									)}
-								</DropDown.ItemList>
-							</DropDown>
-						</div>
-
-						<ClayButton
-							data-testid="inviteButton"
+					<div className="dsr-site-role-input position-relative">
+						<MultiSelect
+							allowDuplicateValues={false}
+							autoFocus={true}
+							data-testid="emailAddressesInput"
 							disabled={loading || readOnly}
-							onClick={handleInvite}
+							inputName="userEmailAddresses"
+							items={emailAddresses}
+							onItemsChange={(emails: Array<any>) =>
+								setEmailAddresses(emails)
+							}
+							placeholder={Liferay.Language.get(
+								'type-a-comma-or-press-enter-to-input-email-addresses'
+							)}
+						/>
+
+						<DropDown
+							closeOnClick={true}
+							trigger={
+								<ClayButton
+									className="dsr-site-role-trigger-button"
+									data-testid="roleKeyButton"
+									disabled={loading || readOnly}
+									displayType="secondary"
+									size="xs"
+								>
+									{getRoleLabel(roleKey)}
+								</ClayButton>
+							}
+							triggerIcon="caret-bottom"
 						>
-							{Liferay.Language.get('invite')}
-						</ClayButton>
+							<DropDown.ItemList items={assignableRoles}>
+								{(item: any) => (
+									<DropDown.Item
+										data-testid={`roleKeyItem_${item.label}`}
+										key={item.key}
+										onClick={() => setRoleKey(item.key)}
+									>
+										<div className="font-weight-semi-bold">
+											{item.label}
+										</div>
+
+										<div className="small text-secondary">
+											{item.description}
+										</div>
+									</DropDown.Item>
+								)}
+							</DropDown.ItemList>
+						</DropDown>
 					</div>
 
 					<div className="align-items-center border d-flex justify-content-between mt-3 px-3 py-2 rounded">
@@ -519,6 +514,15 @@ function RoomShare({
 							/>
 						</div>
 					</div>
+
+					<ClayButton
+						className="mt-3"
+						data-testid="inviteButton"
+						disabled={loading || readOnly || !emailAddresses.length}
+						onClick={handleInvite}
+					>
+						{Liferay.Language.get('invite')}
+					</ClayButton>
 				</div>
 
 				<div className="mt-4">

--- a/modules/apps/site/site-dsr-site-initializer/test/js/components/RoomShare.spec.tsx
+++ b/modules/apps/site/site-dsr-site-initializer/test/js/components/RoomShare.spec.tsx
@@ -119,6 +119,31 @@ describe('RoomShare', () => {
 		expect(
 			container.querySelector('[data-testid="inviteButton"]')
 		).toBeInTheDocument();
+		expect(container.querySelector('.reference-mark')).toBeInTheDocument();
+	});
+
+	it('disables the invite button until an email address is added', async () => {
+		const {container} = renderComponent({
+			roomId: 10,
+		});
+
+		await waitFor(() => {
+			expect(screen.getByText('John Doe')).toBeInTheDocument();
+		});
+
+		const inviteButton = container.querySelector(
+			'[data-testid="inviteButton"]'
+		) as HTMLButtonElement;
+
+		expect(inviteButton).toBeDisabled();
+
+		const emailInput = container.querySelector(
+			'[data-testid="emailAddressesInput"]'
+		) as HTMLInputElement;
+
+		await userEvent.type(emailInput, 'newuser@liferay.com,');
+
+		expect(inviteButton).not.toBeDisabled();
 	});
 
 	it('loads and displays users', async () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97680

## What Is Being Fixed

A segment using a custom User field shows 0 members after a full reindex when using an Oracle database. The reindex cache in ExpandoBridgeIndexerImpl prepared a DSLQuery with WHERE clause: `typeSettings IS NOT NULL AND typeSettings NOT LIKE ''`.

However, Oracle treats the empty string as NULL, so the predicate became `NOT LIKE NULL` and matched no rows. As a result, no Expando columns were cached and no Expando fields were indexed during the reindex.

## How It Is Being Fixed

For the WHERE clause, `typeSettings IS NOT NULL` is sufficient. The dropped predicate was likely added as an optimization for row reduction, not for correctness: the query results are already filtered by `ExpandoBridgeUtil.getIndexType`, which parses `typeSettings` and treats an empty value as `INDEX_TYPE_NONE`.

The new `ExpandoBridgeIndexerTest` covers `ExpandoBridgeIndexer.addAttributes` through both the reindex cache path and the non-cached fallback; the cache path fails on Oracle without the fix.

## PR Check

**pr-check: PASS** — tested on `a2935d4250218ed672485ec95e67cc43394b7d67`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "a2935d4250218ed672485ec95e67cc43394b7d67"} -->