### PR TITLE
LPD-98791 Set the maximum pool size first if it is being increased

### DIFF
--- a/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/BaseAsyncDestination.java
+++ b/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/BaseAsyncDestination.java
@@ -236,11 +236,22 @@ public abstract class BaseAsyncDestination extends BaseDestination {
 		_workersMaxSize = workersMaxSize;
 
 		if (_noticeableThreadPoolExecutor != null) {
-			_noticeableThreadPoolExecutor.setCorePoolSize(workersCoreSize);
+			if (_noticeableThreadPoolExecutor.getMaximumPoolSize() <
+					workersMaxSize) {
 
-			// Invoke setMaximumPoolSize after setCorePoolSize. See LPS-124209.
+				_noticeableThreadPoolExecutor.setMaximumPoolSize(
+					workersMaxSize);
 
-			_noticeableThreadPoolExecutor.setMaximumPoolSize(workersMaxSize);
+				_noticeableThreadPoolExecutor.setCorePoolSize(workersCoreSize);
+			}
+			else {
+				_noticeableThreadPoolExecutor.setCorePoolSize(workersCoreSize);
+
+				// Invoke setMaximumPoolSize after setCorePoolSize. See LPS-124209.
+
+				_noticeableThreadPoolExecutor.setMaximumPoolSize(
+					workersMaxSize);
+			}
 		}
 	}
 

--- a/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/BaseAsyncDestination.java
+++ b/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/BaseAsyncDestination.java
@@ -246,9 +246,6 @@ public abstract class BaseAsyncDestination extends BaseDestination {
 			}
 			else {
 				_noticeableThreadPoolExecutor.setCorePoolSize(workersCoreSize);
-
-				// Invoke setMaximumPoolSize after setCorePoolSize. See LPS-124209.
-
 				_noticeableThreadPoolExecutor.setMaximumPoolSize(
 					workersMaxSize);
 			}

--- a/modules/apps/portal/portal-messaging/src/test/java/com/liferay/portal/messaging/internal/BaseAsyncDestinationTest.java
+++ b/modules/apps/portal/portal-messaging/src/test/java/com/liferay/portal/messaging/internal/BaseAsyncDestinationTest.java
@@ -1,0 +1,60 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.messaging.internal;
+
+import com.liferay.petra.executor.PortalExecutorManager;
+import com.liferay.portal.kernel.messaging.DestinationStatistics;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Eric Yan
+ */
+public class BaseAsyncDestinationTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testSetWorkersSize() {
+		ParallelDestination parallelDestination = new ParallelDestination();
+
+		parallelDestination.setName(RandomTestUtil.randomString());
+		parallelDestination.setPortalExecutorManager(
+			Mockito.mock(PortalExecutorManager.class));
+
+		parallelDestination.open();
+
+		_testSetWorkersSize(parallelDestination, 1, 1);
+		_testSetWorkersSize(parallelDestination, 2, 2);
+		_testSetWorkersSize(parallelDestination, 1, 1);
+	}
+
+	private void _testSetWorkersSize(
+		ParallelDestination parallelDestination, int workersCoreSize,
+		int workersMaxSize) {
+
+		parallelDestination.setWorkersSize(workersCoreSize, workersMaxSize);
+
+		DestinationStatistics destinationStatistics =
+			parallelDestination.getDestinationStatistics();
+
+		Assert.assertEquals(
+			workersCoreSize, destinationStatistics.getMinThreadPoolSize());
+		Assert.assertEquals(
+			workersMaxSize, destinationStatistics.getMaxThreadPoolSize());
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98791

## What Is Being Fixed

Since JDK 9, `ThreadPoolExecutor.setCorePoolSize` throws an `IllegalArgumentException` if the core pool size is greater than the maximum pool size. 

`BaseAsyncDestination.setWorkersSize` invokes `setCorePoolSize` before `setMaximumPoolSize`, so increasing a destination's Worker Core Size above its previously configured Worker Maximum Size would result in an `IllegalArgumentException`.

## How It Is Being Fixed

Set the maximum pool size first when it is being increased; otherwise set the core pool size first.

## PR Check

**pr-check: PASS** — tested on `4ba0ab48424d493aef07ad03fef18c6537d8804f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "4ba0ab48424d493aef07ad03fef18c6537d8804f"} -->