### PR TITLE
LPD-96888 Fix Hibernate 7 sequence increment size mismatch

### DIFF
--- a/modules/util/portal-tools-service-builder-test-sequence-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/util/portal-tools-service-builder-test-sequence-service/src/main/resources/META-INF/module-hbm.xml
@@ -6,6 +6,7 @@
 	<class dynamic-update="true" name="com.liferay.portal.tools.service.builder.test.sequence.model.impl.SequenceEntryImpl" table="SequenceEntry">
 		<id access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="sequenceEntryId" type="long">
 			<generator class="sequence">
+				<param name="increment_size">1</param>
 				<param name="sequence_name">id_sequence</param>
 			</generator>
 		</id>

--- a/modules/util/portal-tools-service-builder-test-sequence-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/sequence/service/test/SequenceEntryLocalServiceTest.java
+++ b/modules/util/portal-tools-service-builder-test-sequence-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/sequence/service/test/SequenceEntryLocalServiceTest.java
@@ -6,15 +6,23 @@
 package com.liferay.portal.tools.service.builder.test.sequence.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Release;
+import com.liferay.portal.kernel.service.ReleaseLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.tools.service.builder.test.sequence.service.SequenceEntryLocalService;
 
+import java.io.IOException;
 import java.io.InputStream;
+
+import java.sql.SQLException;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -51,6 +59,8 @@ public class SequenceEntryLocalServiceTest {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
+		_deleteSequenceEntrySchema();
+
 		Bundle bundle = FrameworkUtil.getBundle(
 			SequenceEntryLocalServiceTest.class);
 
@@ -73,6 +83,8 @@ public class SequenceEntryLocalServiceTest {
 	@AfterClass
 	public static void tearDownClass() throws Exception {
 		_bundle.uninstall();
+
+		_deleteSequenceEntrySchema();
 	}
 
 	@Test
@@ -81,6 +93,34 @@ public class SequenceEntryLocalServiceTest {
 			_sequenceEntryLocalService.addSequenceEntry(
 				_sequenceEntryLocalService.createSequenceEntry(0)));
 	}
+
+	private static void _deleteSequenceEntrySchema() {
+		_runSQL("drop table SequenceEntry");
+		_runSQL("drop sequence id_sequence");
+
+		Release release = ReleaseLocalServiceUtil.fetchRelease(
+			"com.liferay.portal.tools.service.builder.test.sequence.service");
+
+		if (release != null) {
+			ReleaseLocalServiceUtil.deleteRelease(release);
+		}
+	}
+
+	private static void _runSQL(String sql) {
+		try {
+			DB db = DBManagerUtil.getDB();
+
+			db.runSQL(sql);
+		}
+		catch (IOException | SQLException exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SequenceEntryLocalServiceTest.class);
 
 	private static Bundle _bundle;
 

--- a/modules/util/portal-tools-service-builder-test-sequence-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/sequence/service/test/SequenceEntryLocalServiceTest.java
+++ b/modules/util/portal-tools-service-builder-test-sequence-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/sequence/service/test/SequenceEntryLocalServiceTest.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.tools.service.builder.test.sequence.model.SequenceEntry;
 import com.liferay.portal.tools.service.builder.test.sequence.service.SequenceEntryLocalService;
 
 import java.io.IOException;
@@ -89,9 +90,21 @@ public class SequenceEntryLocalServiceTest {
 
 	@Test
 	public void testAddSequenceEntry() {
-		Assert.assertNotNull(
-			_sequenceEntryLocalService.addSequenceEntry(
-				_sequenceEntryLocalService.createSequenceEntry(0)));
+		Assert.assertNotNull(_addSequenceEntry());
+	}
+
+	@Test
+	public void testAddSequenceEntryIncrementsPrimaryKeyByOne() {
+		SequenceEntry sequenceEntry1 = _addSequenceEntry();
+		SequenceEntry sequenceEntry2 = _addSequenceEntry();
+		SequenceEntry sequenceEntry3 = _addSequenceEntry();
+
+		Assert.assertEquals(
+			sequenceEntry1.getSequenceEntryId() + 1,
+			sequenceEntry2.getSequenceEntryId());
+		Assert.assertEquals(
+			sequenceEntry2.getSequenceEntryId() + 1,
+			sequenceEntry3.getSequenceEntryId());
 	}
 
 	private static void _deleteSequenceEntrySchema() {
@@ -117,6 +130,11 @@ public class SequenceEntryLocalServiceTest {
 				_log.debug(exception);
 			}
 		}
+	}
+
+	private SequenceEntry _addSequenceEntry() {
+		return _sequenceEntryLocalService.addSequenceEntry(
+			_sequenceEntryLocalService.createSequenceEntry(0));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/hbm_xml.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/hbm_xml.ftl
@@ -80,7 +80,8 @@
 
 					<#if stringUtil.equals(class, "sequence")>
 						<#if serviceBuilder.isVersionGTE_7_4_0()>
-							><param name="sequence_name">${entityColumn.idParam}</param>
+							><param name="increment_size">1</param>
+							<param name="sequence_name">${entityColumn.idParam}</param>
 						<#else>
 							><param name="sequence">${entityColumn.idParam}</param>
 						</#if>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96888

## What Is Being Fixed

Service Builder generates the sequence generator mapping with only a `sequence_name` parameter, so the increment size falls back to whatever Hibernate defaults to, while the generated `sequences.sql` creates the sequence with the database default increment of 1. Hibernate 5 defaults to 1 and agrees by coincidence. Hibernate 7 defaults to 50 and validates the mapping against the sequence it finds, so on DB2, Oracle, and PostgreSQL the module never builds its session factory and every test in `SequenceEntryLocalServiceTest` fails with `The increment size of the [id_sequence] sequence is set to [50] in the entity mapping but the mapped database sequence increment size is [1]`.

That test also could not run twice against the same database, and this half is not specific to the Hibernate upgrade — it reproduces identically on clean master. The test installs its own service bundle, whose schema creation runs `tables.sql` and `sequences.sql` on start but never drops what it created. `ReleaseManagerImpl` decides whether to create the schema from the module's `Release` row, so the table, the sequence, and that row have to agree. When they disagree the service never registers and the test hangs waiting for it instead of failing, and no later run recovers on its own. Continuous integration never noticed because it provisions a fresh database per run.

## How It Is Being Fixed

The mapping now declares an explicit increment size of 1, aligning it with the sequence Service Builder actually creates. Aligning in that direction needs no migration, since every database whose sequences were already created with an increment of 1 keeps working. Declaring a larger increment on the sequence instead would break existing installations until their sequences were altered, and would only benefit entities with sequence primary keys, which is a rare special case in Liferay.

The test cleanup now removes the table, the sequence, and the `Release` row together, before installing the bundle as well as after uninstalling it, so the database is left consistent no matter how a run ended, including a run killed before it reached its teardown. Each statement is attempted independently so a missing object does not abort the rest. Only one entity in the repository declares a sequence primary key and nothing outside its own module references `SequenceEntry` or `id_sequence`, so the cleanup cannot reach anything else; `ant build-services` confirms the generator change rewrites that one mapping and nothing more.

The new test adds three entries and asserts that their primary keys are consecutive, which holds only when the mapping increment matches the sequence increment. It passes either way on Hibernate 5, so on master it stands as a guard that keeps the mapping and the sequence in step rather than as a reproduction of the failure. Both directions were confirmed on Hibernate 7.4.0 locally: the class fails without the explicit increment and passes with it, and the rerun cleanup was verified by poisoning the database into each inconsistent state and confirming the next run recovers.

## PR Check

**pr-check: PASS** — tested on `a97eefe869d68e91542e8d3322e771548ccb4228`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "a97eefe869d68e91542e8d3322e771548ccb4228"} -->
