### PR TITLE
LPD-95334 Prevent a failed cluster task from killing the worker

### DIFF
--- a/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/BaseClusterChannel.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/BaseClusterChannel.java
@@ -35,7 +35,7 @@ public abstract class BaseClusterChannel implements ClusterChannel {
 		}
 
 		try {
-			_executorService.execute(() -> doSendMessage(message, null));
+			_executorService.execute(() -> _doSendMessage(message, null));
 		}
 		catch (RejectedExecutionException rejectedExecutionException) {
 			_log.error(
@@ -55,7 +55,7 @@ public abstract class BaseClusterChannel implements ClusterChannel {
 		}
 
 		try {
-			_executorService.execute(() -> doSendMessage(message, address));
+			_executorService.execute(() -> _doSendMessage(message, address));
 		}
 		catch (RejectedExecutionException rejectedExecutionException) {
 			_log.error(
@@ -68,6 +68,17 @@ public abstract class BaseClusterChannel implements ClusterChannel {
 
 	protected abstract void doSendMessage(
 		Serializable message, Address address);
+
+	private void _doSendMessage(Serializable message, Address address) {
+		try {
+			doSendMessage(message, address);
+		}
+		catch (Throwable throwable) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to send message " + message, throwable);
+			}
+		}
+	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		BaseClusterChannel.class);

--- a/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/BaseClusterReceiver.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/BaseClusterReceiver.java
@@ -185,6 +185,17 @@ public abstract class BaseClusterReceiver implements ClusterReceiver {
 	protected abstract void doReceive(
 		Object messagePayload, Address srcAddress);
 
+	private void _run(Runnable runnable) {
+		try {
+			runnable.run();
+		}
+		catch (Throwable throwable) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to run cluster receiver task", throwable);
+			}
+		}
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		BaseClusterReceiver.class);
 
@@ -199,7 +210,7 @@ public abstract class BaseClusterReceiver implements ClusterReceiver {
 
 		@Override
 		public void run() {
-			doAddressesUpdated(_oldAddresses, _newAddresses);
+			_run(() -> doAddressesUpdated(_oldAddresses, _newAddresses));
 		}
 
 		private AddressesUpdatedRunnable(
@@ -218,8 +229,9 @@ public abstract class BaseClusterReceiver implements ClusterReceiver {
 
 		@Override
 		public void run() {
-			doCoordinatorAddressUpdated(
-				_oldCoordinatorAddress, _newCoordinatorAddress);
+			_run(
+				() -> doCoordinatorAddressUpdated(
+					_oldCoordinatorAddress, _newCoordinatorAddress));
 		}
 
 		private CoordinatorAddressUpdatedRunnable(
@@ -238,7 +250,7 @@ public abstract class BaseClusterReceiver implements ClusterReceiver {
 
 		@Override
 		public void run() {
-			doReceive(_messagePayload, _srcAddress);
+			_run(() -> doReceive(_messagePayload, _srcAddress));
 		}
 
 		private ReceiveRunnable(Object messagePayload, Address srcAddress) {

--- a/modules/apps/portal/portal-cluster-multiple/src/test/java/com/liferay/portal/cluster/multiple/internal/BaseClusterChannelTest.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/test/java/com/liferay/portal/cluster/multiple/internal/BaseClusterChannelTest.java
@@ -1,0 +1,131 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.cluster.multiple.internal;
+
+import com.liferay.portal.kernel.cluster.Address;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.io.Serializable;
+
+import java.net.InetAddress;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Debora Buriti
+ */
+public class BaseClusterChannelTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testSendMulticastMessageWhenDoSendMessageThrowsError()
+		throws Exception {
+
+		_assertSendFailureContained(new Error());
+	}
+
+	@Test
+	public void testSendMulticastMessageWhenDoSendMessageThrowsRuntimeException()
+		throws Exception {
+
+		_assertSendFailureContained(new RuntimeException());
+	}
+
+	private void _assertSendFailureContained(Throwable throwable)
+		throws Exception {
+
+		ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				BaseClusterChannel.class.getName(), LoggerTestUtil.WARN)) {
+
+			BaseClusterChannel baseClusterChannel = new TestBaseClusterChannel(
+				executorService, throwable);
+
+			baseClusterChannel.sendMulticastMessage("message");
+
+			executorService.shutdown();
+
+			Assert.assertTrue(
+				executorService.awaitTermination(1, TimeUnit.MINUTES));
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(LoggerTestUtil.WARN, logEntry.getPriority());
+			Assert.assertSame(throwable, logEntry.getThrowable());
+		}
+		finally {
+			executorService.shutdownNow();
+		}
+	}
+
+	private static class TestBaseClusterChannel extends BaseClusterChannel {
+
+		@Override
+		public void close() {
+		}
+
+		@Override
+		public InetAddress getBindInetAddress() {
+			return null;
+		}
+
+		@Override
+		public String getClusterName() {
+			return null;
+		}
+
+		@Override
+		public ClusterReceiver getClusterReceiver() {
+			return null;
+		}
+
+		@Override
+		public Address getLocalAddress() {
+			return null;
+		}
+
+		@Override
+		protected void doSendMessage(Serializable message, Address address) {
+			if (_throwable instanceof RuntimeException) {
+				throw (RuntimeException)_throwable;
+			}
+
+			throw (Error)_throwable;
+		}
+
+		private TestBaseClusterChannel(
+			ExecutorService executorService, Throwable throwable) {
+
+			super(executorService);
+
+			_throwable = throwable;
+		}
+
+		private final Throwable _throwable;
+
+	}
+
+}

--- a/modules/apps/portal/portal-cluster-multiple/src/test/java/com/liferay/portal/cluster/multiple/internal/BaseClusterReceiverTest.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/test/java/com/liferay/portal/cluster/multiple/internal/BaseClusterReceiverTest.java
@@ -1,0 +1,103 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.cluster.multiple.internal;
+
+import com.liferay.portal.kernel.cluster.Address;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Debora Buriti
+ */
+public class BaseClusterReceiverTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testReceiveWhenDoReceiveThrowsError() throws Exception {
+		_assertReceiveFailureContained(new Error());
+	}
+
+	@Test
+	public void testReceiveWhenDoReceiveThrowsRuntimeException()
+		throws Exception {
+
+		_assertReceiveFailureContained(new RuntimeException());
+	}
+
+	private void _assertReceiveFailureContained(Throwable throwable)
+		throws Exception {
+
+		ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				BaseClusterReceiver.class.getName(), LoggerTestUtil.WARN)) {
+
+			BaseClusterReceiver baseClusterReceiver =
+				new TestBaseClusterReceiver(executorService, throwable);
+
+			baseClusterReceiver.openLatch();
+
+			baseClusterReceiver.receive("message", null);
+
+			executorService.shutdown();
+
+			Assert.assertTrue(
+				executorService.awaitTermination(1, TimeUnit.MINUTES));
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(LoggerTestUtil.WARN, logEntry.getPriority());
+			Assert.assertSame(throwable, logEntry.getThrowable());
+		}
+		finally {
+			executorService.shutdownNow();
+		}
+	}
+
+	private static class TestBaseClusterReceiver extends BaseClusterReceiver {
+
+		@Override
+		protected void doReceive(Object messagePayload, Address srcAddress) {
+			if (_throwable instanceof RuntimeException) {
+				throw (RuntimeException)_throwable;
+			}
+
+			throw (Error)_throwable;
+		}
+
+		private TestBaseClusterReceiver(
+			ExecutorService executorService, Throwable throwable) {
+
+			super(executorService);
+
+			_throwable = throwable;
+		}
+
+		private final Throwable _throwable;
+
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95334

## What Is Being Fixed

`BaseClusterChannel` and `BaseClusterReceiver` submit their send and receive work to a
portal executor with `execute(() -> ...)` and no error handling. When one of those tasks
fails — for example, a queued send whose JGroups channel is tearing down, which rethrows
the failure as a `SystemException` — the exception propagates uncaught and terminates the
executor worker thread. In a clustered test the dying workers dump their stack traces to
`System.err`, and under output backpressure those writes contend on the forked node's
shared stdout stream, so the node JVM never finishes shutting down and the test hangs
until the build's wall-clock timeout.

## How It Is Being Fixed

The failure is contained at its source. `BaseClusterChannel` now routes both
`sendMulticastMessage` and `sendUnicastMessage` through a wrapper, and `BaseClusterReceiver`
wraps each of its three runnables, so a failing `doSendMessage`, `doReceive`, or
view/coordinator update is caught and logged at WARN instead of escaping. The worker thread
survives, so there is no stack-trace flood and no shutdown wedge. The wrapper catches
`Throwable` rather than `Exception` so that an `Error` — plausible during teardown — cannot
slip through and re-open the same failure. Each change is preceded by a failing contract
test that drives the public API with both a `RuntimeException` and an `Error` and asserts
the failure is contained and logged.

## PR Check

**pr-check: PASS** — tested on `b84483744947f5023a3fde32bd878706e34f6125`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b84483744947f5023a3fde32bd878706e34f6125"} -->
