### PR TITLE
LPD-98405 Add method to retrieve an app license's expiration date

### DIFF
--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/AppModuleLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/AppModuleLicenseTest.java
@@ -8,6 +8,7 @@ package com.liferay.portal.license.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.license.util.App;
+import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -16,6 +17,7 @@ import com.liferay.portal.kernel.util.Time;
 import java.io.File;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import org.junit.AfterClass;
@@ -93,6 +95,8 @@ public class AppModuleLicenseTest extends BaseLicenseTestCase {
 
 			assertBundlesExisted(appSymbolicNames);
 
+			Assert.assertNull(LicenseManagerUtil.getAppExpirationDate(app));
+
 			deployEnterprisePortalLicense(Time.HOUR);
 
 			assertLicensePropertiesNotExisted(getProductId(app));
@@ -101,13 +105,23 @@ public class AppModuleLicenseTest extends BaseLicenseTestCase {
 
 			assertBundlesNotExisted(appSymbolicNames);
 
-			File binaryFile = deployAppLicense(app, Time.HOUR);
+			Assert.assertNull(LicenseManagerUtil.getAppExpirationDate(app));
+
+			long startTime = System.currentTimeMillis();
+
+			File binaryFile = deployAppLicense(app, startTime, Time.HOUR);
 
 			assertLicensePropertiesExisted(getProductId(app));
 
 			assertPortalLicenseRegistered();
 
 			assertBundlesExisted(appSymbolicNames);
+
+			Date expirationDate = LicenseManagerUtil.getAppExpirationDate(app);
+
+			Assert.assertEquals(
+				getDateString(new Date(startTime + Time.HOUR)),
+				getDateString(expirationDate));
 
 			binaryFile.delete();
 
@@ -120,6 +134,8 @@ public class AppModuleLicenseTest extends BaseLicenseTestCase {
 			assertPortalLicenseRegistered();
 
 			assertBundlesNotExisted(appSymbolicNames);
+
+			Assert.assertNull(LicenseManagerUtil.getAppExpirationDate(app));
 		}
 	}
 

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
@@ -248,7 +248,12 @@ public abstract class BaseLicenseTestCase implements Serializable {
 	public File deployAppLicense(App app, long validityPeriod)
 		throws Exception {
 
-		long currentTimeMillis = System.currentTimeMillis();
+		return deployAppLicense(
+			app, System.currentTimeMillis(), validityPeriod);
+	}
+
+	public File deployAppLicense(App app, long startTime, long validityPeriod)
+		throws Exception {
 
 		StringBundler sb = new StringBundler(19);
 
@@ -261,10 +266,9 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		sb.append(_APP_LICENSE_TYPE);
 		sb.append("</license-type><license-version>3</license-version>");
 		sb.append("<start-date>");
-		sb.append(_DATE_FORMAT.format(new Date(currentTimeMillis)));
+		sb.append(_DATE_FORMAT.format(new Date(startTime)));
 		sb.append("</start-date><expiration-date>");
-		sb.append(
-			_DATE_FORMAT.format(new Date(currentTimeMillis + validityPeriod)));
+		sb.append(_DATE_FORMAT.format(new Date(startTime + validityPeriod)));
 		sb.append("</expiration-date><host-names>");
 		sb.append("<host-name>localhost</host-name>");
 		sb.append("</host-names><ip-addresses>");

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
@@ -527,6 +527,10 @@ public abstract class BaseLicenseTestCase implements Serializable {
 			classLoader.loadClass(className), methodSimpleName, parameterTypes);
 	}
 
+	protected static String getDateString(Date date) {
+		return _DATE_FORMAT.format(date);
+	}
+
 	protected static String getPortalProductId() {
 		return getProperty("product.id.portal");
 	}

--- a/portal-impl/src/com/liferay/portal/license/util/DefaultLicenseManagerImpl.java
+++ b/portal-impl/src/com/liferay/portal/license/util/DefaultLicenseManagerImpl.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.util.LicenseUtil;
 
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -33,6 +34,11 @@ public class DefaultLicenseManagerImpl implements LicenseManager {
 
 	@Override
 	public void checkLicense(String productId) {
+	}
+
+	@Override
+	public Date getAppExpirationDate(App app) {
+		return null;
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/license/util/LicenseManager.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/license/util/LicenseManager.java
@@ -8,6 +8,7 @@ package com.liferay.portal.kernel.license.util;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.license.LicenseInfo;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -30,6 +31,8 @@ public interface LicenseManager {
 	public static final int STATE_OVERLOAD = 6;
 
 	public void checkLicense(String productId);
+
+	public Date getAppExpirationDate(App app);
 
 	public List<Map<String, String>> getClusterLicenseProperties(
 		String clusterNodeId);

--- a/portal-kernel/src/com/liferay/portal/kernel/license/util/LicenseManagerUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/license/util/LicenseManagerUtil.java
@@ -8,6 +8,7 @@ package com.liferay.portal.kernel.license.util;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.license.LicenseInfo;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -25,6 +26,10 @@ public class LicenseManagerUtil {
 
 	public static void checkLicense(String productId) {
 		_licenseManager.checkLicense(productId);
+	}
+
+	public static Date getAppExpirationDate(App app) {
+		return _licenseManager.getAppExpirationDate(app);
 	}
 
 	public static List<Map<String, String>> getClusterLicenseProperties(

--- a/portal-kernel/src/com/liferay/portal/kernel/license/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/license/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 4.0.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98405

## Companion Pull Request

This PR must be merged together with https://github.com/tinatian/liferay-release-tool-ee/pull/149.

## What Is Being Fixed

The portal license API had no supported way to retrieve the expiration date of an app (Marketplace) license. Callers that need to know when an app license expires had no accessor to reach for.

## How It Is Being Fixed

Adds a `getAppExpirationDate(App)` method to the `LicenseManager` interface and exposes it through `LicenseManagerUtil`. The default portal implementation (`DefaultLicenseManagerImpl`) returns `null`, since app license enforcement is supplied by the enterprise layer. The exported package version of `com.liferay.portal.kernel.license.util` is bumped from 3.0.0 to 4.0.0 to reflect the interface change.

The license integration test infrastructure gains support for verifying the new accessor: `BaseLicenseTestCase.deployAppLicense` gets an overload that accepts an explicit start time, and `AppModuleLicenseTest` now asserts the expiration date is null before deployment, equal to start time plus the validity period after deployment, and null again after the license is removed.

## PR Check

**pr-check: PASS** — tested on `84d578f0d0c5f1b5287f644860bcb484952ab2c6`

All validations exercising this change passed. Full Portal Build failed only on a pre-existing, unrelated module (`knowledge-base-web` could not resolve `com.liferay.wiki.*` — a `wiki-api` classpath/cache issue in the forced-cache deploy), which this branch does not touch.

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | FAIL (unrelated — knowledge-base-web/wiki, pre-existing) |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "84d578f0d0c5f1b5287f644860bcb484952ab2c6"} -->
