### PR TITLE
LPD-98245 Enable Faces tests in CI acceptance and release tester

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/AlloyShowcase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/AlloyShowcase.testcase
@@ -4,7 +4,7 @@ definition {
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.alloy.showcase.portlet";
 	property portal.release = "true";
-	property portal.upstream = "quarantine";
+	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemos.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemos.testcase
@@ -7,7 +7,7 @@ definition {
 	property liferay.faces.war.auto.deploy = "false";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.jsf.export.pdf.portlet,com.liferay.faces.demo.jsf.flows.portlet";
 	property portal.release = "true";
-	property portal.upstream = "quarantine";
+	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosAlloyApplicant.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosAlloyApplicant.testcase
@@ -6,7 +6,7 @@ definition {
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.alloy.applicant.portlet";
 	property portal.release = "true";
-	property portal.upstream = "quarantine";
+	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosHtml5Applicant.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosHtml5Applicant.testcase
@@ -6,7 +6,7 @@ definition {
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.jsf.html5.applicant.portlet";
 	property portal.release = "true";
-	property portal.upstream = "quarantine";
+	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosIPC.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosIPC.testcase
@@ -6,7 +6,7 @@ definition {
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.jsf.ipc.pub.render.params.portlet,com.liferay.faces.demo.jsf.ipc.events.bookings.portlet,com.liferay.faces.demo.jsf.ipc.events.customers.portlet";
 	property portal.release = "true";
-	property portal.upstream = "quarantine";
+	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosJSFApplicant.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosJSFApplicant.testcase
@@ -6,7 +6,7 @@ definition {
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.jsf.applicant.portlet";
 	property portal.release = "true";
-	property portal.upstream = "quarantine";
+	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosJSFCDIApplicant.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosJSFCDIApplicant.testcase
@@ -7,7 +7,7 @@ definition {
 	property liferay.faces.war.auto.deploy = "false";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.jsf.cdi.applicant.portlet";
 	property portal.release = "true";
-	property portal.upstream = "quarantine";
+	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosPrimefacesApplicant.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosPrimefacesApplicant.testcase
@@ -6,7 +6,7 @@ definition {
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.primefaces.applicant.portlet";
 	property portal.release = "true";
-	property portal.upstream = "quarantine";
+	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosSpringApplicant.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosSpringApplicant.testcase
@@ -6,7 +6,7 @@ definition {
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.jsf.spring.applicant.portlet";
 	property portal.release = "true";
-	property portal.upstream = "quarantine";
+	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeIssues.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeIssues.testcase
@@ -31,11 +31,6 @@ definition {
 
 	@priority = 3
 	test Faces1470And1478PortletSmoke {
-
-		// FACES_1470
-
-		property portal.upstream = "quarantine";
-
 		BridgeIssues.addPageAndPortlet(
 			pageURL = "faces-1470",
 			portletName = "FACES-1470");
@@ -245,11 +240,6 @@ definition {
 
 	@priority = 3
 	test Faces1635And1433PortletSmoke {
-
-		// FACES_1635Resources
-
-		property portal.upstream = "quarantine";
-
 		BridgeIssues.addPageAndPortlet(
 			pageURL = "jsf-applicant?p_p_parallel=0",
 			portletName = "jsf-applicant");
@@ -319,11 +309,6 @@ definition {
 
 	@priority = 3
 	test FacesIssuesPortletSmoke {
-
-		// FACES_224
-
-		property portal.upstream = "quarantine";
-
 		BridgeIssues.addPageAndPortlet(
 			pageURL = "faces-224",
 			portletName = "FACES-224");
@@ -503,11 +488,6 @@ definition {
 
 	@priority = 3
 	test PrimefacesIssuesSmoke {
-
-		// FACES_1513_2185
-
-		property portal.upstream = "quarantine";
-
 		BridgeIssues.addPageAndPortlet(
 			pageURL = "faces-1513-2185",
 			portletName = "FACES-1513-2185");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/JSFShowcase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/JSFShowcase.testcase
@@ -6,7 +6,7 @@ definition {
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.jsf.showcase.portlet";
 	property portal.release = "true";
-	property portal.upstream = "quarantine";
+	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/PortalShowcase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/PortalShowcase.testcase
@@ -50,6 +50,8 @@ definition {
 
 	@priority = 5
 	test InputRichTextSmoke {
+		property portal.upstream = "quarantine";
+
 		Navigator.openWithAppendToBaseURL(urlAppend = "web/portal-showcase/portal-showcase/-/portal-tag/portal/inputrichtext/general");
 
 		AssertElementPresent(locator1 = "PortalShowcase#CHECKED_RENDERED_CHECKBOX");


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98245

## What Is Being Fixed

The Liferay Faces functional tests were quarantined from CI, so they no longer ran in the acceptance suite or the Release Tester. Separately, one test, PortalShowcase#InputRichTextSmoke, fails consistently and must stay out while the rest are re-enabled.

## How It Is Being Fixed

The definition-level `portal.upstream` property on the Faces testcases is set back to `"true"` from `"quarantine"`, and the leftover test-level `portal.upstream = "quarantine"` overrides in BridgeIssues are removed so those tests inherit the re-enabled definition value. Combined with the existing `portal.release = "true"`, this returns the Faces suite to both the upstream acceptance batch and the Release Tester. The persistently-failing PortalShowcase#InputRichTextSmoke is quarantined on its own via a test-level `portal.upstream = "quarantine"`, keeping it out of acceptance while the rest run.

## Why Are There No Tests?

This change only toggles Poshi test quarantine flags to re-enable the Faces suite in CI; there is no product code change to cover with new tests.

## PR Check

**pr-check: PASS** — tested on `ba0ffe6b395b29ae3ecb01412062d9608ef0c82f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "ba0ffe6b395b29ae3ecb01412062d9608ef0c82f"} -->
