### PR TITLE
LPD-98397 Honor the swapped portlet ID in the fetched portlet wrapper

### DIFF
--- a/modules/apps/portlet/portlet-test/src/testIntegration/java/com/liferay/portlet/test/PortletLocalServiceTest.java
+++ b/modules/apps/portlet/portlet-test/src/testIntegration/java/com/liferay/portlet/test/PortletLocalServiceTest.java
@@ -76,8 +76,10 @@ public class PortletLocalServiceTest {
 					"jakarta.portlet.name", portletName
 				).build()));
 
-		_testFetchPortletById(RandomTestUtil.randomString(), portletName);
-		_testFetchPortletById(null, portletName);
+		_testFetchPortletById(
+			RandomTestUtil.randomString(), portletName,
+			TestPropsValues.getUserId());
+		_testFetchPortletById(null, portletName, 0);
 	}
 
 	@Test
@@ -156,33 +158,48 @@ public class PortletLocalServiceTest {
 			customAttributesDisplays.size());
 	}
 
-	private void _testFetchPortletById(String instanceId, String portletName)
+	private void _testFetchPortletById(
+			String instanceId, String portletName, long userId)
 		throws Exception {
 
-		String portletId = PortletIdCodec.encode(portletName, instanceId);
+		String portletId = PortletIdCodec.encode(
+			portletName, userId, instanceId);
 
-		com.liferay.portal.kernel.model.Portlet portlet =
+		com.liferay.portal.kernel.model.Portlet portlet1 =
 			_portletLocalService.fetchPortletById(
 				TestPropsValues.getCompanyId(), portletId);
 
-		Assert.assertEquals(instanceId, portlet.getInstanceId());
-		Assert.assertEquals(portletId, portlet.getPortletId());
-		Assert.assertEquals(portletName, portlet.getPortletName());
-		Assert.assertTrue(portlet.isInstanceable());
-		Assert.assertFalse(portlet.isStatic());
-		Assert.assertFalse(portlet.isStaticStart());
+		Assert.assertEquals(instanceId, portlet1.getInstanceId());
+		Assert.assertEquals(portletId, portlet1.getPortletId());
+		Assert.assertEquals(portletName, portlet1.getPortletName());
+		Assert.assertTrue(portlet1.getStaticEnd());
+		Assert.assertFalse(portlet1.getStaticStart());
+		Assert.assertEquals(userId, portlet1.getUserId());
+		Assert.assertEquals(portletId.hashCode(), portlet1.hashCode());
+		Assert.assertTrue(portlet1.isInstanceable());
+		Assert.assertFalse(portlet1.isStatic());
+		Assert.assertTrue(portlet1.isStaticEnd());
+		Assert.assertFalse(portlet1.isStaticStart());
 
-		portlet.setStatic(true);
-		portlet.setStaticStart(true);
+		portlet1.setStatic(true);
+		portlet1.setStaticStart(true);
 
-		Assert.assertTrue(portlet.isStatic());
-		Assert.assertTrue(portlet.isStaticStart());
+		Assert.assertFalse(portlet1.getStaticEnd());
+		Assert.assertTrue(portlet1.getStaticStart());
+		Assert.assertTrue(portlet1.isStatic());
+		Assert.assertFalse(portlet1.isStaticEnd());
+		Assert.assertTrue(portlet1.isStaticStart());
 
-		portlet = _portletLocalService.fetchPortletById(
-			TestPropsValues.getCompanyId(), portletId);
+		com.liferay.portal.kernel.model.Portlet portlet2 =
+			_portletLocalService.fetchPortletById(
+				TestPropsValues.getCompanyId(), portletId);
 
-		Assert.assertFalse(portlet.isStatic());
-		Assert.assertFalse(portlet.isStaticStart());
+		Assert.assertEquals(0, portlet1.compareTo(portlet2));
+		Assert.assertEquals(portlet1, portlet2);
+		Assert.assertEquals(portlet1.hashCode(), portlet2.hashCode());
+
+		Assert.assertFalse(portlet2.isStatic());
+		Assert.assertFalse(portlet2.isStaticStart());
 	}
 
 	@Inject

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -508,6 +508,26 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 			portlet = new PortletWrapper(portlet) {
 
 				@Override
+				public int compareTo(Portlet portlet) {
+					return finalPortletId.compareTo(portlet.getPortletId());
+				}
+
+				@Override
+				public boolean equals(Object object) {
+					if (this == object) {
+						return true;
+					}
+
+					if (!(object instanceof Portlet)) {
+						return false;
+					}
+
+					Portlet portlet = (Portlet)object;
+
+					return finalPortletId.equals(portlet.getPortletId());
+				}
+
+				@Override
 				public String getInstanceId() {
 					return PortletIdCodec.decodeInstanceId(finalPortletId);
 				}
@@ -520,6 +540,16 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 				@Override
 				public boolean getStatic() {
 					return _staticPortlet;
+				}
+
+				@Override
+				public long getUserId() {
+					return PortletIdCodec.decodeUserId(finalPortletId);
+				}
+
+				@Override
+				public int hashCode() {
+					return finalPortletId.hashCode();
 				}
 
 				@Override

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -543,6 +543,16 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 				}
 
 				@Override
+				public boolean getStaticEnd() {
+					return !_staticPortletStart;
+				}
+
+				@Override
+				public boolean getStaticStart() {
+					return _staticPortletStart;
+				}
+
+				@Override
 				public long getUserId() {
 					return PortletIdCodec.decodeUserId(finalPortletId);
 				}
@@ -555,6 +565,11 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 				@Override
 				public boolean isStatic() {
 					return _staticPortlet;
+				}
+
+				@Override
+				public boolean isStaticEnd() {
+					return !_staticPortletStart;
 				}
 
 				@Override


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98397

## What Is Being Fixed

`PortletLocalServiceImpl.fetchPortletById` wraps a shared portlet by swapping its portlet ID rather than cloning it (LPD-64147: 318eae37a84ed). 

The wrapper overrode `getPortletId` but not `equals`, `hashCode`, `compareTo`, or `getUserId`, so these fell through to `PortletWrapper` and resolved against the shared portlet's root portlet ID. Similarly, `setStaticStart` and `isStaticStart` already use a local field, but `getStaticStart`, `getStaticEnd`, and `isStaticEnd` fell through to `PortletWrapper` and read the shared portlet's value rather than the wrapper's own.

A fetched instanced portlet therefore did not compare equal to itself in `LayoutTypePortletImpl.addStaticPortlets`, and its static placement was read from the shared portlet during rendering.

## How It Is Being Fixed

Override all four identity methods to resolve against the swapped ID, and the remaining three static getters to read the local field, restoring the parity the full clone had before LPD-64147. `PortletLocalServiceTest` is expanded to assert the wrapper's identity and static state on an instanced, user-scoped portlet ID, failing before the fix and passing after.

## PR Check

**pr-check: PASS** — tested on `82fc35ea77638`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "82fc35ea77638308471f508e4fb1fe1c52193623"} -->
