### PR TITLE
LPD-98408 Add test coverage for combined licenses

### DIFF
--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/AppModuleLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/AppModuleLicenseTest.java
@@ -9,25 +9,18 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.license.util.App;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
-import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
 
 import java.io.File;
 
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 
 /**
  * @author Kevin Lee
@@ -61,27 +54,9 @@ public class AppModuleLicenseTest extends BaseLicenseTestCase {
 		}
 	}
 
-	private String[] _getAppSymbolicNames(App app) {
-		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
-
-		List<String> symbolicNames = new ArrayList<>();
-
-		for (Bundle bundle : bundleContext.getBundles()) {
-			String symbolicName = bundle.getSymbolicName();
-
-			if (symbolicName.contains(
-					"." + StringUtil.toLowerCase(app.toString()) + ".")) {
-
-				symbolicNames.add(symbolicName);
-			}
-		}
-
-		return ArrayUtil.toStringArray(symbolicNames);
-	}
-
 	private void _testEnterpriseLicense(App app) throws Exception {
 		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
-			String[] appSymbolicNames = _getAppSymbolicNames(app);
+			String[] appSymbolicNames = getAppSymbolicNames(app);
 
 			Assert.assertFalse(
 				appSymbolicNames.toString(),
@@ -141,7 +116,7 @@ public class AppModuleLicenseTest extends BaseLicenseTestCase {
 
 	private void _testFreeTierLicense(App app) throws Exception {
 		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
-			String[] appSymbolicNames = _getAppSymbolicNames(app);
+			String[] appSymbolicNames = getAppSymbolicNames(app);
 
 			Assert.assertFalse(
 				appSymbolicNames.toString(),

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
@@ -85,28 +85,12 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		Assume.assumeTrue(isReleaseBundle());
 	}
 
-	public static File deployFreeTierPortalLicense(long validityPeriod)
-		throws Exception {
-
-		return deployFreeTierPortalLicense(
-			_FREE_TIER_DOMAIN, StringPool.BLANK, validityPeriod);
-	}
-
-	public static File deployFreeTierPortalLicense(
-			String domain, long validityPeriod)
-		throws Exception {
-
-		return deployFreeTierPortalLicense(
-			domain, StringPool.BLANK, validityPeriod);
-	}
-
-	public static File deployFreeTierPortalLicense(
-			String domain, String key, long validityPeriod)
-		throws Exception {
+	public static String buildFreeTierPortalLicenseXML(
+		String domain, String key, long validityPeriod) {
 
 		StringBundler sb = new StringBundler(20);
 
-		sb.append("<?xml version=\"1.0\"?><license><account-name>");
+		sb.append("<license><account-name>");
 		sb.append(_FREE_TIER_ACCOUNT_NAME);
 		sb.append("</account-name><product-id>");
 		sb.append(getPortalProductId());
@@ -131,7 +115,30 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		sb.append(key);
 		sb.append("</key></license>");
 
-		_registerLicense(sb.toString());
+		return sb.toString();
+	}
+
+	public static File deployFreeTierPortalLicense(long validityPeriod)
+		throws Exception {
+
+		return deployFreeTierPortalLicense(
+			_FREE_TIER_DOMAIN, StringPool.BLANK, validityPeriod);
+	}
+
+	public static File deployFreeTierPortalLicense(
+			String domain, long validityPeriod)
+		throws Exception {
+
+		return deployFreeTierPortalLicense(
+			domain, StringPool.BLANK, validityPeriod);
+	}
+
+	public static File deployFreeTierPortalLicense(
+			String domain, String key, long validityPeriod)
+		throws Exception {
+
+		_registerLicense(
+			buildFreeTierPortalLicenseXML(domain, key, validityPeriod));
 
 		return _buildBinaryFile(
 			getPortalProductId(), _FREE_TIER_ACCOUNT_NAME,
@@ -245,19 +252,12 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		Assert.assertFalse(response.contains(_LICENSE_PAGE_KEY));
 	}
 
-	public File deployAppLicense(App app, long validityPeriod)
-		throws Exception {
-
-		return deployAppLicense(
-			app, System.currentTimeMillis(), validityPeriod);
-	}
-
-	public File deployAppLicense(App app, long startTime, long validityPeriod)
-		throws Exception {
+	public String buildAppLicenseXML(
+		App app, long startTime, long validityPeriod) {
 
 		StringBundler sb = new StringBundler(19);
 
-		sb.append("<?xml version=\"1.0\"?><license><product-id>");
+		sb.append("<license><product-id>");
 		sb.append(getProductId(app));
 		sb.append("</product-id><product-name>");
 		sb.append(app);
@@ -289,21 +289,15 @@ public abstract class BaseLicenseTestCase implements Serializable {
 
 		sb.append("</mac-addresses><key></key></license>");
 
-		_registerLicense(sb.toString());
-
-		return _buildBinaryFile(
-			getProductId(app), StringPool.BLANK, app.toString(),
-			_APP_LICENSE_TYPE);
+		return sb.toString();
 	}
 
-	public File deployEnterprisePortalLicense(long validityPeriod)
-		throws Exception {
-
+	public String buildEnterprisePortalLicenseXML(long validityPeriod) {
 		long currentTimeMillis = System.currentTimeMillis();
 
 		StringBundler sb = new StringBundler(19);
 
-		sb.append("<?xml version=\"1.0\"?><license><account-name>");
+		sb.append("<license><account-name>");
 		sb.append(_ENTERPRISE_ACCOUNT_NAME);
 		sb.append("</account-name><product-id>");
 		sb.append(getPortalProductId());
@@ -324,7 +318,30 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		sb.append("</domain><domain>localhost</domain></domains>");
 		sb.append("<key></key></license>");
 
-		_registerLicense(sb.toString());
+		return sb.toString();
+	}
+
+	public File deployAppLicense(App app, long validityPeriod)
+		throws Exception {
+
+		return deployAppLicense(
+			app, System.currentTimeMillis(), validityPeriod);
+	}
+
+	public File deployAppLicense(App app, long startTime, long validityPeriod)
+		throws Exception {
+
+		_registerLicense(buildAppLicenseXML(app, startTime, validityPeriod));
+
+		return _buildBinaryFile(
+			getProductId(app), StringPool.BLANK, app.toString(),
+			_APP_LICENSE_TYPE);
+	}
+
+	public File deployEnterprisePortalLicense(long validityPeriod)
+		throws Exception {
+
+		_registerLicense(buildEnterprisePortalLicenseXML(validityPeriod));
 
 		return _buildBinaryFile(
 			getPortalProductId(), _ENTERPRISE_ACCOUNT_NAME,
@@ -625,7 +642,8 @@ public abstract class BaseLicenseTestCase implements Serializable {
 				_licensePackageName, LoggerTestUtil.ALL)) {
 
 			LicenseManagerUtil.registerLicense(
-				JSONUtil.put("licenseXML", licenseXML));
+				JSONUtil.put(
+					"licenseXML", "<?xml version=\"1.0\"?>" + licenseXML));
 
 			_throwLogEntriesException(logCapture, null, LoggerTestUtil.ERROR);
 		}

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.AssumeTestRule;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
@@ -561,6 +562,24 @@ public abstract class BaseLicenseTestCase implements Serializable {
 
 		return ReflectionTestUtil.getMethod(
 			classLoader.loadClass(className), methodSimpleName, parameterTypes);
+	}
+
+	protected static String[] getAppSymbolicNames(App app) {
+		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+
+		List<String> symbolicNames = new ArrayList<>();
+
+		for (Bundle bundle : bundleContext.getBundles()) {
+			String symbolicName = bundle.getSymbolicName();
+
+			if (symbolicName.contains(
+					"." + StringUtil.toLowerCase(app.toString()) + ".")) {
+
+				symbolicNames.add(symbolicName);
+			}
+		}
+
+		return ArrayUtil.toStringArray(symbolicNames);
 	}
 
 	protected static String getDateString(Date date) {

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
@@ -86,6 +86,11 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		Assume.assumeTrue(isReleaseBundle());
 	}
 
+	public static String buildFreeTierPortalLicenseXML(long validityPeriod) {
+		return buildFreeTierPortalLicenseXML(
+			_FREE_TIER_DOMAIN, StringPool.BLANK, validityPeriod);
+	}
+
 	public static String buildFreeTierPortalLicenseXML(
 		String domain, String key, long validityPeriod) {
 

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
@@ -137,10 +137,10 @@ public abstract class BaseLicenseTestCase implements Serializable {
 			String domain, String key, long validityPeriod)
 		throws Exception {
 
-		_registerLicense(
+		registerLicense(
 			buildFreeTierPortalLicenseXML(domain, key, validityPeriod));
 
-		return _buildBinaryFile(
+		return buildBinaryFile(
 			getPortalProductId(), _FREE_TIER_ACCOUNT_NAME,
 			_FREE_TIER_PRODUCT_NAME, _FREE_TIER_LICENSE_TYPE);
 	}
@@ -331,9 +331,9 @@ public abstract class BaseLicenseTestCase implements Serializable {
 	public File deployAppLicense(App app, long startTime, long validityPeriod)
 		throws Exception {
 
-		_registerLicense(buildAppLicenseXML(app, startTime, validityPeriod));
+		registerLicense(buildAppLicenseXML(app, startTime, validityPeriod));
 
-		return _buildBinaryFile(
+		return buildBinaryFile(
 			getProductId(app), StringPool.BLANK, app.toString(),
 			_APP_LICENSE_TYPE);
 	}
@@ -341,9 +341,9 @@ public abstract class BaseLicenseTestCase implements Serializable {
 	public File deployEnterprisePortalLicense(long validityPeriod)
 		throws Exception {
 
-		_registerLicense(buildEnterprisePortalLicenseXML(validityPeriod));
+		registerLicense(buildEnterprisePortalLicenseXML(validityPeriod));
 
-		return _buildBinaryFile(
+		return buildBinaryFile(
 			getPortalProductId(), _ENTERPRISE_ACCOUNT_NAME,
 			_ENTERPRISE_PRODUCT_NAME, _ENTERPRISE_LICENSE_TYPE);
 	}
@@ -499,6 +499,25 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		}
 	}
 
+	protected static File buildBinaryFile(
+		String productId, String accountName, String productEntryName,
+		String licenseType) {
+
+		StringBundler sb = new StringBundler(6);
+
+		if (productId.equals(getPortalProductId())) {
+			sb.append(StringUtil.extractChars(accountName));
+			sb.append("_");
+		}
+
+		sb.append(StringUtil.extractChars(productEntryName));
+		sb.append("_");
+		sb.append(StringUtil.extractChars(licenseType));
+		sb.append(".li");
+
+		return new File(LicenseUtil.LICENSE_REPOSITORY_DIR, sb.toString());
+	}
+
 	protected static Field findField(String propertyKey) throws Exception {
 		ClassLoader classLoader = PortalClassLoaderUtil.getClassLoader();
 
@@ -568,6 +587,18 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		return ReflectionsHolder._validateClass;
 	}
 
+	protected static void registerLicense(String licenseXML) throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_licensePackageName, LoggerTestUtil.ALL)) {
+
+			LicenseManagerUtil.registerLicense(
+				JSONUtil.put(
+					"licenseXML", "<?xml version=\"1.0\"?>" + licenseXML));
+
+			_throwLogEntriesException(logCapture, null, LoggerTestUtil.ERROR);
+		}
+	}
+
 	protected void checkLicense(String productId) throws Exception {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				_licensePackageName, LoggerTestUtil.ALL)) {
@@ -615,37 +646,6 @@ public abstract class BaseLicenseTestCase implements Serializable {
 				logCapture, response, LoggerTestUtil.DEBUG);
 
 			return response;
-		}
-	}
-
-	private static File _buildBinaryFile(
-		String productId, String accountName, String productEntryName,
-		String licenseType) {
-
-		StringBundler sb = new StringBundler(6);
-
-		if (productId.equals(getPortalProductId())) {
-			sb.append(StringUtil.extractChars(accountName));
-			sb.append("_");
-		}
-
-		sb.append(StringUtil.extractChars(productEntryName));
-		sb.append("_");
-		sb.append(StringUtil.extractChars(licenseType));
-		sb.append(".li");
-
-		return new File(LicenseUtil.LICENSE_REPOSITORY_DIR, sb.toString());
-	}
-
-	private static void _registerLicense(String licenseXML) throws Exception {
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				_licensePackageName, LoggerTestUtil.ALL)) {
-
-			LicenseManagerUtil.registerLicense(
-				JSONUtil.put(
-					"licenseXML", "<?xml version=\"1.0\"?>" + licenseXML));
-
-			_throwLogEntriesException(logCapture, null, LoggerTestUtil.ERROR);
 		}
 	}
 

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
@@ -10,6 +10,7 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.license.util.App;
+import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
@@ -106,6 +107,27 @@ public class CombinedLicenseTest extends BaseLicenseTestCase {
 			assertPortalLicenseNotRegistered();
 
 			Assert.assertNull(Arrays.toString(binaryFiles), binaryFiles);
+		}
+	}
+
+	@Test
+	public void testPortalLicensesEnterpriseAndFreeTier() throws Exception {
+		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
+			assertPortalLicenseNotRegistered();
+
+			File[] binaryFiles = _deployCombinedLicense(
+				List.of(
+					buildEnterprisePortalLicenseXML(Time.HOUR),
+					buildFreeTierPortalLicenseXML(Time.HOUR)));
+
+			assertLicensePropertiesExisted(getPortalProductId());
+
+			assertPortalLicenseRegistered();
+
+			Assert.assertEquals(
+				Arrays.toString(binaryFiles), 2, binaryFiles.length);
+
+			Assert.assertFalse(LicenseManagerUtil.isFreeTier());
 		}
 	}
 

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.license.util.App;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.util.LicenseUtil;
 
 import java.io.File;
@@ -47,6 +48,20 @@ public class CombinedLicenseTest extends BaseLicenseTestCase {
 	public static void tearDownClass() {
 		_disableKeyValidatorSafeCloseable.close();
 		_setVersionSafeCloseable.close();
+	}
+
+	@Test
+	public void testAppLicensesWithExpiredPortalLicenseEnterprise()
+		throws Exception {
+
+		_testAppLicensesWithExpiredPortalLicense(false);
+	}
+
+	@Test
+	public void testAppLicensesWithExpiredPortalLicenseFreeTier()
+		throws Exception {
+
+		_testAppLicensesWithExpiredPortalLicense(true);
 	}
 
 	@Test
@@ -100,11 +115,98 @@ public class CombinedLicenseTest extends BaseLicenseTestCase {
 				"<licenses>", StringUtil.merge(licenseXMLs, StringPool.BLANK),
 				"</licenses>"));
 
+		return _getLicenseBinaryFiles();
+	}
+
+	private File[] _getLicenseBinaryFiles() {
 		return new File(
 			LicenseUtil.LICENSE_REPOSITORY_DIR
 		).listFiles(
 			(dirFile, name) -> name.endsWith(".li")
 		);
+	}
+
+	private void _testAppLicensesWithExpiredPortalLicense(boolean freeTier)
+		throws Exception {
+
+		Map<App, String[]> appSymbolicNamesMap = new HashMap<>();
+
+		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
+			assertLicensePropertiesNotExisted(getPortalProductId());
+
+			for (App app : App.values()) {
+				String[] appSymbolicNames = getAppSymbolicNames(app);
+
+				Assert.assertFalse(
+					Arrays.toString(appSymbolicNames),
+					ArrayUtil.isEmpty(appSymbolicNames));
+
+				assertLicensePropertiesNotExisted(getProductId(app));
+
+				assertBundlesExisted(appSymbolicNames);
+
+				appSymbolicNamesMap.put(app, appSymbolicNames);
+			}
+
+			assertPortalLicenseNotRegistered();
+
+			List<String> licenseXMLs = new ArrayList<>();
+
+			if (freeTier) {
+				licenseXMLs.add(buildFreeTierPortalLicenseXML(-Time.WEEK));
+			}
+			else {
+				licenseXMLs.add(buildEnterprisePortalLicenseXML(-Time.WEEK));
+			}
+
+			long startTime = System.currentTimeMillis();
+
+			for (App app : App.values()) {
+				licenseXMLs.add(buildAppLicenseXML(app, startTime, Time.HOUR));
+			}
+
+			try {
+				_deployCombinedLicense(licenseXMLs);
+
+				Assert.fail(
+					"Expected expired portal license to fail validation");
+			}
+			catch (LogEntriesException logEntriesException) {
+				List<LogEntry> logEntries = logEntriesException.getLogEntries();
+
+				Assert.assertEquals(
+					logEntries.toString(), 1, logEntries.size());
+
+				LogEntry logEntry = logEntries.get(0);
+
+				if (freeTier) {
+					Assert.assertEquals(
+						"DXP Production license is expired",
+						logEntry.getMessage());
+				}
+				else {
+					Assert.assertEquals(
+						"DXP Enterprise license is expired",
+						logEntry.getMessage());
+				}
+
+				assertPortalLicenseExpired();
+
+				assertLicensePropertiesExisted(getPortalProductId());
+
+				for (App app : App.values()) {
+					assertLicensePropertiesExisted(getProductId(app));
+
+					assertBundlesExisted(appSymbolicNamesMap.get(app));
+				}
+
+				File[] binaryFiles = _getLicenseBinaryFiles();
+
+				Assert.assertEquals(
+					Arrays.toString(binaryFiles), App.values().length + 1,
+					binaryFiles.length);
+			}
+		}
 	}
 
 	private void _testAppLicensesWithPortalLicense(boolean freeTier)

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
@@ -1,0 +1,141 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.license.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.license.util.App;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.util.LicenseUtil;
+
+import java.io.File;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Kevin Lee
+ */
+@RunWith(Arquillian.class)
+public class CombinedLicenseTest extends BaseLicenseTestCase {
+
+	@BeforeClass
+	public static void setUpClass() {
+		_disableKeyValidatorSafeCloseable = disableValidateWithSafeCloseable();
+		_setVersionSafeCloseable = setVersionWithSafeCloseable("2026.Q1.0 LTS");
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_disableKeyValidatorSafeCloseable.close();
+		_setVersionSafeCloseable.close();
+	}
+
+	@Test
+	public void testAppLicensesWithPortalLicenseEnterprise() throws Exception {
+		_testAppLicensesWithPortalLicense(false);
+	}
+
+	@Test
+	public void testAppLicensesWithPortalLicenseFreeTier() throws Exception {
+		_testAppLicensesWithPortalLicense(true);
+	}
+
+	private File[] _deployCombinedLicense(Collection<String> licenseXMLs)
+		throws Exception {
+
+		registerLicense(
+			StringBundler.concat(
+				"<licenses>", StringUtil.merge(licenseXMLs, StringPool.BLANK),
+				"</licenses>"));
+
+		return new File(
+			LicenseUtil.LICENSE_REPOSITORY_DIR
+		).listFiles(
+			(dirFile, name) -> name.endsWith(".li")
+		);
+	}
+
+	private void _testAppLicensesWithPortalLicense(boolean freeTier)
+		throws Exception {
+
+		Map<App, String[]> appSymbolicNamesMap = new HashMap<>();
+
+		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
+			assertLicensePropertiesNotExisted(getPortalProductId());
+
+			for (App app : App.values()) {
+				String[] appSymbolicNames = getAppSymbolicNames(app);
+
+				Assert.assertFalse(
+					Arrays.toString(appSymbolicNames),
+					ArrayUtil.isEmpty(appSymbolicNames));
+
+				assertLicensePropertiesNotExisted(getProductId(app));
+
+				assertBundlesExisted(appSymbolicNames);
+
+				appSymbolicNamesMap.put(app, appSymbolicNames);
+			}
+
+			assertPortalLicenseNotRegistered();
+
+			List<String> licenseXMLs = new ArrayList<>();
+
+			if (freeTier) {
+				licenseXMLs.add(buildFreeTierPortalLicenseXML(Time.HOUR));
+			}
+			else {
+				licenseXMLs.add(buildEnterprisePortalLicenseXML(Time.HOUR));
+			}
+
+			long startTime = System.currentTimeMillis();
+
+			for (App app : App.values()) {
+				licenseXMLs.add(buildAppLicenseXML(app, startTime, Time.HOUR));
+			}
+
+			File[] binaryFiles = _deployCombinedLicense(licenseXMLs);
+
+			assertPortalLicenseRegistered();
+
+			assertLicensePropertiesExisted(getPortalProductId());
+
+			for (App app : App.values()) {
+				assertLicensePropertiesExisted(getProductId(app));
+
+				if (freeTier) {
+					assertBundlesNotExisted(appSymbolicNamesMap.get(app));
+				}
+				else {
+					assertBundlesExisted(appSymbolicNamesMap.get(app));
+				}
+			}
+
+			Assert.assertEquals(
+				Arrays.toString(binaryFiles), App.values().length + 1,
+				binaryFiles.length);
+		}
+	}
+
+	private static SafeCloseable _disableKeyValidatorSafeCloseable;
+	private static SafeCloseable _setVersionSafeCloseable;
+
+}

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -56,6 +57,39 @@ public class CombinedLicenseTest extends BaseLicenseTestCase {
 	@Test
 	public void testAppLicensesWithPortalLicenseFreeTier() throws Exception {
 		_testAppLicensesWithPortalLicense(true);
+	}
+
+	@Test
+	public void testNoLicenses() throws Exception {
+		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
+			assertPortalLicenseNotRegistered();
+
+			File[] binaryFiles = _deployCombinedLicense(
+				Collections.emptyList());
+
+			assertPortalLicenseNotRegistered();
+
+			Assert.assertNull(Arrays.toString(binaryFiles), binaryFiles);
+		}
+	}
+
+	@Test
+	public void testSingleLicense() throws Exception {
+		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
+			assertLicensePropertiesNotExisted(getPortalProductId());
+
+			assertPortalLicenseNotRegistered();
+
+			File[] binaryFiles = _deployCombinedLicense(
+				List.of(buildFreeTierPortalLicenseXML(Time.HOUR)));
+
+			assertLicensePropertiesExisted(getPortalProductId());
+
+			assertPortalLicenseRegistered();
+
+			Assert.assertEquals(
+				Arrays.toString(binaryFiles), 1, binaryFiles.length);
+		}
 	}
 
 	private File[] _deployCombinedLicense(Collection<String> licenseXMLs)

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
@@ -75,6 +75,27 @@ public class CombinedLicenseTest extends BaseLicenseTestCase {
 	}
 
 	@Test
+	public void testDuplicateLicenses() throws Exception {
+		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
+			assertLicensePropertiesNotExisted(getPortalProductId());
+
+			assertPortalLicenseNotRegistered();
+
+			File[] binaryFiles = _deployCombinedLicense(
+				List.of(
+					buildFreeTierPortalLicenseXML(Time.HOUR),
+					buildFreeTierPortalLicenseXML(Time.HOUR)));
+
+			assertLicensePropertiesExisted(getPortalProductId());
+
+			assertPortalLicenseRegistered();
+
+			Assert.assertEquals(
+				Arrays.toString(binaryFiles), 1, binaryFiles.length);
+		}
+	}
+
+	@Test
 	public void testNoLicenses() throws Exception {
 		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
 			assertPortalLicenseNotRegistered();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98408

## What Is Being Fixed

The license integration tests only covered a single `<license>` per XML document. There was no coverage for the combined-license format — a `<licenses>` root wrapping multiple `<license>` entries — even though the license manager validates and registers each entry individually.

## How It Is Being Fixed

The single-license XML assembly in `BaseLicenseTestCase` was extracted into reusable `build*LicenseXML` methods (free tier, enterprise, app) and widened in access so tests can compose a document from individual license strings. A new `CombinedLicenseTest` wraps those strings in a `<licenses>` document and registers them, covering: a portal license plus every app license (enterprise activates the app bundles, free tier does not), a single license via the combined wrapper, an empty document, duplicate licenses, an enterprise and a free tier portal license together (enterprise takes precedence), and an expired portal license alongside valid app licenses (the expired entry does not block the others from registering). `AppModuleLicenseTest` was updated to share the extracted helpers.

## PR Check

**pr-check: PASS** — tested on `5c09d1d956e62412fcd31c0b567edd65cb269973`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "5c09d1d956e62412fcd31c0b567edd65cb269973"} -->
