### PR TITLE
LPD-97436 Escape input move boxes labels to prevent script errors

### DIFF
--- a/modules/test/playwright/tests/asset-publisher-web/main/assetPublisherConfiguration.spec.ts
+++ b/modules/test/playwright/tests/asset-publisher-web/main/assetPublisherConfiguration.spec.ts
@@ -14,6 +14,7 @@ import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
 import {pageViewModePagesTest} from '../../../fixtures/pageViewModePagesTest';
+import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../../utils/getRandomString';
 import getPageDefinition from '../../layout-content-page-editor-web/main/utils/getPageDefinition';
 import getWidgetDefinition from '../../layout-content-page-editor-web/main/utils/getWidgetDefinition';
@@ -244,5 +245,50 @@ test(
 			['assetEntryId', 'tags', 'tag'],
 			true
 		);
+	}
+);
+
+test(
+	'Metadata move boxes render when configuring an Asset Publisher on a widget page in French',
+	{
+		tag: '@LPD-97436',
+	},
+	async ({assetPublisherPage, assetPublisherWidgetPage, page, site}) => {
+
+		// Add an Asset Publisher to a widget page
+
+		const layout =
+			await assetPublisherWidgetPage.addAssetPublisherPortlet(site);
+
+		// View the widget page in French
+
+		await page.goto(`/fr/web${site.friendlyUrlPath}${layout.friendlyURL}`);
+
+		// Open the widget configuration ("Facultatif" is French for "Options")
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: page.getByRole('menuitem', {
+				exact: true,
+				name: 'Configuration',
+			}),
+			trigger: page
+				.locator('.portlet-asset-publisher')
+				.getByLabel('Facultatif'),
+		});
+
+		// Open the Display Settings panel ("Paramètres d'affichage" in French)
+
+		await assetPublisherPage.configurationIframe
+			.getByRole('tab', {name: "Paramètres d'affichage"})
+			.click();
+
+		// Assert a move button rendered in the metadata section
+
+		await expect(
+			assetPublisherPage.configurationIframe
+				.locator('[id$="metadata"]')
+				.getByTestId('ltr')
+		).toBeVisible();
 	}
 );

--- a/portal-web/docroot/html/taglib/ui/input_move_boxes/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_move_boxes/page.jsp
@@ -85,44 +85,51 @@ Map<String, Object> data = new HashMap<String, Object>();
 	function main({initialItems}) {
 		const [items, setItems] = React.useState(initialItems);
 
-		return React.createElement(
-			ClayDualListBox,
-			{
-				ariaLabels: {
-					transferRTL: '<%= LanguageUtil.format(request, "move-selected-items-from-x-to-x", new Object[] {rightTitle, leftTitle}, false) %>',
-					transferLTR: '<%= LanguageUtil.format(request, "move-selected-items-from-x-to-x", new Object[] {leftTitle, rightTitle}, false) %>'
-				},
-				items: items,
-				left: {
-					id: '<portlet:namespace /><%= leftBoxName %>',
-					label: '<%= leftTitle %>'
-				},
-				leftMaxItems: <%= leftBoxMaxItems %>,
-				onItemsChange: (newItems) => {
-					const initialLeftItemsLength = items[0].length;
-					const newLeftItemsLength = newItems[0].length;
+		return React.createElement(ClayDualListBox, {
+			ariaLabels: {
+				transferRTL:
+					'<%= HtmlUtil.escapeJS(LanguageUtil.format(request, "move-selected-items-from-x-to-x", new Object[] {rightTitle, leftTitle}, false)) %>',
+				transferLTR:
+					'<%= HtmlUtil.escapeJS(LanguageUtil.format(request, "move-selected-items-from-x-to-x", new Object[] {leftTitle, rightTitle}, false)) %>',
+			},
+			items: items,
+			left: {
+				id: '<portlet:namespace /><%= leftBoxName %>',
+				label: '<%= HtmlUtil.escapeJS(leftTitle) %>',
+			},
+			leftMaxItems: <%= leftBoxMaxItems %>,
+			onItemsChange: (newItems) => {
+				const initialLeftItemsLength = items[0].length;
+				const newLeftItemsLength = newItems[0].length;
 
-					let fromBox = document.getElementById('<portlet:namespace /><%= leftBoxName %>');
-					let toBox = document.getElementById('<portlet:namespace /><%= rightBoxName %>');
+				let fromBox = document.getElementById(
+					'<portlet:namespace /><%= leftBoxName %>'
+				);
+				let toBox = document.getElementById(
+					'<portlet:namespace /><%= rightBoxName %>'
+				);
 
-					if (initialLeftItemsLength > newLeftItemsLength) {
-						fromBox = document.getElementById('<portlet:namespace /><%= rightBoxName %>');
-						toBox = document.getElementById('<portlet:namespace /><%= leftBoxName %>');
-					}
+				if (initialLeftItemsLength > newLeftItemsLength) {
+					fromBox = document.getElementById(
+						'<portlet:namespace /><%= rightBoxName %>'
+					);
+					toBox = document.getElementById(
+						'<portlet:namespace /><%= leftBoxName %>'
+					);
+				}
 
-					setItems(newItems);
+				setItems(newItems);
 
-					Liferay.fire('inputmoveboxes:moveItem', {fromBox, toBox});
-					Liferay.fire('inputmoveboxes:orderItem');
-				},
-				right: {
-					id: '<portlet:namespace /><%= rightBoxName %>',
-					label: '<%= rightTitle %>'
-				},
-				rightMaxItems: <%= rightBoxMaxItems %>,
-				size: 10,
-			}
-		);
+				Liferay.fire('inputmoveboxes:moveItem', {fromBox, toBox});
+				Liferay.fire('inputmoveboxes:orderItem');
+			},
+			right: {
+				id: '<portlet:namespace /><%= rightBoxName %>',
+				label: '<%= HtmlUtil.escapeJS(rightTitle) %>',
+			},
+			rightMaxItems: <%= rightBoxMaxItems %>,
+			size: 10,
+		});
 	}
 
 	render(
@@ -130,6 +137,7 @@ Map<String, Object> data = new HashMap<String, Object>();
 		{
 			initialItems: [
 				[
+
 					<%
 					for (int i = 0; i < leftList.size(); i++) {
 						KeyValuePair kvp = (KeyValuePair)leftList.get(i);
@@ -137,14 +145,16 @@ Map<String, Object> data = new HashMap<String, Object>();
 
 						{
 							label: '<%= HtmlUtil.escapeJS(kvp.getValue()) %>',
-							value: '<%= HtmlUtil.escapeJS(kvp.getKey()) %>'
+							value: '<%= HtmlUtil.escapeJS(kvp.getKey()) %>',
 						},
+
 					<%
 					}
 					%>
 
 				],
 				[
+
 					<%
 					for (int i = 0; i < rightList.size(); i++) {
 						KeyValuePair kvp = (KeyValuePair)rightList.get(i);
@@ -152,14 +162,15 @@ Map<String, Object> data = new HashMap<String, Object>();
 
 						{
 							label: '<%= HtmlUtil.escapeJS(kvp.getValue()) %>',
-							value: '<%= HtmlUtil.escapeJS(kvp.getKey()) %>'
+							value: '<%= HtmlUtil.escapeJS(kvp.getKey()) %>',
 						},
+
 					<%
 					}
 					%>
 
-				]
-			]
+				],
+			],
 		},
 		document.querySelector('#<%= randomNamespace %>input-move-boxes')
 	);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97436

## What Is Being Fixed

When the UI renders in a locale whose translation contains an apostrophe (for example French, where "In Use" is "En cours d'utilisation"), the dual list box rendered by liferay-ui:input-move-boxes -- such as the Asset Publisher's Display Settings > Metadata -- failed to render its move buttons and logged a JavaScript error. The arrow buttons that move items between the "Available" and "In Use" lists were missing, so the configuration could not be completed. It surfaced in the widget-page portlet configuration pop-up.

## How It Is Being Fixed

The taglib interpolated the localized titles and aria-labels straight into single-quoted JavaScript string literals in the inline ClayDualListBox script, without escaping them. An apostrophe in the value closed the string early and produced a syntax error that aborted the module, so ClayDualListBox never mounted. The fix wraps those values in HtmlUtil.escapeJS -- matching how the item labels a few lines below are already handled -- so the emitted script is valid in every locale.

## How Can You Verify That It Works?

1. Enable the "Asset Selection for Asset Publisher" deprecation flag (LPD-39304).
2. Create a widget page and add an Asset Publisher.
3. Switch the display language to French.
4. Open the Asset Publisher's Configuration and go to Display Settings.
5. Confirm there are no console errors and the arrow buttons between the Available and In Use lists render, so metadata fields can be moved between them.

The added Playwright test (assetPublisherConfiguration.spec.ts) automates this: it configures an Asset Publisher on a widget page in French and asserts the metadata dual list box move button renders.

## PR Check

**pr-check: PASS** -- tested on `c77b6cc7402fc1a944d81da7b427d28d5180a9ce`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| JSP Compile | PASS |

<!-- pr-check {"result": "success", "sha": "c77b6cc7402fc1a944d81da7b427d28d5180a9ce"} -->

