### PR TITLE
LPD-94999 Exclude the Docker image internal env variables

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/util/EnvPropertiesUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/EnvPropertiesUtil.java
@@ -81,7 +81,9 @@ public class EnvPropertiesUtil {
 		for (Map.Entry<String, String> entry : env.entrySet()) {
 			String key = entry.getKey();
 
-			if (!key.startsWith(envPrefix)) {
+			if (!key.startsWith(envPrefix) ||
+				ArrayUtil.exists(_DOCKER_IMAGE_ENV_PREFIXES, key::startsWith)) {
+
 				continue;
 			}
 
@@ -124,6 +126,10 @@ public class EnvPropertiesUtil {
 			throw new ExceptionInInitializerError(exception);
 		}
 	}
+
+	private static final String[] _DOCKER_IMAGE_ENV_PREFIXES = {
+		"LIFERAY_CONTAINER_", "LIFERAY_DOCKER_"
+	};
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		EnvPropertiesUtil.class);

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/EnvPropertiesUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/EnvPropertiesUtilTest.java
@@ -5,13 +5,19 @@
 
 package com.liferay.portal.kernel.util;
 
+import com.liferay.portal.kernel.test.rule.NewEnv;
+import com.liferay.portal.kernel.test.rule.NewEnvTestRule;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -79,5 +85,28 @@ public class EnvPropertiesUtilTest {
 				logEntry.getMessage());
 		}
 	}
+
+	@NewEnv(type = NewEnv.Type.JVM)
+	@NewEnv.Environment(
+		append = false,
+		variables = {
+			"LIFERAY_CONTAINER_DISABLE_TRIAL_LICENSE=false",
+			"LIFERAY_DOCKER_HOTFIX=liferay-hotfix-1-7413.zip",
+			"LIFERAY_SETUP_PERIOD_WIZARD_PERIOD_ENABLED=false"
+		}
+	)
+	@Test
+	public void testLoadEnvOverrides() {
+		Map<String, String> properties = new HashMap<>();
+
+		EnvPropertiesUtil.loadEnvOverrides("LIFERAY_", properties::put);
+
+		Assert.assertEquals(
+			Collections.singletonMap("setup.wizard.enabled", "false"),
+			properties);
+	}
+
+	@Rule
+	public final NewEnvTestRule newEnvTestRule = NewEnvTestRule.INSTANCE;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94999

For additional context, see: [PTR-8956](https://liferay.atlassian.net/browse/PTR-8956)

## What Is Being Fixed

The Liferay Docker image sets internal env variables such as `LIFERAY_CONTAINER_DISABLE_TRIAL_LICENSE` and `LIFERAY_DOCKER_HOTFIX`. These start with the `LIFERAY_` prefix, which is also used to declare Liferay portal properties through env variables. 

As a result, unnecessary warnings were logged during portal startup:
```
WARN [EnvPropertiesUtil:54] Unable to decode part "status" from "container_status_enabled", preserve it literally
```

## How It Is Being Fixed

Skip env variables with the `LIFERAY_CONTAINER_` and `LIFERAY_DOCKER_` prefixes before decoding, since they are not Liferay portal properties.

## PR Check

**pr-check: PASS** — tested on `0ed27b58011189ee911d8a8ba3c1ce4f341e4fe8`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "0ed27b58011189ee911d8a8ba3c1ce4f341e4fe8"} -->


[PTR-8956]: https://liferay.atlassian.net/browse/PTR-8956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ