### PR TITLE
LPD-98408 Add integration tests for combined license files

### DIFF
--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
@@ -85,28 +85,12 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		Assume.assumeTrue(isReleaseBundle());
 	}
 
-	public static File deployFreeTierPortalLicense(long validityPeriod)
-		throws Exception {
-
-		return deployFreeTierPortalLicense(
-			_FREE_TIER_DOMAIN, StringPool.BLANK, validityPeriod);
-	}
-
-	public static File deployFreeTierPortalLicense(
-			String domain, long validityPeriod)
-		throws Exception {
-
-		return deployFreeTierPortalLicense(
-			domain, StringPool.BLANK, validityPeriod);
-	}
-
-	public static File deployFreeTierPortalLicense(
-			String domain, String key, long validityPeriod)
-		throws Exception {
+	public static String buildFreeTierPortalLicenseXML(
+		String domain, String key, long validityPeriod) {
 
 		StringBundler sb = new StringBundler(20);
 
-		sb.append("<?xml version=\"1.0\"?><license><account-name>");
+		sb.append("<license><account-name>");
 		sb.append(_FREE_TIER_ACCOUNT_NAME);
 		sb.append("</account-name><product-id>");
 		sb.append(getPortalProductId());
@@ -131,7 +115,30 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		sb.append(key);
 		sb.append("</key></license>");
 
-		_registerLicense(sb.toString());
+		return sb.toString();
+	}
+
+	public static File deployFreeTierPortalLicense(long validityPeriod)
+		throws Exception {
+
+		return deployFreeTierPortalLicense(
+			_FREE_TIER_DOMAIN, StringPool.BLANK, validityPeriod);
+	}
+
+	public static File deployFreeTierPortalLicense(
+			String domain, long validityPeriod)
+		throws Exception {
+
+		return deployFreeTierPortalLicense(
+			domain, StringPool.BLANK, validityPeriod);
+	}
+
+	public static File deployFreeTierPortalLicense(
+			String domain, String key, long validityPeriod)
+		throws Exception {
+
+		_registerLicense(
+			buildFreeTierPortalLicenseXML(domain, key, validityPeriod));
 
 		return _buildBinaryFile(
 			getPortalProductId(), _FREE_TIER_ACCOUNT_NAME,
@@ -245,19 +252,12 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		Assert.assertFalse(response.contains(_LICENSE_PAGE_KEY));
 	}
 
-	public File deployAppLicense(App app, long validityPeriod)
-		throws Exception {
-
-		return deployAppLicense(
-			app, System.currentTimeMillis(), validityPeriod);
-	}
-
-	public File deployAppLicense(App app, long startTime, long validityPeriod)
-		throws Exception {
+	public String buildAppLicenseXML(
+		App app, long startTime, long validityPeriod) {
 
 		StringBundler sb = new StringBundler(19);
 
-		sb.append("<?xml version=\"1.0\"?><license><product-id>");
+		sb.append("<license><product-id>");
 		sb.append(getProductId(app));
 		sb.append("</product-id><product-name>");
 		sb.append(app);
@@ -289,21 +289,15 @@ public abstract class BaseLicenseTestCase implements Serializable {
 
 		sb.append("</mac-addresses><key></key></license>");
 
-		_registerLicense(sb.toString());
-
-		return _buildBinaryFile(
-			getProductId(app), StringPool.BLANK, app.toString(),
-			_APP_LICENSE_TYPE);
+		return sb.toString();
 	}
 
-	public File deployEnterprisePortalLicense(long validityPeriod)
-		throws Exception {
-
+	public String buildEnterprisePortalLicenseXML(long validityPeriod) {
 		long currentTimeMillis = System.currentTimeMillis();
 
 		StringBundler sb = new StringBundler(19);
 
-		sb.append("<?xml version=\"1.0\"?><license><account-name>");
+		sb.append("<license><account-name>");
 		sb.append(_ENTERPRISE_ACCOUNT_NAME);
 		sb.append("</account-name><product-id>");
 		sb.append(getPortalProductId());
@@ -324,7 +318,30 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		sb.append("</domain><domain>localhost</domain></domains>");
 		sb.append("<key></key></license>");
 
-		_registerLicense(sb.toString());
+		return sb.toString();
+	}
+
+	public File deployAppLicense(App app, long validityPeriod)
+		throws Exception {
+
+		return deployAppLicense(
+			app, System.currentTimeMillis(), validityPeriod);
+	}
+
+	public File deployAppLicense(App app, long startTime, long validityPeriod)
+		throws Exception {
+
+		_registerLicense(buildAppLicenseXML(app, startTime, validityPeriod));
+
+		return _buildBinaryFile(
+			getProductId(app), StringPool.BLANK, app.toString(),
+			_APP_LICENSE_TYPE);
+	}
+
+	public File deployEnterprisePortalLicense(long validityPeriod)
+		throws Exception {
+
+		_registerLicense(buildEnterprisePortalLicenseXML(validityPeriod));
 
 		return _buildBinaryFile(
 			getPortalProductId(), _ENTERPRISE_ACCOUNT_NAME,
@@ -625,7 +642,8 @@ public abstract class BaseLicenseTestCase implements Serializable {
 				_licensePackageName, LoggerTestUtil.ALL)) {
 
 			LicenseManagerUtil.registerLicense(
-				JSONUtil.put("licenseXML", licenseXML));
+				JSONUtil.put(
+					"licenseXML", "<?xml version=\"1.0\"?>" + licenseXML));
 
 			_throwLogEntriesException(logCapture, null, LoggerTestUtil.ERROR);
 		}

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
@@ -85,39 +85,6 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		Assume.assumeTrue(isReleaseBundle());
 	}
 
-	public static String buildFreeTierPortalLicenseXML(
-		String domain, String key, long validityPeriod) {
-
-		StringBundler sb = new StringBundler(20);
-
-		sb.append("<license><account-name>");
-		sb.append(_FREE_TIER_ACCOUNT_NAME);
-		sb.append("</account-name><product-id>");
-		sb.append(getPortalProductId());
-		sb.append("</product-id><product-name>");
-		sb.append(_FREE_TIER_PRODUCT_NAME);
-		sb.append("</product-name><product-version>2026.Q1</product-version>");
-		sb.append("<license-type>");
-		sb.append(_FREE_TIER_LICENSE_TYPE);
-		sb.append("</license-type><license-version>6</license-version>");
-		sb.append("<start-date>");
-
-		long startTime = System.currentTimeMillis();
-
-		sb.append(_DATE_FORMAT.format(new Date(startTime)));
-
-		sb.append("</start-date><expiration-date>");
-		sb.append(_DATE_FORMAT.format(new Date(startTime + validityPeriod)));
-		sb.append("</expiration-date>");
-		sb.append("<max-cluster-nodes>3</max-cluster-nodes><domains><domain>");
-		sb.append(domain);
-		sb.append("</domain><domain>localhost</domain></domains><key>");
-		sb.append(key);
-		sb.append("</key></license>");
-
-		return sb.toString();
-	}
-
 	public static File deployFreeTierPortalLicense(long validityPeriod)
 		throws Exception {
 
@@ -138,11 +105,42 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		throws Exception {
 
 		_registerLicense(
-			buildFreeTierPortalLicenseXML(domain, key, validityPeriod));
+			_buildFreeTierPortalLicenseXML(domain, key, validityPeriod));
 
 		return _buildBinaryFile(
 			getPortalProductId(), _FREE_TIER_ACCOUNT_NAME,
-			_FREE_TIER_PRODUCT_NAME, _FREE_TIER_LICENSE_TYPE);
+			_FREE_TIER_PRODUCT_NAME, FREE_TIER_LICENSE_TYPE);
+	}
+
+	public static void deployLicenses(String[][] licenses) throws Exception {
+		StringBundler sb = new StringBundler();
+
+		sb.append("<licenses>");
+
+		for (String[] license : licenses) {
+			if (Objects.equals(license[0], ENTERPRISE_LICENSE_TYPE)) {
+				sb.append(
+					_buildEnterprisePortalLicenseXML(Long.valueOf(license[1])));
+			}
+			else if (Objects.equals(license[0], FREE_TIER_LICENSE_TYPE)) {
+				sb.append(
+					_buildFreeTierPortalLicenseXML(
+						_FREE_TIER_DOMAIN, StringPool.BLANK,
+						Long.valueOf(license[1])));
+			}
+			else {
+				App app = App.valueOf(license[0]);
+
+				sb.append(
+					_buildAppLicenseXML(
+						app, System.currentTimeMillis(),
+						Long.valueOf(license[1])));
+			}
+		}
+
+		sb.append("</licenses>");
+
+		_registerLicense(sb.toString());
 	}
 
 	public static SafeCloseable disableValidateWithSafeCloseable() {
@@ -252,75 +250,6 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		Assert.assertFalse(response.contains(_LICENSE_PAGE_KEY));
 	}
 
-	public String buildAppLicenseXML(
-		App app, long startTime, long validityPeriod) {
-
-		StringBundler sb = new StringBundler(19);
-
-		sb.append("<license><product-id>");
-		sb.append(getProductId(app));
-		sb.append("</product-id><product-name>");
-		sb.append(app);
-		sb.append("</product-name><product-version>2026.Q1</product-version>");
-		sb.append("<license-type>");
-		sb.append(_APP_LICENSE_TYPE);
-		sb.append("</license-type><license-version>3</license-version>");
-		sb.append("<start-date>");
-		sb.append(_DATE_FORMAT.format(new Date(startTime)));
-		sb.append("</start-date><expiration-date>");
-		sb.append(_DATE_FORMAT.format(new Date(startTime + validityPeriod)));
-		sb.append("</expiration-date><host-names>");
-		sb.append("<host-name>localhost</host-name>");
-		sb.append("</host-names><ip-addresses>");
-
-		for (String localIpAddress : LicenseUtil.getIpAddresses()) {
-			sb.append("<ip-address>");
-			sb.append(localIpAddress);
-			sb.append("</ip-address>");
-		}
-
-		sb.append("</ip-addresses><mac-addresses>");
-
-		for (String localMacAddress : LicenseUtil.getMacAddresses()) {
-			sb.append("<mac-address>");
-			sb.append(localMacAddress);
-			sb.append("</mac-address>");
-		}
-
-		sb.append("</mac-addresses><key></key></license>");
-
-		return sb.toString();
-	}
-
-	public String buildEnterprisePortalLicenseXML(long validityPeriod) {
-		long currentTimeMillis = System.currentTimeMillis();
-
-		StringBundler sb = new StringBundler(19);
-
-		sb.append("<license><account-name>");
-		sb.append(_ENTERPRISE_ACCOUNT_NAME);
-		sb.append("</account-name><product-id>");
-		sb.append(getPortalProductId());
-		sb.append("</product-id><product-name>");
-		sb.append(_ENTERPRISE_PRODUCT_NAME);
-		sb.append("</product-name><product-version>2026.Q1</product-version>");
-		sb.append("<license-type>");
-		sb.append(_ENTERPRISE_LICENSE_TYPE);
-		sb.append("</license-type><license-version>6</license-version>");
-		sb.append("<start-date>");
-		sb.append(_DATE_FORMAT.format(new Date(currentTimeMillis)));
-		sb.append("</start-date><expiration-date>");
-		sb.append(
-			_DATE_FORMAT.format(new Date(currentTimeMillis + validityPeriod)));
-		sb.append("</expiration-date>");
-		sb.append("<domains><domain>");
-		sb.append(_ENTERPRISE_DOMAIN);
-		sb.append("</domain><domain>localhost</domain></domains>");
-		sb.append("<key></key></license>");
-
-		return sb.toString();
-	}
-
 	public File deployAppLicense(App app, long validityPeriod)
 		throws Exception {
 
@@ -331,7 +260,7 @@ public abstract class BaseLicenseTestCase implements Serializable {
 	public File deployAppLicense(App app, long startTime, long validityPeriod)
 		throws Exception {
 
-		_registerLicense(buildAppLicenseXML(app, startTime, validityPeriod));
+		_registerLicense(_buildAppLicenseXML(app, startTime, validityPeriod));
 
 		return _buildBinaryFile(
 			getProductId(app), StringPool.BLANK, app.toString(),
@@ -341,11 +270,11 @@ public abstract class BaseLicenseTestCase implements Serializable {
 	public File deployEnterprisePortalLicense(long validityPeriod)
 		throws Exception {
 
-		_registerLicense(buildEnterprisePortalLicenseXML(validityPeriod));
+		_registerLicense(_buildEnterprisePortalLicenseXML(validityPeriod));
 
 		return _buildBinaryFile(
 			getPortalProductId(), _ENTERPRISE_ACCOUNT_NAME,
-			_ENTERPRISE_PRODUCT_NAME, _ENTERPRISE_LICENSE_TYPE);
+			_ENTERPRISE_PRODUCT_NAME, ENTERPRISE_LICENSE_TYPE);
 	}
 
 	public void resetCheckInterval() throws Exception {
@@ -552,6 +481,11 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		return getProperty("product.id.portal");
 	}
 
+	protected static String getProductId(App app) {
+		return getProperty(
+			"product.id." + StringUtil.toLowerCase(app.toString()));
+	}
+
 	protected static String getProperty(String propertyKey) {
 		String value = _licenseTestProperties.getProperty(propertyKey);
 
@@ -594,11 +528,6 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		return localPort;
 	}
 
-	protected String getProductId(App app) {
-		return getProperty(
-			"product.id." + StringUtil.toLowerCase(app.toString()));
-	}
-
 	protected String hitHomePage(String host, int port) throws Exception {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				_lifecycleActionClass.getName(), LoggerTestUtil.ALL)) {
@@ -618,6 +547,50 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		}
 	}
 
+	protected static final String ENTERPRISE_LICENSE_TYPE = "enterprise";
+
+	protected static final String FREE_TIER_LICENSE_TYPE = "free";
+
+	private static String _buildAppLicenseXML(
+		App app, long startTime, long validityPeriod) {
+
+		StringBundler sb = new StringBundler(19);
+
+		sb.append("<license><product-id>");
+		sb.append(getProductId(app));
+		sb.append("</product-id><product-name>");
+		sb.append(app);
+		sb.append("</product-name><product-version>2026.Q1</product-version>");
+		sb.append("<license-type>");
+		sb.append(_APP_LICENSE_TYPE);
+		sb.append("</license-type><license-version>3</license-version>");
+		sb.append("<start-date>");
+		sb.append(_DATE_FORMAT.format(new Date(startTime)));
+		sb.append("</start-date><expiration-date>");
+		sb.append(_DATE_FORMAT.format(new Date(startTime + validityPeriod)));
+		sb.append("</expiration-date><host-names>");
+		sb.append("<host-name>localhost</host-name>");
+		sb.append("</host-names><ip-addresses>");
+
+		for (String localIpAddress : LicenseUtil.getIpAddresses()) {
+			sb.append("<ip-address>");
+			sb.append(localIpAddress);
+			sb.append("</ip-address>");
+		}
+
+		sb.append("</ip-addresses><mac-addresses>");
+
+		for (String localMacAddress : LicenseUtil.getMacAddresses()) {
+			sb.append("<mac-address>");
+			sb.append(localMacAddress);
+			sb.append("</mac-address>");
+		}
+
+		sb.append("</mac-addresses><key></key></license>");
+
+		return sb.toString();
+	}
+
 	private static File _buildBinaryFile(
 		String productId, String accountName, String productEntryName,
 		String licenseType) {
@@ -635,6 +608,70 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		sb.append(".li");
 
 		return new File(LicenseUtil.LICENSE_REPOSITORY_DIR, sb.toString());
+	}
+
+	private static String _buildEnterprisePortalLicenseXML(
+		long validityPeriod) {
+
+		long currentTimeMillis = System.currentTimeMillis();
+
+		StringBundler sb = new StringBundler(19);
+
+		sb.append("<license><account-name>");
+		sb.append(_ENTERPRISE_ACCOUNT_NAME);
+		sb.append("</account-name><product-id>");
+		sb.append(getPortalProductId());
+		sb.append("</product-id><product-name>");
+		sb.append(_ENTERPRISE_PRODUCT_NAME);
+		sb.append("</product-name><product-version>2026.Q1</product-version>");
+		sb.append("<license-type>");
+		sb.append(ENTERPRISE_LICENSE_TYPE);
+		sb.append("</license-type><license-version>6</license-version>");
+		sb.append("<start-date>");
+		sb.append(_DATE_FORMAT.format(new Date(currentTimeMillis)));
+		sb.append("</start-date><expiration-date>");
+		sb.append(
+			_DATE_FORMAT.format(new Date(currentTimeMillis + validityPeriod)));
+		sb.append("</expiration-date>");
+		sb.append("<domains><domain>");
+		sb.append(_ENTERPRISE_DOMAIN);
+		sb.append("</domain><domain>localhost</domain></domains>");
+		sb.append("<key></key></license>");
+
+		return sb.toString();
+	}
+
+	private static String _buildFreeTierPortalLicenseXML(
+		String domain, String key, long validityPeriod) {
+
+		StringBundler sb = new StringBundler(20);
+
+		sb.append("<license><account-name>");
+		sb.append(_FREE_TIER_ACCOUNT_NAME);
+		sb.append("</account-name><product-id>");
+		sb.append(getPortalProductId());
+		sb.append("</product-id><product-name>");
+		sb.append(_FREE_TIER_PRODUCT_NAME);
+		sb.append("</product-name><product-version>2026.Q1</product-version>");
+		sb.append("<license-type>");
+		sb.append(FREE_TIER_LICENSE_TYPE);
+		sb.append("</license-type><license-version>6</license-version>");
+		sb.append("<start-date>");
+
+		long startTime = System.currentTimeMillis();
+
+		sb.append(_DATE_FORMAT.format(new Date(startTime)));
+
+		sb.append("</start-date><expiration-date>");
+		sb.append(_DATE_FORMAT.format(new Date(startTime + validityPeriod)));
+		sb.append("</expiration-date>");
+		sb.append("<max-cluster-nodes>3</max-cluster-nodes><domains><domain>");
+		sb.append(domain);
+		sb.append("</domain><domain>localhost</domain></domains><key>");
+		sb.append(key);
+		sb.append("</key></license>");
+
+		return sb.toString();
 	}
 
 	private static void _registerLicense(String licenseXML) throws Exception {
@@ -711,8 +748,6 @@ public abstract class BaseLicenseTestCase implements Serializable {
 
 	private static final String _ENTERPRISE_DOMAIN = "enterprise.com";
 
-	private static final String _ENTERPRISE_LICENSE_TYPE = "enterprise";
-
 	private static final String _ENTERPRISE_PRODUCT_NAME = "DXP Enterprise";
 
 	private static final String _EXPIRED_LICENSE_KEY =
@@ -721,8 +756,6 @@ public abstract class BaseLicenseTestCase implements Serializable {
 	private static final String _FREE_TIER_ACCOUNT_NAME = "Free Account";
 
 	private static final String _FREE_TIER_DOMAIN = "free.tier.com";
-
-	private static final String _FREE_TIER_LICENSE_TYPE = "free";
 
 	private static final String _FREE_TIER_PRODUCT_NAME = "DXP Production";
 

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
@@ -49,6 +49,25 @@ public class CombinedLicenseTest extends BaseLicenseTestCase {
 	}
 
 	@Test
+	public void testDuplicateLicenses() throws Exception {
+		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
+			assertLicensePropertiesNotExisted(getPortalProductId());
+
+			assertPortalLicenseNotRegistered();
+
+			deployLicenses(
+				new String[][] {
+					{FREE_TIER_LICENSE_TYPE, String.valueOf(Time.HOUR)},
+					{FREE_TIER_LICENSE_TYPE, String.valueOf(Time.HOUR)}
+				});
+
+			assertLicensePropertiesExisted(getPortalProductId());
+
+			assertPortalLicenseRegistered();
+		}
+	}
+
+	@Test
 	public void testNoLicenses() throws Exception {
 		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
 			assertPortalLicenseNotRegistered();

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
@@ -79,6 +79,25 @@ public class CombinedLicenseTest extends BaseLicenseTestCase {
 	}
 
 	@Test
+	public void testPortalLicensesEnterpriseAndFreeTier() throws Exception {
+		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
+			assertPortalLicenseNotRegistered();
+
+			deployLicenses(
+				new String[][] {
+					{ENTERPRISE_LICENSE_TYPE, String.valueOf(Time.HOUR)},
+					{FREE_TIER_LICENSE_TYPE, String.valueOf(Time.HOUR)}
+				});
+
+			assertLicensePropertiesExisted(getPortalProductId());
+
+			assertPortalLicenseRegistered();
+
+			Assert.assertFalse(LicenseManagerUtil.isFreeTier());
+		}
+	}
+
+	@Test
 	public void testSingleLicense() throws Exception {
 		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
 			assertLicensePropertiesNotExisted(getPortalProductId());

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.license.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.license.util.App;
+import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
+import com.liferay.portal.kernel.util.Time;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Kevin Lee
+ */
+@RunWith(Arquillian.class)
+public class CombinedLicenseTest extends BaseLicenseTestCase {
+
+	@BeforeClass
+	public static void setUpClass() {
+		_disableKeyValidatorSafeCloseable = disableValidateWithSafeCloseable();
+		_setVersionSafeCloseable = setVersionWithSafeCloseable("2026.Q1.0 LTS");
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_disableKeyValidatorSafeCloseable.close();
+		_setVersionSafeCloseable.close();
+	}
+
+	@Test
+	public void testAppLicensesWithPortalLicenseEnterprise() throws Exception {
+		_testAppLicensesWithPortalLicense(false);
+	}
+
+	@Test
+	public void testAppLicensesWithPortalLicenseFreeTier() throws Exception {
+		_testAppLicensesWithPortalLicense(true);
+	}
+
+	private void _testAppLicensesWithPortalLicense(boolean freeTier)
+		throws Exception {
+
+		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
+			assertLicensePropertiesNotExisted(getPortalProductId());
+
+			for (App app : App.values()) {
+				assertLicensePropertiesNotExisted(getProductId(app));
+			}
+
+			assertPortalLicenseNotRegistered();
+
+			List<String[]> licenses = new ArrayList<>();
+
+			if (freeTier) {
+				licenses.add(
+					new String[] {
+						FREE_TIER_LICENSE_TYPE, String.valueOf(Time.HOUR)
+					});
+			}
+			else {
+				licenses.add(
+					new String[] {
+						ENTERPRISE_LICENSE_TYPE, String.valueOf(Time.HOUR)
+					});
+			}
+
+			for (App app : App.values()) {
+				licenses.add(
+					new String[] {app.name(), String.valueOf(Time.HOUR)});
+			}
+
+			deployLicenses(licenses.toArray(new String[0][]));
+
+			assertPortalLicenseRegistered();
+
+			assertLicensePropertiesExisted(getPortalProductId());
+
+			for (App app : App.values()) {
+				assertLicensePropertiesExisted(getProductId(app));
+			}
+
+			if (freeTier) {
+				Assert.assertTrue(LicenseManagerUtil.isFreeTier());
+			}
+			else {
+				Assert.assertFalse(LicenseManagerUtil.isFreeTier());
+			}
+		}
+	}
+
+	private static SafeCloseable _disableKeyValidatorSafeCloseable;
+	private static SafeCloseable _setVersionSafeCloseable;
+
+}

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CombinedLicenseTest.java
@@ -48,6 +48,35 @@ public class CombinedLicenseTest extends BaseLicenseTestCase {
 		_testAppLicensesWithPortalLicense(true);
 	}
 
+	@Test
+	public void testNoLicenses() throws Exception {
+		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
+			assertPortalLicenseNotRegistered();
+
+			deployLicenses(new String[0][]);
+
+			assertPortalLicenseNotRegistered();
+		}
+	}
+
+	@Test
+	public void testSingleLicense() throws Exception {
+		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
+			assertLicensePropertiesNotExisted(getPortalProductId());
+
+			assertPortalLicenseNotRegistered();
+
+			deployLicenses(
+				new String[][] {
+					{FREE_TIER_LICENSE_TYPE, String.valueOf(Time.HOUR)}
+				});
+
+			assertLicensePropertiesExisted(getPortalProductId());
+
+			assertPortalLicenseRegistered();
+		}
+	}
+
 	private void _testAppLicensesWithPortalLicense(boolean freeTier)
 		throws Exception {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98408

## What Is Being Fixed

The portal license integration tests only exercised licenses deployed one at a time. There was no coverage for a combined license file — multiple `<license>` entries (a portal license plus app licenses, or more than one portal license) registered together — even though that is a supported deployment shape.

## How It Is Being Fixed

`BaseLicenseTestCase` is refactored so each license's XML is produced by a dedicated builder method (`_buildAppLicenseXML`, `_buildEnterprisePortalLicenseXML`, `_buildFreeTierPortalLicenseXML`) that returns a bare `<license>` fragment, with the `<?xml?>` prolog now added once at registration time. A new `deployLicenses(String[][])` method assembles any number of these fragments under a single `<licenses>` root and registers them as one combined license.

The new `CombinedLicenseTest` builds on this to cover the single-license and no-license baselines, duplicate free-tier licenses, portal-plus-app licenses for both the enterprise and free-tier portal licenses, and an enterprise-and-free-tier portal license combination, asserting in each case that the expected license properties are written, the portal license is registered, and the free-tier flag is set correctly.

## PR Check

**pr-check: PASS** — tested on `747378227986067f67d7abe29ccbf84ae8a439da`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "747378227986067f67d7abe29ccbf84ae8a439da"} -->
