### PR TITLE
LPD-98149 Use property type not column type_ in User finders

### DIFF
--- a/portal-impl/src/com/liferay/portal/service.xml
+++ b/portal-impl/src/com/liferay/portal/service.xml
@@ -2587,7 +2587,7 @@
 
 		<!-- Finder methods -->
 
-		<finder name="CompanyId" return-type="Collection" where="type_ = 1">
+		<finder name="CompanyId" return-type="Collection" where="type = 1">
 			<finder-column name="companyId" />
 		</finder>
 		<finder name="ContactId" return-type="User" unique="true">
@@ -2599,7 +2599,7 @@
 		<finder name="PortraitId" return-type="Collection">
 			<finder-column name="portraitId" />
 		</finder>
-		<finder db-index="false" name="GtU_C" return-type="Collection" where="type_ = 1">
+		<finder db-index="false" name="GtU_C" return-type="Collection" where="type = 1">
 			<finder-column comparator="&gt;" name="userId" />
 			<finder-column name="companyId" />
 		</finder>
@@ -2607,11 +2607,11 @@
 			<finder-column name="companyId" />
 			<finder-column name="userId" />
 		</finder>
-		<finder name="C_CD" return-type="Collection" where="type_ = 1">
+		<finder name="C_CD" return-type="Collection" where="type = 1">
 			<finder-column name="companyId" />
 			<finder-column name="createDate" />
 		</finder>
-		<finder name="C_MD" return-type="Collection" where="type_ = 1">
+		<finder name="C_MD" return-type="Collection" where="type = 1">
 			<finder-column name="companyId" />
 			<finder-column name="modifiedDate" />
 		</finder>
@@ -2631,11 +2631,11 @@
 			<finder-column name="companyId" />
 			<finder-column name="type" />
 		</finder>
-		<finder name="C_S" return-type="Collection" where="type_ = 1">
+		<finder name="C_S" return-type="Collection" where="type = 1">
 			<finder-column name="companyId" />
 			<finder-column name="status" />
 		</finder>
-		<finder name="C_CD_MD" return-type="Collection" where="type_ = 1">
+		<finder name="C_CD_MD" return-type="Collection" where="type = 1">
 			<finder-column name="companyId" />
 			<finder-column name="createDate" />
 			<finder-column name="modifiedDate" />

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserPersistenceImpl.java
@@ -3782,8 +3782,8 @@ public class UserPersistenceImpl
 					"countByCompanyId", new String[] {Long.class.getName()},
 					new String[] {"companyId"}, false),
 				_SQL_SELECT_USER_WHERE, _SQL_COUNT_USER_WHERE,
-				UserModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "type_ = 1",
-				"type_ = 1", null,
+				UserModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
+				"user.type = 1", "user.type_ = 1", null,
 				new FinderColumn<>(
 					"user.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, User::getCompanyId));
@@ -3867,8 +3867,8 @@ public class UserPersistenceImpl
 				new String[] {Long.class.getName(), Long.class.getName()},
 				new String[] {"userId", "companyId"}, false),
 			_SQL_SELECT_USER_WHERE, _SQL_COUNT_USER_WHERE,
-			UserModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "type_ = 1",
-			"type_ = 1", null,
+			UserModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "user.type = 1",
+			"user.type_ = 1", null,
 			new FinderColumn<>(
 				"user.", "userId", FinderColumn.Type.LONG, ">", true, true,
 				User::getUserId),
@@ -3910,8 +3910,8 @@ public class UserPersistenceImpl
 				new String[] {Long.class.getName(), Date.class.getName()},
 				new String[] {"companyId", "createDate"}, false),
 			_SQL_SELECT_USER_WHERE, _SQL_COUNT_USER_WHERE,
-			UserModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "type_ = 1",
-			"type_ = 1", null,
+			UserModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "user.type = 1",
+			"user.type_ = 1", null,
 			new FinderColumn<>(
 				"user.", "companyId", FinderColumn.Type.LONG, "=", true, true,
 				User::getCompanyId),
@@ -3938,8 +3938,8 @@ public class UserPersistenceImpl
 				new String[] {Long.class.getName(), Date.class.getName()},
 				new String[] {"companyId", "modifiedDate"}, false),
 			_SQL_SELECT_USER_WHERE, _SQL_COUNT_USER_WHERE,
-			UserModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "type_ = 1",
-			"type_ = 1", null,
+			UserModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "user.type = 1",
+			"user.type_ = 1", null,
 			new FinderColumn<>(
 				"user.", "companyId", FinderColumn.Type.LONG, "=", true, true,
 				User::getCompanyId),
@@ -4050,8 +4050,8 @@ public class UserPersistenceImpl
 				new String[] {Long.class.getName(), Integer.class.getName()},
 				new String[] {"companyId", "status"}, false),
 			_SQL_SELECT_USER_WHERE, _SQL_COUNT_USER_WHERE,
-			UserModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "type_ = 1",
-			"type_ = 1", null,
+			UserModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "user.type = 1",
+			"user.type_ = 1", null,
 			new FinderColumn<>(
 				"user.", "companyId", FinderColumn.Type.LONG, "=", true, true,
 				User::getCompanyId),
@@ -4089,8 +4089,8 @@ public class UserPersistenceImpl
 					new String[] {"companyId", "createDate", "modifiedDate"},
 					false),
 				_SQL_SELECT_USER_WHERE, _SQL_COUNT_USER_WHERE,
-				UserModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "type_ = 1",
-				"type_ = 1", null,
+				UserModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
+				"user.type = 1", "user.type_ = 1", null,
 				new FinderColumn<>(
 					"user.", "companyId", FinderColumn.Type.LONG, "=", true,
 					true, User::getCompanyId),
@@ -4218,4 +4218,4 @@ public class UserPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:228390115
+// LIFERAY-SERVICE-BUILDER-HASH:288719783


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98149

## What Is Being Fixed

The User entity finders CompanyId, GtU_C, C_CD, C_MD, C_S, and C_CD_MD declared where="type_ = 1" using the database column name instead of the entity property name type. Service Builder only rewrites recognized property names in a finder where clause, so the raw column name passed straight into the generated HQL. Hibernate 5 tolerated the unmapped path, but Hibernate 7's semantic query parser rejects it with SemanticException: Could not interpret path expression 'type_', so every User finder carrying this filter fails once the portal runs on Hibernate 7. Because it is an HQL parse error rather than a dialect issue, it reproduces on every database.

## How It Is Being Fixed

The first commit changes the six User finder where clauses to where="type = 1" (the property name), matching how the Layout entity uses where="system = [$FALSE$]". The second commit regenerates the portal services; only UserPersistenceImpl changes, and Service Builder now emits HQL user.type = 1 for the finder while keeping native SQL user.type_ = 1.

## Why Are There No Tests?

The fix corrects a Service Builder input and its generated output; the behavior is already covered by existing integration tests (UserLocalServiceTest, CompanyLocalServiceTest, RoleLocalServiceSystemRolesTest, UserModelPreFilterContributorTest) that fail on Hibernate 7 before this change and pass after it. A configuration-and-regeneration fix with no new logic warrants no additional test.

## PR Check

**pr-check: PASS** — tested on `3beb6e47ec138cdc3202ec423237a41ef108e2f3`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "3beb6e47ec138cdc3202ec423237a41ef108e2f3"} -->

