### PR TITLE
LPD-98055 Keep page path in canonical URL for non-ASCII friendly URLs

### DIFF
--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplCanonicalURLTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplCanonicalURLTest.java
@@ -180,6 +180,14 @@ public class PortalImplCanonicalURLTest {
 			HashMapBuilder.put(
 				LocaleUtil.US, "/test-page"
 			).build());
+		_layout6 = LayoutTestUtil.addTypePortletLayout(
+			_group.getGroupId(), false,
+			HashMapBuilder.put(
+				LocaleUtil.US, "Pöge"
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.US, "/pöge"
+			).build());
 
 		String groupKey = PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME;
 
@@ -236,6 +244,24 @@ public class PortalImplCanonicalURLTest {
 					_group.getFriendlyURL(), "/test%20page", false),
 				_createThemeDisplay(portalDomain, _defaultGroup, 8080, false),
 				_layout5, false, false));
+	}
+
+	@Test
+	public void testCanonicalURLLayoutFriendlyURLWithSpecialCharacter()
+		throws Exception {
+
+		String portalDomain = "localhost";
+
+		Assert.assertEquals(
+			_generateURL(
+				portalDomain, "8080", StringPool.BLANK, _group.getFriendlyURL(),
+				"/p%C3%B6ge", false),
+			_portal.getCanonicalURL(
+				_generateURL(
+					portalDomain, "8080", StringPool.BLANK,
+					_group.getFriendlyURL(), "/p%C3%B6ge", false),
+				_createThemeDisplay(portalDomain, _defaultGroup, 8080, false),
+				_layout6, false, false));
 	}
 
 	@Test
@@ -811,6 +837,7 @@ public class PortalImplCanonicalURLTest {
 	private Layout _layout3;
 	private Layout _layout4;
 	private Layout _layout5;
+	private Layout _layout6;
 
 	@Inject
 	private LayoutLocalService _layoutLocalService;

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplCanonicalURLTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplCanonicalURLTest.java
@@ -16,10 +16,12 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
+import com.liferay.portal.kernel.model.LayoutFriendlyURL;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolverRegistryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.LayoutFriendlyURLLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.VirtualHostLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
@@ -228,6 +230,33 @@ public class PortalImplCanonicalURLTest {
 			completeURL,
 			_portal.getCanonicalURL(
 				completeURL, themeDisplay, _layout2, false, false));
+	}
+
+	@Test
+	public void testCanonicalURLLayoutFriendlyURLNotStoredInCanonicalForm()
+		throws Exception {
+
+		LayoutFriendlyURL layoutFriendlyURL =
+			_layoutFriendlyURLLocalService.getLayoutFriendlyURL(
+				_layout6.getPlid(), LocaleUtil.toLanguageId(LocaleUtil.US));
+
+		layoutFriendlyURL.setFriendlyURL("/pöge");
+
+		_layoutFriendlyURLLocalService.updateLayoutFriendlyURL(
+			layoutFriendlyURL);
+
+		String portalDomain = "localhost";
+
+		Assert.assertEquals(
+			_generateURL(
+				portalDomain, "8080", StringPool.BLANK, _group.getFriendlyURL(),
+				"/p%C3%B6ge", false),
+			_portal.getCanonicalURL(
+				_generateURL(
+					portalDomain, "8080", StringPool.BLANK,
+					_group.getFriendlyURL(), "/p%C3%B6ge", false),
+				_createThemeDisplay(portalDomain, _defaultGroup, 8080, false),
+				_layout6, false, false));
 	}
 
 	@Test
@@ -838,6 +867,9 @@ public class PortalImplCanonicalURLTest {
 	private Layout _layout4;
 	private Layout _layout5;
 	private Layout _layout6;
+
+	@Inject
+	private LayoutFriendlyURLLocalService _layoutFriendlyURLLocalService;
 
 	@Inject
 	private LayoutLocalService _layoutLocalService;

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1571,7 +1571,7 @@ public class PortalImpl implements Portal {
 			 _requiresLayoutFriendlyURL(
 				 layoutGroup.getFriendlyURL(),
 				 themeDisplay.getLayoutFriendlyURL(layout),
-				 StringUtil.toLowerCase(groupFriendlyURL))) ||
+				 groupFriendlyURL)) ||
 			groupFriendlyURL.endsWith(
 				StringPool.SLASH + layout.getLayoutId())) {
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1569,9 +1569,8 @@ public class PortalImpl implements Portal {
 		if (forceLayoutFriendlyURL ||
 			((!layout.isFirstParent() || Validator.isNotNull(parametersURL)) &&
 			 _requiresLayoutFriendlyURL(
-				 layoutGroup.getFriendlyURL(),
-				 themeDisplay.getLayoutFriendlyURL(layout),
-				 groupFriendlyURL)) ||
+				 groupFriendlyURL, themeDisplay.getLayoutFriendlyURL(layout),
+				 layoutGroup.getFriendlyURL())) ||
 			groupFriendlyURL.endsWith(
 				StringPool.SLASH + layout.getLayoutId())) {
 
@@ -8172,14 +8171,14 @@ public class PortalImpl implements Portal {
 	}
 
 	private boolean _requiresLayoutFriendlyURL(
-		String siteGroupFriendlyURL, String layoutFriendlyURL,
-		String groupFriendlyURL) {
-
-		layoutFriendlyURL = FriendlyURLNormalizerUtil.normalizeWithEncoding(
-			layoutFriendlyURL);
+		String groupFriendlyURL, String layoutFriendlyURL,
+		String siteGroupFriendlyURL) {
 
 		groupFriendlyURL = FriendlyURLNormalizerUtil.normalizeWithEncoding(
 			groupFriendlyURL);
+
+		layoutFriendlyURL = FriendlyURLNormalizerUtil.normalizeWithEncoding(
+			layoutFriendlyURL);
 
 		if (groupFriendlyURL.contains(
 				_PUBLIC_GROUP_SERVLET_MAPPING + StringPool.SLASH)) {

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8175,6 +8175,9 @@ public class PortalImpl implements Portal {
 		String siteGroupFriendlyURL, String layoutFriendlyURL,
 		String groupFriendlyURL) {
 
+		layoutFriendlyURL = FriendlyURLNormalizerUtil.normalizeWithEncoding(
+			layoutFriendlyURL);
+
 		groupFriendlyURL = FriendlyURLNormalizerUtil.normalizeWithEncoding(
 			groupFriendlyURL);
 
@@ -8184,14 +8187,12 @@ public class PortalImpl implements Portal {
 			if (groupFriendlyURL.contains(
 					StringBundler.concat(
 						_PUBLIC_GROUP_SERVLET_MAPPING, siteGroupFriendlyURL,
-						StringUtil.toLowerCase(layoutFriendlyURL)))) {
+						layoutFriendlyURL))) {
 
 				return true;
 			}
 		}
-		else if (groupFriendlyURL.contains(
-					StringUtil.toLowerCase(layoutFriendlyURL))) {
-
+		else if (groupFriendlyURL.contains(layoutFriendlyURL)) {
 			return true;
 		}
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1564,6 +1564,10 @@ public class PortalImpl implements Portal {
 				getSiteDefaultLocale(layout.getGroupId()));
 		}
 
+		defaultLayoutFriendlyURL =
+			FriendlyURLNormalizerUtil.normalizeWithEncoding(
+				defaultLayoutFriendlyURL);
+
 		Group layoutGroup = layout.getGroup();
 
 		if (forceLayoutFriendlyURL ||


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98055

## What is this trying to solve?

A page whose friendly URL contains a non-ASCII character (for example `/pöge`) renders its canonical and hreflang alternate link tags without the page path — they all point to the site root. Pages with ASCII friendly URLs render correctly. Reported by a customer in [LPP-64772](https://liferay.atlassian.net/browse/LPP-64772).

## How am I fixing it?

`PortalImpl._requiresLayoutFriendlyURL` decides whether `getCanonicalURL` appends the layout's friendly URL. It normalizes the request-derived URL with `FriendlyURLNormalizerUtil.normalizeWithEncoding`, which percent-encodes non-ASCII characters with uppercase hex, while the layout friendly URL side of the comparison is only lowercased — so the `contains` check never matches and the page path is dropped. The fix normalizes both sides the same way, making the comparison consistent.

## How can you verify that it works?

Create a page named `pöge`, open it as a guest, and inspect the page source: the `rel="canonical"` and hreflang `rel="alternate"` link tags now include `/p%C3%B6ge`. Alternatively run `PortalImplCanonicalURLTest` — the new `testCanonicalURLLayoutFriendlyURLWithSpecialCharacter` fails before the fix and passes after; the full class (35 tests) passes.

## PR Check

**pr-check: PASS** — tested on `1a5fa84454d9d1cb2188d819fde5d7e1acd0265c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "1a5fa84454d9d1cb2188d819fde5d7e1acd0265c"} -->


[LPP-64772]: https://liferay.atlassian.net/browse/LPP-64772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ