### PR TITLE
LPD-97153 Prevent license registration failure on an empty server ID

### DIFF
--- a/portal-impl/src/com/liferay/portal/license/util/DefaultLicenseManagerImpl.java
+++ b/portal-impl/src/com/liferay/portal/license/util/DefaultLicenseManagerImpl.java
@@ -163,7 +163,7 @@ public class DefaultLicenseManagerImpl implements LicenseManager {
 	public void registerLicense(JSONObject jsonObject) throws Exception {
 		String serverId = jsonObject.getString("serverId");
 
-		if (Validator.isNotNull(serverId) && (serverId.length() <= 2)) {
+		if (Validator.isNull(serverId) || (serverId.length() <= 2)) {
 			return;
 		}
 

--- a/portal-impl/test/unit/com/liferay/portal/license/util/DefaultLicenseManagerImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/license/util/DefaultLicenseManagerImplTest.java
@@ -1,0 +1,54 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.license.util;
+
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.util.LicenseUtil;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Victor Kammerer
+ */
+public class DefaultLicenseManagerImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testRegisterLicense() throws Exception {
+		try (MockedStatic<LicenseUtil> licenseUtilMockedStatic =
+				Mockito.mockStatic(LicenseUtil.class)) {
+
+			_defaultLicenseManagerImpl.registerLicense(
+				JSONUtil.put("licenseXML", "<license />"));
+			_defaultLicenseManagerImpl.registerLicense(
+				JSONUtil.put("serverId", "[]"));
+
+			licenseUtilMockedStatic.verify(
+				() -> LicenseUtil.writeServerProperties(Mockito.any()),
+				Mockito.never());
+
+			_defaultLicenseManagerImpl.registerLicense(
+				JSONUtil.put("serverId", "[1, 2, 3]"));
+
+			licenseUtilMockedStatic.verify(
+				() -> LicenseUtil.writeServerProperties(Mockito.any()));
+		}
+	}
+
+	private final DefaultLicenseManagerImpl _defaultLicenseManagerImpl =
+		new DefaultLicenseManagerImpl();
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97153

## What Is Being Fixed

CMP license activation failed inconsistently across internal build images with a StringIndexOutOfBoundsException. When the registration payload carried a null or empty server ID, DefaultLicenseManagerImpl.registerLicense still tried to strip the surrounding brackets with serverId.substring(1, serverId.length() - 1), which throws for a value shorter than the two bracket characters.

## How It Is Being Fixed

The early-return guard in registerLicense was inverted. It previously returned only when the server ID was non-null and short (Validator.isNotNull(serverId) && serverId.length() <= 2), letting a null or empty server ID fall through to the substring call. The guard now returns when the server ID is null or too short (Validator.isNull(serverId) || serverId.length() <= 2), so registration is skipped safely instead of failing. A unit test covers the empty-brackets and populated server ID cases.

## PR Check

**pr-check: PASS** — tested on `c0c7d0f953dab6508783116849974d6bbdd23c07`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c0c7d0f953dab6508783116849974d6bbdd23c07"} -->
