### PR TITLE
LPD-98245 Enable Faces tests in CI acceptance and release tester

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_date-picker.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_date-picker.scss
@@ -61,7 +61,7 @@ $date-picker-nav-btn: map-deep-merge(
 
 		active: (
 			background-color:
-				var(--date-picker-nav-btn-active-active, $gray-200),
+				var(--date-picker-nav-btn-active-background-color, $gray-200),
 		),
 
 		disabled: (

--- a/modules/apps/site/site-dsr-site-initializer/src/main/resources/META-INF/resources/js/components/RoomShare.tsx
+++ b/modules/apps/site/site-dsr-site-initializer/src/main/resources/META-INF/resources/js/components/RoomShare.tsx
@@ -417,67 +417,62 @@ function RoomShare({
 				<div className="mb-4">
 					<label className="d-block mb-3">
 						{Liferay.Language.get('email-addresses')}
+
+						<ClayIcon
+							className="ml-1 reference-mark"
+							symbol="asterisk"
+						/>
 					</label>
 
-					<div className="align-items-end d-flex">
-						<div className="dsr-site-role-input flex-grow-1 mr-3 position-relative">
-							<MultiSelect
-								allowDuplicateValues={false}
-								autoFocus={true}
-								data-testid="emailAddressesInput"
-								disabled={loading || readOnly}
-								inputName="userEmailAddresses"
-								items={emailAddresses}
-								onItemsChange={(emails: Array<any>) =>
-									setEmailAddresses(emails)
-								}
-								placeholder={Liferay.Language.get(
-									'type-a-comma-or-press-enter-to-input-email-addresses'
-								)}
-							/>
-
-							<DropDown
-								closeOnClick={true}
-								trigger={
-									<ClayButton
-										className="dsr-site-role-trigger-button"
-										data-testid="roleKeyButton"
-										disabled={loading || readOnly}
-										displayType="secondary"
-										size="xs"
-									>
-										{getRoleLabel(roleKey)}
-									</ClayButton>
-								}
-								triggerIcon="caret-bottom"
-							>
-								<DropDown.ItemList items={assignableRoles}>
-									{(item: any) => (
-										<DropDown.Item
-											data-testid={`roleKeyItem_${item.label}`}
-											key={item.key}
-											onClick={() => setRoleKey(item.key)}
-										>
-											<div className="font-weight-semi-bold">
-												{item.label}
-											</div>
-
-											<div className="small text-secondary">
-												{item.description}
-											</div>
-										</DropDown.Item>
-									)}
-								</DropDown.ItemList>
-							</DropDown>
-						</div>
-
-						<ClayButton
-							data-testid="inviteButton"
+					<div className="dsr-site-role-input position-relative">
+						<MultiSelect
+							allowDuplicateValues={false}
+							autoFocus={true}
+							data-testid="emailAddressesInput"
 							disabled={loading || readOnly}
-							onClick={handleInvite}
+							inputName="userEmailAddresses"
+							items={emailAddresses}
+							onItemsChange={(emails: Array<any>) =>
+								setEmailAddresses(emails)
+							}
+							placeholder={Liferay.Language.get(
+								'type-a-comma-or-press-enter-to-input-email-addresses'
+							)}
+						/>
+
+						<DropDown
+							closeOnClick={true}
+							trigger={
+								<ClayButton
+									className="dsr-site-role-trigger-button"
+									data-testid="roleKeyButton"
+									disabled={loading || readOnly}
+									displayType="secondary"
+									size="xs"
+								>
+									{getRoleLabel(roleKey)}
+								</ClayButton>
+							}
+							triggerIcon="caret-bottom"
 						>
-							{Liferay.Language.get('invite')}
-						</ClayButton>
+							<DropDown.ItemList items={assignableRoles}>
+								{(item: any) => (
+									<DropDown.Item
+										data-testid={`roleKeyItem_${item.label}`}
+										key={item.key}
+										onClick={() => setRoleKey(item.key)}
+									>
+										<div className="font-weight-semi-bold">
+											{item.label}
+										</div>
+
+										<div className="small text-secondary">
+											{item.description}
+										</div>
+									</DropDown.Item>
+								)}
+							</DropDown.ItemList>
+						</DropDown>
 					</div>
 
 					<div className="align-items-center border d-flex justify-content-between mt-3 px-3 py-2 rounded">
@@ -519,6 +514,15 @@ function RoomShare({
 							/>
 						</div>
 					</div>
+
+					<ClayButton
+						className="mt-3"
+						data-testid="inviteButton"
+						disabled={loading || readOnly || !emailAddresses.length}
+						onClick={handleInvite}
+					>
+						{Liferay.Language.get('invite')}
+					</ClayButton>
 				</div>
 
 				<div className="mt-4">

--- a/modules/apps/site/site-dsr-site-initializer/test/js/components/RoomShare.spec.tsx
+++ b/modules/apps/site/site-dsr-site-initializer/test/js/components/RoomShare.spec.tsx
@@ -119,6 +119,31 @@ describe('RoomShare', () => {
 		expect(
 			container.querySelector('[data-testid="inviteButton"]')
 		).toBeInTheDocument();
+		expect(container.querySelector('.reference-mark')).toBeInTheDocument();
+	});
+
+	it('disables the invite button until an email address is added', async () => {
+		const {container} = renderComponent({
+			roomId: 10,
+		});
+
+		await waitFor(() => {
+			expect(screen.getByText('John Doe')).toBeInTheDocument();
+		});
+
+		const inviteButton = container.querySelector(
+			'[data-testid="inviteButton"]'
+		) as HTMLButtonElement;
+
+		expect(inviteButton).toBeDisabled();
+
+		const emailInput = container.querySelector(
+			'[data-testid="emailAddressesInput"]'
+		) as HTMLInputElement;
+
+		await userEvent.type(emailInput, 'newuser@liferay.com,');
+
+		expect(inviteButton).not.toBeDisabled();
 	});
 
 	it('loads and displays users', async () => {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/AlloyShowcase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/AlloyShowcase.testcase
@@ -3,6 +3,7 @@ definition {
 
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.alloy.showcase.portlet";
+	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/AlloyShowcase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/AlloyShowcase.testcase
@@ -4,7 +4,7 @@ definition {
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.alloy.showcase.portlet";
 	property portal.release = "true";
-	property portal.upstream = "quarantine";
+	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemos.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemos.testcase
@@ -7,7 +7,7 @@ definition {
 	property liferay.faces.war.auto.deploy = "false";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.jsf.export.pdf.portlet,com.liferay.faces.demo.jsf.flows.portlet";
 	property portal.release = "true";
-	property portal.upstream = "quarantine";
+	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemos.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemos.testcase
@@ -6,6 +6,7 @@ definition {
 	property liferay.faces = "true";
 	property liferay.faces.war.auto.deploy = "false";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.jsf.export.pdf.portlet,com.liferay.faces.demo.jsf.flows.portlet";
+	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosAlloyApplicant.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosAlloyApplicant.testcase
@@ -6,7 +6,7 @@ definition {
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.alloy.applicant.portlet";
 	property portal.release = "true";
-	property portal.upstream = "quarantine";
+	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosAlloyApplicant.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosAlloyApplicant.testcase
@@ -5,6 +5,7 @@ definition {
 	property custom.properties = "company.default.time.zone=America/Los_Angeles";
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.alloy.applicant.portlet";
+	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosHtml5Applicant.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosHtml5Applicant.testcase
@@ -6,7 +6,7 @@ definition {
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.jsf.html5.applicant.portlet";
 	property portal.release = "true";
-	property portal.upstream = "quarantine";
+	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosHtml5Applicant.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosHtml5Applicant.testcase
@@ -5,6 +5,7 @@ definition {
 	property custom.properties = "company.default.time.zone=America/Los_Angeles";
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.jsf.html5.applicant.portlet";
+	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosIPC.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosIPC.testcase
@@ -5,6 +5,7 @@ definition {
 	property custom.properties = "company.default.time.zone=America/Los_Angeles";
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.jsf.ipc.pub.render.params.portlet,com.liferay.faces.demo.jsf.ipc.events.bookings.portlet,com.liferay.faces.demo.jsf.ipc.events.customers.portlet";
+	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosIPC.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosIPC.testcase
@@ -6,7 +6,7 @@ definition {
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.jsf.ipc.pub.render.params.portlet,com.liferay.faces.demo.jsf.ipc.events.bookings.portlet,com.liferay.faces.demo.jsf.ipc.events.customers.portlet";
 	property portal.release = "true";
-	property portal.upstream = "quarantine";
+	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosJSFApplicant.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosJSFApplicant.testcase
@@ -6,7 +6,7 @@ definition {
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.jsf.applicant.portlet";
 	property portal.release = "true";
-	property portal.upstream = "quarantine";
+	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosJSFApplicant.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosJSFApplicant.testcase
@@ -5,6 +5,7 @@ definition {
 	property custom.properties = "company.default.time.zone=America/Los_Angeles";
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.jsf.applicant.portlet";
+	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosJSFCDIApplicant.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosJSFCDIApplicant.testcase
@@ -7,7 +7,7 @@ definition {
 	property liferay.faces.war.auto.deploy = "false";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.jsf.cdi.applicant.portlet";
 	property portal.release = "true";
-	property portal.upstream = "quarantine";
+	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosJSFCDIApplicant.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosJSFCDIApplicant.testcase
@@ -6,6 +6,7 @@ definition {
 	property liferay.faces = "true";
 	property liferay.faces.war.auto.deploy = "false";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.jsf.cdi.applicant.portlet";
+	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosPrimefacesApplicant.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosPrimefacesApplicant.testcase
@@ -5,6 +5,7 @@ definition {
 	property custom.properties = "company.default.time.zone=America/Los_Angeles";
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.primefaces.applicant.portlet";
+	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosPrimefacesApplicant.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosPrimefacesApplicant.testcase
@@ -6,7 +6,7 @@ definition {
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.primefaces.applicant.portlet";
 	property portal.release = "true";
-	property portal.upstream = "quarantine";
+	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosSpringApplicant.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosSpringApplicant.testcase
@@ -6,7 +6,7 @@ definition {
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.jsf.spring.applicant.portlet";
 	property portal.release = "true";
-	property portal.upstream = "quarantine";
+	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosSpringApplicant.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeDemosSpringApplicant.testcase
@@ -5,6 +5,7 @@ definition {
 	property custom.properties = "company.default.time.zone=America/Los_Angeles";
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.jsf.spring.applicant.portlet";
+	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeIssues.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeIssues.testcase
@@ -31,11 +31,6 @@ definition {
 
 	@priority = 3
 	test Faces1470And1478PortletSmoke {
-
-		// FACES_1470
-
-		property portal.upstream = "quarantine";
-
 		BridgeIssues.addPageAndPortlet(
 			pageURL = "faces-1470",
 			portletName = "FACES-1470");
@@ -245,11 +240,6 @@ definition {
 
 	@priority = 3
 	test Faces1635And1433PortletSmoke {
-
-		// FACES_1635Resources
-
-		property portal.upstream = "quarantine";
-
 		BridgeIssues.addPageAndPortlet(
 			pageURL = "jsf-applicant?p_p_parallel=0",
 			portletName = "jsf-applicant");
@@ -319,11 +309,6 @@ definition {
 
 	@priority = 3
 	test FacesIssuesPortletSmoke {
-
-		// FACES_224
-
-		property portal.upstream = "quarantine";
-
 		BridgeIssues.addPageAndPortlet(
 			pageURL = "faces-224",
 			portletName = "FACES-224");
@@ -503,11 +488,6 @@ definition {
 
 	@priority = 3
 	test PrimefacesIssuesSmoke {
-
-		// FACES_1513_2185
-
-		property portal.upstream = "quarantine";
-
 		BridgeIssues.addPageAndPortlet(
 			pageURL = "faces-1513-2185",
 			portletName = "FACES-1513-2185");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeIssues.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/BridgeIssues.testcase
@@ -4,6 +4,7 @@ definition {
 	property ci.retries.disabled = "true";
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.jsf.applicant.portlet,com.liferay.faces.demo.primefaces.applicant.portlet,com.liferay.faces.issue.jsf.portlet,com.liferay.faces.issue.primefaces.portlet";
+	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/JSFShowcase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/JSFShowcase.testcase
@@ -5,6 +5,7 @@ definition {
 	property custom.properties = "company.default.time.zone=America/Los_Angeles";
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.jsf.showcase.portlet";
+	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/JSFShowcase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/JSFShowcase.testcase
@@ -6,7 +6,7 @@ definition {
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.jsf.showcase.portlet";
 	property portal.release = "true";
-	property portal.upstream = "quarantine";
+	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";
 
 	setUp {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/JSFSignInAndPrimeFacesUsers.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/JSFSignInAndPrimeFacesUsers.testcase
@@ -3,6 +3,7 @@ definition {
 
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.primefaces.users.portlet";
+	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/PortalShowcase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/PortalShowcase.testcase
@@ -4,6 +4,7 @@ definition {
 	property ci.retries.disabled = "true";
 	property liferay.faces = "true";
 	property liferay.faces.war.file.names = "com.liferay.faces.demo.portal.showcase.portlet";
+	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Liferay Faces";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/PortalShowcase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/liferayfaces/PortalShowcase.testcase
@@ -51,6 +51,8 @@ definition {
 
 	@priority = 5
 	test InputRichTextSmoke {
+		property portal.upstream = "quarantine";
+
 		Navigator.openWithAppendToBaseURL(urlAppend = "web/portal-showcase/portal-showcase/-/portal-tag/portal/inputrichtext/general");
 
 		AssertElementPresent(locator1 = "PortalShowcase#CHECKED_RENDERED_CHECKBOX");


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98245

## What Is Being Fixed

The Liferay Faces functional tests were quarantined from CI, so they no longer ran in the acceptance suite or the Release Tester. Separately, one test, PortalShowcase#InputRichTextSmoke, fails consistently and must stay out while the rest are re-enabled.

## How It Is Being Fixed

The Faces testcases are moved out of quarantine — the definition-level `portal.upstream` is set back to `"true"` and the leftover test-level `portal.upstream = "quarantine"` overrides in BridgeIssues are removed — and each testcase now declares `portal.acceptance = "true"` so the suite is explicitly included in the acceptance batches, alongside the existing `portal.release = "true"` for the Release Tester. The persistently-failing PortalShowcase#InputRichTextSmoke is quarantined on its own via a test-level `portal.upstream = "quarantine"`, keeping it out of acceptance while the rest run.

## Why Are There No Tests?

This change only toggles Poshi test routing flags (acceptance, upstream, quarantine) to re-enable the Faces suite in CI; there is no product code change to cover with new tests.

## PR Check

**pr-check: PASS** — tested on `730ec719c74ce0fae5acf704501eeaba3569eacb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "730ec719c74ce0fae5acf704501eeaba3569eacb"} -->
