### PR TITLE
LPD-98408 Add integration tests for combined license scenarios

### DIFF
--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/AppModuleLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/AppModuleLicenseTest.java
@@ -9,25 +9,18 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.license.util.App;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
-import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
 
 import java.io.File;
 
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 
 /**
  * @author Kevin Lee
@@ -61,27 +54,9 @@ public class AppModuleLicenseTest extends BaseLicenseTestCase {
 		}
 	}
 
-	private String[] _getAppSymbolicNames(App app) {
-		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
-
-		List<String> symbolicNames = new ArrayList<>();
-
-		for (Bundle bundle : bundleContext.getBundles()) {
-			String symbolicName = bundle.getSymbolicName();
-
-			if (symbolicName.contains(
-					"." + StringUtil.toLowerCase(app.toString()) + ".")) {
-
-				symbolicNames.add(symbolicName);
-			}
-		}
-
-		return ArrayUtil.toStringArray(symbolicNames);
-	}
-
 	private void _testEnterpriseLicense(App app) throws Exception {
 		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
-			String[] appSymbolicNames = _getAppSymbolicNames(app);
+			String[] appSymbolicNames = getAppSymbolicNames(app);
 
 			Assert.assertFalse(
 				appSymbolicNames.toString(),
@@ -141,7 +116,7 @@ public class AppModuleLicenseTest extends BaseLicenseTestCase {
 
 	private void _testFreeTierLicense(App app) throws Exception {
 		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
-			String[] appSymbolicNames = _getAppSymbolicNames(app);
+			String[] appSymbolicNames = getAppSymbolicNames(app);
 
 			Assert.assertFalse(
 				appSymbolicNames.toString(),

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
@@ -85,28 +85,12 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		Assume.assumeTrue(isReleaseBundle());
 	}
 
-	public static File deployFreeTierPortalLicense(long validityPeriod)
-		throws Exception {
-
-		return deployFreeTierPortalLicense(
-			_FREE_TIER_DOMAIN, StringPool.BLANK, validityPeriod);
-	}
-
-	public static File deployFreeTierPortalLicense(
-			String domain, long validityPeriod)
-		throws Exception {
-
-		return deployFreeTierPortalLicense(
-			domain, StringPool.BLANK, validityPeriod);
-	}
-
-	public static File deployFreeTierPortalLicense(
-			String domain, String key, long validityPeriod)
-		throws Exception {
+	public static String buildFreeTierPortalLicenseXML(
+		String domain, String key, long validityPeriod) {
 
 		StringBundler sb = new StringBundler(20);
 
-		sb.append("<?xml version=\"1.0\"?><license><account-name>");
+		sb.append("<license><account-name>");
 		sb.append(_FREE_TIER_ACCOUNT_NAME);
 		sb.append("</account-name><product-id>");
 		sb.append(getPortalProductId());
@@ -131,7 +115,30 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		sb.append(key);
 		sb.append("</key></license>");
 
-		_registerLicense(sb.toString());
+		return sb.toString();
+	}
+
+	public static File deployFreeTierPortalLicense(long validityPeriod)
+		throws Exception {
+
+		return deployFreeTierPortalLicense(
+			_FREE_TIER_DOMAIN, StringPool.BLANK, validityPeriod);
+	}
+
+	public static File deployFreeTierPortalLicense(
+			String domain, long validityPeriod)
+		throws Exception {
+
+		return deployFreeTierPortalLicense(
+			domain, StringPool.BLANK, validityPeriod);
+	}
+
+	public static File deployFreeTierPortalLicense(
+			String domain, String key, long validityPeriod)
+		throws Exception {
+
+		_registerLicense(
+			buildFreeTierPortalLicenseXML(domain, key, validityPeriod));
 
 		return _buildBinaryFile(
 			getPortalProductId(), _FREE_TIER_ACCOUNT_NAME,
@@ -245,19 +252,12 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		Assert.assertFalse(response.contains(_LICENSE_PAGE_KEY));
 	}
 
-	public File deployAppLicense(App app, long validityPeriod)
-		throws Exception {
-
-		return deployAppLicense(
-			app, System.currentTimeMillis(), validityPeriod);
-	}
-
-	public File deployAppLicense(App app, long startTime, long validityPeriod)
-		throws Exception {
+	public String buildAppLicenseXML(
+		App app, long startTime, long validityPeriod) {
 
 		StringBundler sb = new StringBundler(19);
 
-		sb.append("<?xml version=\"1.0\"?><license><product-id>");
+		sb.append("<license><product-id>");
 		sb.append(getProductId(app));
 		sb.append("</product-id><product-name>");
 		sb.append(app);
@@ -289,21 +289,15 @@ public abstract class BaseLicenseTestCase implements Serializable {
 
 		sb.append("</mac-addresses><key></key></license>");
 
-		_registerLicense(sb.toString());
-
-		return _buildBinaryFile(
-			getProductId(app), StringPool.BLANK, app.toString(),
-			_APP_LICENSE_TYPE);
+		return sb.toString();
 	}
 
-	public File deployEnterprisePortalLicense(long validityPeriod)
-		throws Exception {
-
+	public String buildEnterprisePortalLicenseXML(long validityPeriod) {
 		long currentTimeMillis = System.currentTimeMillis();
 
 		StringBundler sb = new StringBundler(19);
 
-		sb.append("<?xml version=\"1.0\"?><license><account-name>");
+		sb.append("<license><account-name>");
 		sb.append(_ENTERPRISE_ACCOUNT_NAME);
 		sb.append("</account-name><product-id>");
 		sb.append(getPortalProductId());
@@ -324,7 +318,30 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		sb.append("</domain><domain>localhost</domain></domains>");
 		sb.append("<key></key></license>");
 
-		_registerLicense(sb.toString());
+		return sb.toString();
+	}
+
+	public File deployAppLicense(App app, long validityPeriod)
+		throws Exception {
+
+		return deployAppLicense(
+			app, System.currentTimeMillis(), validityPeriod);
+	}
+
+	public File deployAppLicense(App app, long startTime, long validityPeriod)
+		throws Exception {
+
+		_registerLicense(buildAppLicenseXML(app, startTime, validityPeriod));
+
+		return _buildBinaryFile(
+			getProductId(app), StringPool.BLANK, app.toString(),
+			_APP_LICENSE_TYPE);
+	}
+
+	public File deployEnterprisePortalLicense(long validityPeriod)
+		throws Exception {
+
+		_registerLicense(buildEnterprisePortalLicenseXML(validityPeriod));
 
 		return _buildBinaryFile(
 			getPortalProductId(), _ENTERPRISE_ACCOUNT_NAME,
@@ -625,7 +642,8 @@ public abstract class BaseLicenseTestCase implements Serializable {
 				_licensePackageName, LoggerTestUtil.ALL)) {
 
 			LicenseManagerUtil.registerLicense(
-				JSONUtil.put("licenseXML", licenseXML));
+				JSONUtil.put(
+					"licenseXML", "<?xml version=\"1.0\"?>" + licenseXML));
 
 			_throwLogEntriesException(logCapture, null, LoggerTestUtil.ERROR);
 		}

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
@@ -86,44 +86,6 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		Assume.assumeTrue(isReleaseBundle());
 	}
 
-	public static String buildFreeTierPortalLicenseXML(long validityPeriod) {
-		return buildFreeTierPortalLicenseXML(
-			_FREE_TIER_DOMAIN, StringPool.BLANK, validityPeriod);
-	}
-
-	public static String buildFreeTierPortalLicenseXML(
-		String domain, String key, long validityPeriod) {
-
-		StringBundler sb = new StringBundler(20);
-
-		sb.append("<license><account-name>");
-		sb.append(_FREE_TIER_ACCOUNT_NAME);
-		sb.append("</account-name><product-id>");
-		sb.append(getPortalProductId());
-		sb.append("</product-id><product-name>");
-		sb.append(_FREE_TIER_PRODUCT_NAME);
-		sb.append("</product-name><product-version>2026.Q1</product-version>");
-		sb.append("<license-type>");
-		sb.append(_FREE_TIER_LICENSE_TYPE);
-		sb.append("</license-type><license-version>6</license-version>");
-		sb.append("<start-date>");
-
-		long startTime = System.currentTimeMillis();
-
-		sb.append(_DATE_FORMAT.format(new Date(startTime)));
-
-		sb.append("</start-date><expiration-date>");
-		sb.append(_DATE_FORMAT.format(new Date(startTime + validityPeriod)));
-		sb.append("</expiration-date>");
-		sb.append("<max-cluster-nodes>3</max-cluster-nodes><domains><domain>");
-		sb.append(domain);
-		sb.append("</domain><domain>localhost</domain></domains><key>");
-		sb.append(key);
-		sb.append("</key></license>");
-
-		return sb.toString();
-	}
-
 	public static File deployFreeTierPortalLicense(long validityPeriod)
 		throws Exception {
 
@@ -143,12 +105,43 @@ public abstract class BaseLicenseTestCase implements Serializable {
 			String domain, String key, long validityPeriod)
 		throws Exception {
 
-		registerLicense(
-			buildFreeTierPortalLicenseXML(domain, key, validityPeriod));
+		_registerLicense(
+			_buildFreeTierPortalLicenseXML(domain, key, validityPeriod));
 
-		return buildBinaryFile(
+		return _buildBinaryFile(
 			getPortalProductId(), _FREE_TIER_ACCOUNT_NAME,
-			_FREE_TIER_PRODUCT_NAME, _FREE_TIER_LICENSE_TYPE);
+			_FREE_TIER_PRODUCT_NAME, FREE_TIER_LICENSE_TYPE);
+	}
+
+	public static void deployLicenses(String[][] licenses) throws Exception {
+		StringBundler sb = new StringBundler();
+
+		sb.append("<licenses>");
+
+		for (String[] license : licenses) {
+			if (Objects.equals(license[0], ENTERPRISE_LICENSE_TYPE)) {
+				sb.append(
+					_buildEnterprisePortalLicenseXML(Long.valueOf(license[1])));
+			}
+			else if (Objects.equals(license[0], FREE_TIER_LICENSE_TYPE)) {
+				sb.append(
+					_buildFreeTierPortalLicenseXML(
+						_FREE_TIER_DOMAIN, StringPool.BLANK,
+						Long.valueOf(license[1])));
+			}
+			else {
+				App app = App.valueOf(license[0]);
+
+				sb.append(
+					_buildAppLicenseXML(
+						app, System.currentTimeMillis(),
+						Long.valueOf(license[1])));
+			}
+		}
+
+		sb.append("</licenses>");
+
+		_registerLicense(sb.toString());
 	}
 
 	public static SafeCloseable disableValidateWithSafeCloseable() {
@@ -258,75 +251,6 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		Assert.assertFalse(response.contains(_LICENSE_PAGE_KEY));
 	}
 
-	public String buildAppLicenseXML(
-		App app, long startTime, long validityPeriod) {
-
-		StringBundler sb = new StringBundler(19);
-
-		sb.append("<license><product-id>");
-		sb.append(getProductId(app));
-		sb.append("</product-id><product-name>");
-		sb.append(app);
-		sb.append("</product-name><product-version>2026.Q1</product-version>");
-		sb.append("<license-type>");
-		sb.append(_APP_LICENSE_TYPE);
-		sb.append("</license-type><license-version>3</license-version>");
-		sb.append("<start-date>");
-		sb.append(_DATE_FORMAT.format(new Date(startTime)));
-		sb.append("</start-date><expiration-date>");
-		sb.append(_DATE_FORMAT.format(new Date(startTime + validityPeriod)));
-		sb.append("</expiration-date><host-names>");
-		sb.append("<host-name>localhost</host-name>");
-		sb.append("</host-names><ip-addresses>");
-
-		for (String localIpAddress : LicenseUtil.getIpAddresses()) {
-			sb.append("<ip-address>");
-			sb.append(localIpAddress);
-			sb.append("</ip-address>");
-		}
-
-		sb.append("</ip-addresses><mac-addresses>");
-
-		for (String localMacAddress : LicenseUtil.getMacAddresses()) {
-			sb.append("<mac-address>");
-			sb.append(localMacAddress);
-			sb.append("</mac-address>");
-		}
-
-		sb.append("</mac-addresses><key></key></license>");
-
-		return sb.toString();
-	}
-
-	public String buildEnterprisePortalLicenseXML(long validityPeriod) {
-		long currentTimeMillis = System.currentTimeMillis();
-
-		StringBundler sb = new StringBundler(19);
-
-		sb.append("<license><account-name>");
-		sb.append(_ENTERPRISE_ACCOUNT_NAME);
-		sb.append("</account-name><product-id>");
-		sb.append(getPortalProductId());
-		sb.append("</product-id><product-name>");
-		sb.append(_ENTERPRISE_PRODUCT_NAME);
-		sb.append("</product-name><product-version>2026.Q1</product-version>");
-		sb.append("<license-type>");
-		sb.append(_ENTERPRISE_LICENSE_TYPE);
-		sb.append("</license-type><license-version>6</license-version>");
-		sb.append("<start-date>");
-		sb.append(_DATE_FORMAT.format(new Date(currentTimeMillis)));
-		sb.append("</start-date><expiration-date>");
-		sb.append(
-			_DATE_FORMAT.format(new Date(currentTimeMillis + validityPeriod)));
-		sb.append("</expiration-date>");
-		sb.append("<domains><domain>");
-		sb.append(_ENTERPRISE_DOMAIN);
-		sb.append("</domain><domain>localhost</domain></domains>");
-		sb.append("<key></key></license>");
-
-		return sb.toString();
-	}
-
 	public File deployAppLicense(App app, long validityPeriod)
 		throws Exception {
 
@@ -337,9 +261,9 @@ public abstract class BaseLicenseTestCase implements Serializable {
 	public File deployAppLicense(App app, long startTime, long validityPeriod)
 		throws Exception {
 
-		registerLicense(buildAppLicenseXML(app, startTime, validityPeriod));
+		_registerLicense(_buildAppLicenseXML(app, startTime, validityPeriod));
 
-		return buildBinaryFile(
+		return _buildBinaryFile(
 			getProductId(app), StringPool.BLANK, app.toString(),
 			_APP_LICENSE_TYPE);
 	}
@@ -347,11 +271,11 @@ public abstract class BaseLicenseTestCase implements Serializable {
 	public File deployEnterprisePortalLicense(long validityPeriod)
 		throws Exception {
 
-		registerLicense(buildEnterprisePortalLicenseXML(validityPeriod));
+		_registerLicense(_buildEnterprisePortalLicenseXML(validityPeriod));
 
-		return buildBinaryFile(
+		return _buildBinaryFile(
 			getPortalProductId(), _ENTERPRISE_ACCOUNT_NAME,
-			_ENTERPRISE_PRODUCT_NAME, _ENTERPRISE_LICENSE_TYPE);
+			_ENTERPRISE_PRODUCT_NAME, ENTERPRISE_LICENSE_TYPE);
 	}
 
 	public void resetCheckInterval() throws Exception {
@@ -505,25 +429,6 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		}
 	}
 
-	protected static File buildBinaryFile(
-		String productId, String accountName, String productEntryName,
-		String licenseType) {
-
-		StringBundler sb = new StringBundler(6);
-
-		if (productId.equals(getPortalProductId())) {
-			sb.append(StringUtil.extractChars(accountName));
-			sb.append("_");
-		}
-
-		sb.append(StringUtil.extractChars(productEntryName));
-		sb.append("_");
-		sb.append(StringUtil.extractChars(licenseType));
-		sb.append(".li");
-
-		return new File(LicenseUtil.LICENSE_REPOSITORY_DIR, sb.toString());
-	}
-
 	protected static Field findField(String propertyKey) throws Exception {
 		ClassLoader classLoader = PortalClassLoaderUtil.getClassLoader();
 
@@ -595,6 +500,11 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		return getProperty("product.id.portal");
 	}
 
+	protected static String getProductId(App app) {
+		return getProperty(
+			"product.id." + StringUtil.toLowerCase(app.toString()));
+	}
+
 	protected static String getProperty(String propertyKey) {
 		String value = _licenseTestProperties.getProperty(propertyKey);
 
@@ -609,18 +519,6 @@ public abstract class BaseLicenseTestCase implements Serializable {
 
 	protected static Class<?> getValidateClass() {
 		return ReflectionsHolder._validateClass;
-	}
-
-	protected static void registerLicense(String licenseXML) throws Exception {
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				_licensePackageName, LoggerTestUtil.ALL)) {
-
-			LicenseManagerUtil.registerLicense(
-				JSONUtil.put(
-					"licenseXML", "<?xml version=\"1.0\"?>" + licenseXML));
-
-			_throwLogEntriesException(logCapture, null, LoggerTestUtil.ERROR);
-		}
 	}
 
 	protected void checkLicense(String productId) throws Exception {
@@ -649,11 +547,6 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		return localPort;
 	}
 
-	protected String getProductId(App app) {
-		return getProperty(
-			"product.id." + StringUtil.toLowerCase(app.toString()));
-	}
-
 	protected String hitHomePage(String host, int port) throws Exception {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				_lifecycleActionClass.getName(), LoggerTestUtil.ALL)) {
@@ -670,6 +563,145 @@ public abstract class BaseLicenseTestCase implements Serializable {
 				logCapture, response, LoggerTestUtil.DEBUG);
 
 			return response;
+		}
+	}
+
+	protected static final String ENTERPRISE_LICENSE_TYPE = "enterprise";
+
+	protected static final String FREE_TIER_LICENSE_TYPE = "free";
+
+	private static String _buildAppLicenseXML(
+		App app, long startTime, long validityPeriod) {
+
+		StringBundler sb = new StringBundler(19);
+
+		sb.append("<license><product-id>");
+		sb.append(getProductId(app));
+		sb.append("</product-id><product-name>");
+		sb.append(app);
+		sb.append("</product-name><product-version>2026.Q1</product-version>");
+		sb.append("<license-type>");
+		sb.append(_APP_LICENSE_TYPE);
+		sb.append("</license-type><license-version>3</license-version>");
+		sb.append("<start-date>");
+		sb.append(_DATE_FORMAT.format(new Date(startTime)));
+		sb.append("</start-date><expiration-date>");
+		sb.append(_DATE_FORMAT.format(new Date(startTime + validityPeriod)));
+		sb.append("</expiration-date><host-names>");
+		sb.append("<host-name>localhost</host-name>");
+		sb.append("</host-names><ip-addresses>");
+
+		for (String localIpAddress : LicenseUtil.getIpAddresses()) {
+			sb.append("<ip-address>");
+			sb.append(localIpAddress);
+			sb.append("</ip-address>");
+		}
+
+		sb.append("</ip-addresses><mac-addresses>");
+
+		for (String localMacAddress : LicenseUtil.getMacAddresses()) {
+			sb.append("<mac-address>");
+			sb.append(localMacAddress);
+			sb.append("</mac-address>");
+		}
+
+		sb.append("</mac-addresses><key></key></license>");
+
+		return sb.toString();
+	}
+
+	private static File _buildBinaryFile(
+		String productId, String accountName, String productEntryName,
+		String licenseType) {
+
+		StringBundler sb = new StringBundler(6);
+
+		if (productId.equals(getPortalProductId())) {
+			sb.append(StringUtil.extractChars(accountName));
+			sb.append("_");
+		}
+
+		sb.append(StringUtil.extractChars(productEntryName));
+		sb.append("_");
+		sb.append(StringUtil.extractChars(licenseType));
+		sb.append(".li");
+
+		return new File(LicenseUtil.LICENSE_REPOSITORY_DIR, sb.toString());
+	}
+
+	private static String _buildEnterprisePortalLicenseXML(
+		long validityPeriod) {
+
+		long currentTimeMillis = System.currentTimeMillis();
+
+		StringBundler sb = new StringBundler(19);
+
+		sb.append("<license><account-name>");
+		sb.append(_ENTERPRISE_ACCOUNT_NAME);
+		sb.append("</account-name><product-id>");
+		sb.append(getPortalProductId());
+		sb.append("</product-id><product-name>");
+		sb.append(_ENTERPRISE_PRODUCT_NAME);
+		sb.append("</product-name><product-version>2026.Q1</product-version>");
+		sb.append("<license-type>");
+		sb.append(ENTERPRISE_LICENSE_TYPE);
+		sb.append("</license-type><license-version>6</license-version>");
+		sb.append("<start-date>");
+		sb.append(_DATE_FORMAT.format(new Date(currentTimeMillis)));
+		sb.append("</start-date><expiration-date>");
+		sb.append(
+			_DATE_FORMAT.format(new Date(currentTimeMillis + validityPeriod)));
+		sb.append("</expiration-date>");
+		sb.append("<domains><domain>");
+		sb.append(_ENTERPRISE_DOMAIN);
+		sb.append("</domain><domain>localhost</domain></domains>");
+		sb.append("<key></key></license>");
+
+		return sb.toString();
+	}
+
+	private static String _buildFreeTierPortalLicenseXML(
+		String domain, String key, long validityPeriod) {
+
+		StringBundler sb = new StringBundler(20);
+
+		sb.append("<license><account-name>");
+		sb.append(_FREE_TIER_ACCOUNT_NAME);
+		sb.append("</account-name><product-id>");
+		sb.append(getPortalProductId());
+		sb.append("</product-id><product-name>");
+		sb.append(_FREE_TIER_PRODUCT_NAME);
+		sb.append("</product-name><product-version>2026.Q1</product-version>");
+		sb.append("<license-type>");
+		sb.append(FREE_TIER_LICENSE_TYPE);
+		sb.append("</license-type><license-version>6</license-version>");
+		sb.append("<start-date>");
+
+		long startTime = System.currentTimeMillis();
+
+		sb.append(_DATE_FORMAT.format(new Date(startTime)));
+
+		sb.append("</start-date><expiration-date>");
+		sb.append(_DATE_FORMAT.format(new Date(startTime + validityPeriod)));
+		sb.append("</expiration-date>");
+		sb.append("<max-cluster-nodes>3</max-cluster-nodes><domains><domain>");
+		sb.append(domain);
+		sb.append("</domain><domain>localhost</domain></domains><key>");
+		sb.append(key);
+		sb.append("</key></license>");
+
+		return sb.toString();
+	}
+
+	private static void _registerLicense(String licenseXML) throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_licensePackageName, LoggerTestUtil.ALL)) {
+
+			LicenseManagerUtil.registerLicense(
+				JSONUtil.put(
+					"licenseXML", "<?xml version=\"1.0\"?>" + licenseXML));
+
+			_throwLogEntriesException(logCapture, null, LoggerTestUtil.ERROR);
 		}
 	}
 
@@ -735,8 +767,6 @@ public abstract class BaseLicenseTestCase implements Serializable {
 
 	private static final String _ENTERPRISE_DOMAIN = "enterprise.com";
 
-	private static final String _ENTERPRISE_LICENSE_TYPE = "enterprise";
-
 	private static final String _ENTERPRISE_PRODUCT_NAME = "DXP Enterprise";
 
 	private static final String _EXPIRED_LICENSE_KEY =
@@ -745,8 +775,6 @@ public abstract class BaseLicenseTestCase implements Serializable {
 	private static final String _FREE_TIER_ACCOUNT_NAME = "Free Account";
 
 	private static final String _FREE_TIER_DOMAIN = "free.tier.com";
-
-	private static final String _FREE_TIER_LICENSE_TYPE = "free";
 
 	private static final String _FREE_TIER_PRODUCT_NAME = "DXP Production";
 

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.AssumeTestRule;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
@@ -561,6 +562,24 @@ public abstract class BaseLicenseTestCase implements Serializable {
 
 		return ReflectionTestUtil.getMethod(
 			classLoader.loadClass(className), methodSimpleName, parameterTypes);
+	}
+
+	protected static String[] getAppSymbolicNames(App app) {
+		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+
+		List<String> symbolicNames = new ArrayList<>();
+
+		for (Bundle bundle : bundleContext.getBundles()) {
+			String symbolicName = bundle.getSymbolicName();
+
+			if (symbolicName.contains(
+					"." + StringUtil.toLowerCase(app.toString()) + ".")) {
+
+				symbolicNames.add(symbolicName);
+			}
+		}
+
+		return ArrayUtil.toStringArray(symbolicNames);
 	}
 
 	protected static String getDateString(Date date) {

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
@@ -86,6 +86,11 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		Assume.assumeTrue(isReleaseBundle());
 	}
 
+	public static String buildFreeTierPortalLicenseXML(long validityPeriod) {
+		return buildFreeTierPortalLicenseXML(
+			_FREE_TIER_DOMAIN, StringPool.BLANK, validityPeriod);
+	}
+
 	public static String buildFreeTierPortalLicenseXML(
 		String domain, String key, long validityPeriod) {
 

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
@@ -137,10 +137,10 @@ public abstract class BaseLicenseTestCase implements Serializable {
 			String domain, String key, long validityPeriod)
 		throws Exception {
 
-		_registerLicense(
+		registerLicense(
 			buildFreeTierPortalLicenseXML(domain, key, validityPeriod));
 
-		return _buildBinaryFile(
+		return buildBinaryFile(
 			getPortalProductId(), _FREE_TIER_ACCOUNT_NAME,
 			_FREE_TIER_PRODUCT_NAME, _FREE_TIER_LICENSE_TYPE);
 	}
@@ -331,9 +331,9 @@ public abstract class BaseLicenseTestCase implements Serializable {
 	public File deployAppLicense(App app, long startTime, long validityPeriod)
 		throws Exception {
 
-		_registerLicense(buildAppLicenseXML(app, startTime, validityPeriod));
+		registerLicense(buildAppLicenseXML(app, startTime, validityPeriod));
 
-		return _buildBinaryFile(
+		return buildBinaryFile(
 			getProductId(app), StringPool.BLANK, app.toString(),
 			_APP_LICENSE_TYPE);
 	}
@@ -341,9 +341,9 @@ public abstract class BaseLicenseTestCase implements Serializable {
 	public File deployEnterprisePortalLicense(long validityPeriod)
 		throws Exception {
 
-		_registerLicense(buildEnterprisePortalLicenseXML(validityPeriod));
+		registerLicense(buildEnterprisePortalLicenseXML(validityPeriod));
 
-		return _buildBinaryFile(
+		return buildBinaryFile(
 			getPortalProductId(), _ENTERPRISE_ACCOUNT_NAME,
 			_ENTERPRISE_PRODUCT_NAME, _ENTERPRISE_LICENSE_TYPE);
 	}
@@ -499,6 +499,25 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		}
 	}
 
+	protected static File buildBinaryFile(
+		String productId, String accountName, String productEntryName,
+		String licenseType) {
+
+		StringBundler sb = new StringBundler(6);
+
+		if (productId.equals(getPortalProductId())) {
+			sb.append(StringUtil.extractChars(accountName));
+			sb.append("_");
+		}
+
+		sb.append(StringUtil.extractChars(productEntryName));
+		sb.append("_");
+		sb.append(StringUtil.extractChars(licenseType));
+		sb.append(".li");
+
+		return new File(LicenseUtil.LICENSE_REPOSITORY_DIR, sb.toString());
+	}
+
 	protected static Field findField(String propertyKey) throws Exception {
 		ClassLoader classLoader = PortalClassLoaderUtil.getClassLoader();
 
@@ -568,6 +587,18 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		return ReflectionsHolder._validateClass;
 	}
 
+	protected static void registerLicense(String licenseXML) throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_licensePackageName, LoggerTestUtil.ALL)) {
+
+			LicenseManagerUtil.registerLicense(
+				JSONUtil.put(
+					"licenseXML", "<?xml version=\"1.0\"?>" + licenseXML));
+
+			_throwLogEntriesException(logCapture, null, LoggerTestUtil.ERROR);
+		}
+	}
+
 	protected void checkLicense(String productId) throws Exception {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				_licensePackageName, LoggerTestUtil.ALL)) {
@@ -615,37 +646,6 @@ public abstract class BaseLicenseTestCase implements Serializable {
 				logCapture, response, LoggerTestUtil.DEBUG);
 
 			return response;
-		}
-	}
-
-	private static File _buildBinaryFile(
-		String productId, String accountName, String productEntryName,
-		String licenseType) {
-
-		StringBundler sb = new StringBundler(6);
-
-		if (productId.equals(getPortalProductId())) {
-			sb.append(StringUtil.extractChars(accountName));
-			sb.append("_");
-		}
-
-		sb.append(StringUtil.extractChars(productEntryName));
-		sb.append("_");
-		sb.append(StringUtil.extractChars(licenseType));
-		sb.append(".li");
-
-		return new File(LicenseUtil.LICENSE_REPOSITORY_DIR, sb.toString());
-	}
-
-	private static void _registerLicense(String licenseXML) throws Exception {
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				_licensePackageName, LoggerTestUtil.ALL)) {
-
-			LicenseManagerUtil.registerLicense(
-				JSONUtil.put(
-					"licenseXML", "<?xml version=\"1.0\"?>" + licenseXML));
-
-			_throwLogEntriesException(logCapture, null, LoggerTestUtil.ERROR);
 		}
 	}
 

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
@@ -93,6 +93,27 @@ public class CombinedLicenseTest extends BaseLicenseTestCase {
 	}
 
 	@Test
+	public void testPortalLicensesEnterpriseAndFreeTier() throws Exception {
+		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
+			assertPortalLicenseNotRegistered();
+
+			File[] binaryFiles = _deployCombinedLicense(
+				List.of(
+					buildEnterprisePortalLicenseXML(Time.HOUR),
+					buildFreeTierPortalLicenseXML(Time.HOUR)));
+
+			assertLicensePropertiesExisted(getPortalProductId());
+
+			assertPortalLicenseRegistered();
+
+			Assert.assertEquals(
+				Arrays.toString(binaryFiles), 2, binaryFiles.length);
+
+			Assert.assertFalse(LicenseManagerUtil.isFreeTier());
+		}
+	}
+
+	@Test
 	public void testSingleLicense() throws Exception {
 		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
 			assertLicensePropertiesNotExisted(getPortalProductId());

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
@@ -58,6 +58,27 @@ public class CombinedLicenseTest extends BaseLicenseTestCase {
 	}
 
 	@Test
+	public void testDuplicateLicenses() throws Exception {
+		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
+			assertLicensePropertiesNotExisted(getPortalProductId());
+
+			assertPortalLicenseNotRegistered();
+
+			File[] binaryFiles = _deployCombinedLicense(
+				List.of(
+					buildFreeTierPortalLicenseXML(Time.HOUR),
+					buildFreeTierPortalLicenseXML(Time.HOUR)));
+
+			assertLicensePropertiesExisted(getPortalProductId());
+
+			assertPortalLicenseRegistered();
+
+			Assert.assertEquals(
+				Arrays.toString(binaryFiles), 1, binaryFiles.length);
+		}
+	}
+
+	@Test
 	public void testNoLicenses() throws Exception {
 		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
 			assertPortalLicenseNotRegistered();

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
@@ -7,20 +7,11 @@ package com.liferay.portal.license.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.lang.SafeCloseable;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.license.util.App;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
-import com.liferay.portal.util.LicenseUtil;
-
-import java.io.File;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.AfterClass;
@@ -64,17 +55,15 @@ public class CombinedLicenseTest extends BaseLicenseTestCase {
 
 			assertPortalLicenseNotRegistered();
 
-			File[] binaryFiles = _deployCombinedLicense(
-				List.of(
-					buildFreeTierPortalLicenseXML(Time.HOUR),
-					buildFreeTierPortalLicenseXML(Time.HOUR)));
+			deployLicenses(
+				new String[][] {
+					{FREE_TIER_LICENSE_TYPE, String.valueOf(Time.HOUR)},
+					{FREE_TIER_LICENSE_TYPE, String.valueOf(Time.HOUR)}
+				});
 
 			assertLicensePropertiesExisted(getPortalProductId());
 
 			assertPortalLicenseRegistered();
-
-			Assert.assertEquals(
-				Arrays.toString(binaryFiles), 1, binaryFiles.length);
 		}
 	}
 
@@ -83,12 +72,9 @@ public class CombinedLicenseTest extends BaseLicenseTestCase {
 		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
 			assertPortalLicenseNotRegistered();
 
-			File[] binaryFiles = _deployCombinedLicense(
-				Collections.emptyList());
+			deployLicenses(new String[0][]);
 
 			assertPortalLicenseNotRegistered();
-
-			Assert.assertNull(Arrays.toString(binaryFiles), binaryFiles);
 		}
 	}
 
@@ -97,17 +83,15 @@ public class CombinedLicenseTest extends BaseLicenseTestCase {
 		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
 			assertPortalLicenseNotRegistered();
 
-			File[] binaryFiles = _deployCombinedLicense(
-				List.of(
-					buildEnterprisePortalLicenseXML(Time.HOUR),
-					buildFreeTierPortalLicenseXML(Time.HOUR)));
+			deployLicenses(
+				new String[][] {
+					{ENTERPRISE_LICENSE_TYPE, String.valueOf(Time.HOUR)},
+					{FREE_TIER_LICENSE_TYPE, String.valueOf(Time.HOUR)}
+				});
 
 			assertLicensePropertiesExisted(getPortalProductId());
 
 			assertPortalLicenseRegistered();
-
-			Assert.assertEquals(
-				Arrays.toString(binaryFiles), 2, binaryFiles.length);
 
 			Assert.assertFalse(LicenseManagerUtil.isFreeTier());
 		}
@@ -120,31 +104,15 @@ public class CombinedLicenseTest extends BaseLicenseTestCase {
 
 			assertPortalLicenseNotRegistered();
 
-			File[] binaryFiles = _deployCombinedLicense(
-				List.of(buildFreeTierPortalLicenseXML(Time.HOUR)));
+			deployLicenses(
+				new String[][] {
+					{FREE_TIER_LICENSE_TYPE, String.valueOf(Time.HOUR)}
+				});
 
 			assertLicensePropertiesExisted(getPortalProductId());
 
 			assertPortalLicenseRegistered();
-
-			Assert.assertEquals(
-				Arrays.toString(binaryFiles), 1, binaryFiles.length);
 		}
-	}
-
-	private File[] _deployCombinedLicense(Collection<String> licenseXMLs)
-		throws Exception {
-
-		registerLicense(
-			StringBundler.concat(
-				"<licenses>", StringUtil.merge(licenseXMLs, StringPool.BLANK),
-				"</licenses>"));
-
-		return new File(
-			LicenseUtil.LICENSE_REPOSITORY_DIR
-		).listFiles(
-			(dirFile, name) -> name.endsWith(".li")
-		);
 	}
 
 	private void _testAppLicensesWithPortalLicense(boolean freeTier)
@@ -159,22 +127,27 @@ public class CombinedLicenseTest extends BaseLicenseTestCase {
 
 			assertPortalLicenseNotRegistered();
 
-			List<String> licenseXMLs = new ArrayList<>();
+			List<String[]> licenses = new ArrayList<>();
 
 			if (freeTier) {
-				licenseXMLs.add(buildFreeTierPortalLicenseXML(Time.HOUR));
+				licenses.add(
+					new String[] {
+						FREE_TIER_LICENSE_TYPE, String.valueOf(Time.HOUR)
+					});
 			}
 			else {
-				licenseXMLs.add(buildEnterprisePortalLicenseXML(Time.HOUR));
+				licenses.add(
+					new String[] {
+						ENTERPRISE_LICENSE_TYPE, String.valueOf(Time.HOUR)
+					});
 			}
-
-			long startTime = System.currentTimeMillis();
 
 			for (App app : App.values()) {
-				licenseXMLs.add(buildAppLicenseXML(app, startTime, Time.HOUR));
+				licenses.add(
+					new String[] {app.name(), String.valueOf(Time.HOUR)});
 			}
 
-			File[] binaryFiles = _deployCombinedLicense(licenseXMLs);
+			deployLicenses(licenses.toArray(new String[0][]));
 
 			assertPortalLicenseRegistered();
 
@@ -190,10 +163,6 @@ public class CombinedLicenseTest extends BaseLicenseTestCase {
 			else {
 				Assert.assertFalse(LicenseManagerUtil.isFreeTier());
 			}
-
-			Assert.assertEquals(
-				Arrays.toString(binaryFiles), App.values().length + 1,
-				binaryFiles.length);
 		}
 	}
 

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.AfterClass;
@@ -54,6 +55,39 @@ public class CombinedLicenseTest extends BaseLicenseTestCase {
 	@Test
 	public void testAppLicensesWithPortalLicenseFreeTier() throws Exception {
 		_testAppLicensesWithPortalLicense(true);
+	}
+
+	@Test
+	public void testNoLicenses() throws Exception {
+		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
+			assertPortalLicenseNotRegistered();
+
+			File[] binaryFiles = _deployCombinedLicense(
+				Collections.emptyList());
+
+			assertPortalLicenseNotRegistered();
+
+			Assert.assertNull(Arrays.toString(binaryFiles), binaryFiles);
+		}
+	}
+
+	@Test
+	public void testSingleLicense() throws Exception {
+		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
+			assertLicensePropertiesNotExisted(getPortalProductId());
+
+			assertPortalLicenseNotRegistered();
+
+			File[] binaryFiles = _deployCombinedLicense(
+				List.of(buildFreeTierPortalLicenseXML(Time.HOUR)));
+
+			assertLicensePropertiesExisted(getPortalProductId());
+
+			assertPortalLicenseRegistered();
+
+			Assert.assertEquals(
+				Arrays.toString(binaryFiles), 1, binaryFiles.length);
+		}
 	}
 
 	private File[] _deployCombinedLicense(Collection<String> licenseXMLs)

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
@@ -1,0 +1,127 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.license.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.license.util.App;
+import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.util.LicenseUtil;
+
+import java.io.File;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Kevin Lee
+ */
+@RunWith(Arquillian.class)
+public class CombinedLicenseTest extends BaseLicenseTestCase {
+
+	@BeforeClass
+	public static void setUpClass() {
+		_disableKeyValidatorSafeCloseable = disableValidateWithSafeCloseable();
+		_setVersionSafeCloseable = setVersionWithSafeCloseable("2026.Q1.0 LTS");
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_disableKeyValidatorSafeCloseable.close();
+		_setVersionSafeCloseable.close();
+	}
+
+	@Test
+	public void testAppLicensesWithPortalLicenseEnterprise() throws Exception {
+		_testAppLicensesWithPortalLicense(false);
+	}
+
+	@Test
+	public void testAppLicensesWithPortalLicenseFreeTier() throws Exception {
+		_testAppLicensesWithPortalLicense(true);
+	}
+
+	private File[] _deployCombinedLicense(Collection<String> licenseXMLs)
+		throws Exception {
+
+		registerLicense(
+			StringBundler.concat(
+				"<licenses>", StringUtil.merge(licenseXMLs, StringPool.BLANK),
+				"</licenses>"));
+
+		return new File(
+			LicenseUtil.LICENSE_REPOSITORY_DIR
+		).listFiles(
+			(dirFile, name) -> name.endsWith(".li")
+		);
+	}
+
+	private void _testAppLicensesWithPortalLicense(boolean freeTier)
+		throws Exception {
+
+		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
+			assertLicensePropertiesNotExisted(getPortalProductId());
+
+			for (App app : App.values()) {
+				assertLicensePropertiesNotExisted(getProductId(app));
+			}
+
+			assertPortalLicenseNotRegistered();
+
+			List<String> licenseXMLs = new ArrayList<>();
+
+			if (freeTier) {
+				licenseXMLs.add(buildFreeTierPortalLicenseXML(Time.HOUR));
+			}
+			else {
+				licenseXMLs.add(buildEnterprisePortalLicenseXML(Time.HOUR));
+			}
+
+			long startTime = System.currentTimeMillis();
+
+			for (App app : App.values()) {
+				licenseXMLs.add(buildAppLicenseXML(app, startTime, Time.HOUR));
+			}
+
+			File[] binaryFiles = _deployCombinedLicense(licenseXMLs);
+
+			assertPortalLicenseRegistered();
+
+			assertLicensePropertiesExisted(getPortalProductId());
+
+			for (App app : App.values()) {
+				assertLicensePropertiesExisted(getProductId(app));
+			}
+
+			if (freeTier) {
+				Assert.assertTrue(LicenseManagerUtil.isFreeTier());
+			}
+			else {
+				Assert.assertFalse(LicenseManagerUtil.isFreeTier());
+			}
+
+			Assert.assertEquals(
+				Arrays.toString(binaryFiles), App.values().length + 1,
+				binaryFiles.length);
+		}
+	}
+
+	private static SafeCloseable _disableKeyValidatorSafeCloseable;
+	private static SafeCloseable _setVersionSafeCloseable;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98408

## What Is Being Fixed

The portal license integration suite had no coverage for deploying a portal license together with app licenses as a single combined license. Edge cases — duplicate licenses, a lone license, no licenses, and an enterprise-plus-free-tier combination — were likewise untested, so regressions in how a combined license is parsed and registered could land unnoticed.

## How It Is Being Fixed

`BaseLicenseTestCase` is refactored so the license-XML-building logic becomes reusable protected static helpers, letting more than one test class construct license payloads. A new `CombinedLicenseTest` then exercises the combined-deployment scenarios: portal and app licenses deployed together under both enterprise and free-tier portal licenses, duplicate licenses, a single license, no licenses, and an enterprise-plus-free-tier pair. Each test asserts the expected license properties and portal-license registration state through the existing `LicenseManagerUtil` API.

## PR Check

**pr-check: PASS** — tested on `05bbee1b11b70148aa12f13f4f407ff39a814963`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "05bbee1b11b70148aa12f13f4f407ff39a814963"} -->
