### PR TITLE
LPD-98534 Add suppression

### DIFF
--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -21,6 +21,7 @@
 		<suppress checks="ConstantNameCheck" files="portal-test/src/com/liferay/portal/kernel/test/rule/CodeCoverageAssertor\.java" />
 		<suppress checks="FactoryCheck" files="portal-kernel/src/com/liferay/portal/kernel/service/ServiceContext\.java" />
 		<suppress checks="FactoryCheck" files="portal-kernel/src/com/liferay/portal/kernel/service/ServiceContextFactory\.java" />
+		<suppress checks="FetchContractCatchCheck" files="portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl\.java" />
 		<suppress checks="InnerExceptionClassCheck" files="portal-kernel/src/com/liferay/document/library/kernel/exception/FileEntryLockException\.java" />
 		<suppress checks="InnerExceptionClassCheck" files="portal-kernel/src/com/liferay/expando/kernel/exception/ColumnNameException\.java" />
 		<suppress checks="InnerExceptionClassCheck" files="portal-kernel/src/com/liferay/portal/kernel/exception/CountryTitleException\.java" />


### PR DESCRIPTION
@shuyangzhou I added an SF suppression for:
```
     [java] 1: Do not catch "NoSuchFileEntryException" around the lookup "dlAppLocalService.getFileEntry" to signal a missing entity, call the null-tolerant fetch sibling and check for null instead, see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/check/fetch_contract_catch_check.md: ./portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java 609 (Checkstyle:FetchContractCatchCheck)
     [java] 2: Do not catch "NoSuchFileEntryException" around the lookup "dlAppLocalService.getFileEntryByFileName" to signal a missing entity, call the null-tolerant fetch sibling and check for null instead, see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/check/fetch_contract_catch_check.md: ./portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java 647 (Checkstyle:FetchContractCatchCheck)
```
or let me know if I need to adjust SF check, thanks.
