### PR TITLE
LPD-98403 Add DynamicQuery test ordering by a projection alias

### DIFF
--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/DynamicQueryEntryTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/DynamicQueryEntryTest.java
@@ -511,6 +511,23 @@ public class DynamicQueryEntryTest {
 	}
 
 	@Test
+	public void testDynamicQueryWithProjectionAliasOrder() {
+		DynamicQuery dynamicQuery =
+			_dynamicQueryEntryLocalService.dynamicQuery();
+
+		dynamicQuery.setProjection(
+			ProjectionFactoryUtil.alias(
+				ProjectionFactoryUtil.sqlProjection(
+					"(select count(*) from DynamicQueryEntry where status = " +
+						"this_.status) AS statusCount",
+					new String[] {"statusCount"}, new Type[] {Type.LONG}),
+				"statusCount"));
+		dynamicQuery.addOrder(OrderFactoryUtil.desc("statusCount"));
+
+		_testDynamicQuery(dynamicQuery, 2L, 2L, 1L, 1L);
+	}
+
+	@Test
 	public void testDynamicQueryWithProjectionGroupProperty() {
 		ProjectionList projectionList = ProjectionFactoryUtil.projectionList();
 


### PR DESCRIPTION
The existing DynamicQuery coverage defines aliased projections but always orders by an entity attribute, so no test exercised ordering by a projection alias. Hibernate 7's SQM parser resolves an order-by name as an entity attribute path and throws a PathElementException when the name is only a projection alias, the failure seen in the taxonomy ranked queries. This test builds an aliased subquery projection and orders by that alias, reproducing the failure on Hibernate 7 while still passing on Hibernate 5.