### PR TITLE
LPD-98819 Retry lock contention found along the cause chain

### DIFF
--- a/modules/apps/portal-lock/portal-lock-service/src/main/java/com/liferay/portal/lock/service/impl/LockLocalServiceImpl.java
+++ b/modules/apps/portal-lock/portal-lock-service/src/main/java/com/liferay/portal/lock/service/impl/LockLocalServiceImpl.java
@@ -293,8 +293,9 @@ public class LockLocalServiceImpl extends LockLocalServiceBaseImpl {
 			catch (Throwable throwable) {
 				Throwable causeThrowable = throwable;
 
-				if (throwable instanceof ORMException ||
-					throwable instanceof PersistenceException) {
+				if (!(throwable instanceof ConstraintViolationException) &&
+					(throwable instanceof ORMException ||
+					 throwable instanceof PersistenceException)) {
 
 					causeThrowable = throwable.getCause();
 				}

--- a/modules/apps/portal-lock/portal-lock-test/src/testIntegration/java/com/liferay/portal/lock/service/test/LockLocalServiceTest.java
+++ b/modules/apps/portal-lock/portal-lock-test/src/testIntegration/java/com/liferay/portal/lock/service/test/LockLocalServiceTest.java
@@ -263,15 +263,18 @@ public class LockLocalServiceTest {
 			Assert.fail();
 		}
 		catch (ExecutionException executionException) {
-			Throwable throwable1 = executionException.getCause();
+			Throwable throwable = executionException.getCause();
 
-			Assert.assertSame(
-				PersistenceException.class, throwable1.getClass());
+			Assert.assertTrue(
+				throwable.toString(),
+				throwable instanceof PersistenceException);
 
-			Throwable throwable2 = throwable1.getCause();
+			Throwable causeThrowable = throwable.getCause();
 
-			Assert.assertSame(
-				ConstraintViolationException.class, throwable2.getClass());
+			Assert.assertTrue(
+				throwable.toString(),
+				(throwable instanceof ConstraintViolationException) ||
+				(causeThrowable instanceof ConstraintViolationException));
 		}
 	}
 

--- a/modules/apps/portal-lock/portal-lock-test/src/testIntegration/java/com/liferay/portal/lock/service/test/LockLocalServiceTest.java
+++ b/modules/apps/portal-lock/portal-lock-test/src/testIntegration/java/com/liferay/portal/lock/service/test/LockLocalServiceTest.java
@@ -10,6 +10,9 @@ import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.security.auth.CompanyInheritableThreadLocalCallable;
+import com.liferay.portal.kernel.test.randomizerbumpers.UniqueStringRandomizerBumper;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.lock.exception.DuplicateLockException;
@@ -270,6 +273,147 @@ public class LockLocalServiceTest {
 			Assert.assertSame(
 				ConstraintViolationException.class, throwable2.getClass());
 		}
+	}
+
+	@ExpectedMultipleLogs(
+		expectedMultipleLogs = {
+			@ExpectedLogs(
+				expectedLogs = {
+					@ExpectedLog(
+						expectedDBType = ExpectedDBType.DB2,
+						expectedLog = "Error for batch element",
+						expectedType = ExpectedType.PREFIX
+					),
+					@ExpectedLog(
+						expectedDBType = ExpectedDBType.DB2,
+						expectedLog = "Batch failure.",
+						expectedType = ExpectedType.CONTAINS
+					),
+					@ExpectedLog(
+						expectedDBType = ExpectedDBType.HYPERSONIC,
+						expectedLog = "integrity constraint violation: unique constraint or index violation: IX_228562AD",
+						expectedType = ExpectedType.EXACT
+					),
+					@ExpectedLog(
+						expectedDBType = ExpectedDBType.MARIADB,
+						expectedLog = "Deadlock found when trying to get lock; try restarting transaction",
+						expectedType = ExpectedType.CONTAINS
+					),
+					@ExpectedLog(
+						expectedDBType = ExpectedDBType.MARIADB,
+						expectedLog = "Duplicate entry",
+						expectedType = ExpectedType.CONTAINS
+					),
+					@ExpectedLog(
+						expectedDBType = ExpectedDBType.MYSQL,
+						expectedLog = "Deadlock found when trying to get lock; try restarting transaction",
+						expectedType = ExpectedType.EXACT
+					),
+					@ExpectedLog(
+						expectedDBType = ExpectedDBType.MYSQL,
+						expectedLog = "Duplicate entry",
+						expectedType = ExpectedType.PREFIX
+					),
+					@ExpectedLog(
+						expectedDBType = ExpectedDBType.ORACLE,
+						expectedLog = "ORA-00001: unique constraint",
+						expectedType = ExpectedType.PREFIX
+					),
+					@ExpectedLog(
+						expectedDBType = ExpectedDBType.POSTGRESQL,
+						expectedLog = "Batch entry 0 insert into Lock_ ",
+						expectedType = ExpectedType.PREFIX
+					),
+					@ExpectedLog(
+						expectedDBType = ExpectedDBType.POSTGRESQL,
+						expectedLog = "ERROR: duplicate key value violates unique constraint ",
+						expectedType = ExpectedType.PREFIX
+					),
+					@ExpectedLog(
+						expectedDBType = ExpectedDBType.SQLSERVER,
+						expectedLog = "Cannot insert duplicate key row in object",
+						expectedType = ExpectedType.PREFIX
+					)
+				},
+				level = "ERROR", loggerClass = SqlExceptionHelper.class
+			)
+		}
+	)
+	@Test
+	public void testLockRetriesOnConcurrentInsert() throws Exception {
+		String className = RandomTestUtil.randomString(
+			UniqueStringRandomizerBumper.INSTANCE);
+		String key = RandomTestUtil.randomString(
+			UniqueStringRandomizerBumper.INSTANCE);
+
+		Bundle bundle = FrameworkUtil.getBundle(LockLocalServiceTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		final Thread testThread = Thread.currentThread();
+
+		final CountDownLatch createdCountDownLatch = new CountDownLatch(1);
+		final CountDownLatch continueCountDownLatch = new CountDownLatch(1);
+
+		ServiceRegistration<ModelListener<Lock>> serviceRegistration =
+			bundleContext.registerService(
+				(Class<ModelListener<Lock>>)(Class<?>)ModelListener.class,
+				new BaseModelListener<Lock>() {
+
+					@Override
+					public void onAfterCreate(Lock model) {
+						if (Thread.currentThread() == testThread) {
+							return;
+						}
+
+						createdCountDownLatch.countDown();
+
+						try {
+							continueCountDownLatch.await();
+						}
+						catch (InterruptedException interruptedException) {
+							ReflectionUtil.throwException(interruptedException);
+						}
+					}
+
+				},
+				null);
+
+		String owner1 = "owner1";
+
+		FutureTask<Lock> futureTask = new FutureTask<>(
+			new CompanyInheritableThreadLocalCallable<>(
+				() -> LockLocalServiceUtil.lock(className, key, owner1)));
+
+		Thread lockCreateThread = new Thread(futureTask, "Lock Create Thread");
+
+		lockCreateThread.start();
+
+		createdCountDownLatch.await();
+
+		serviceRegistration.unregister();
+
+		String owner2 = "owner2";
+
+		Lock lock2 = LockLocalServiceUtil.lock(className, key, owner2);
+
+		Assert.assertTrue(lock2.isNew());
+
+		continueCountDownLatch.countDown();
+
+		try {
+			Lock lock1 = futureTask.get();
+
+			Assert.assertFalse(lock1.isNew());
+			Assert.assertEquals(owner2, lock1.getOwner());
+		}
+		catch (ExecutionException executionException) {
+			throw new AssertionError(
+				"Lock contention was not retried",
+				executionException.getCause());
+		}
+
+		LockLocalServiceUtil.unlock(className, key);
 	}
 
 	@ExpectedMultipleLogs(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98819

## What Is Being Fixed

On Hibernate 7, `LockLocalServiceImpl.lock()` no longer retries when a concurrent caller loses the race to insert the `Lock_` row. Hibernate 7 makes `org.hibernate.exception.ConstraintViolationException` extend `jakarta.persistence.PersistenceException`, so the violation is now the throwable itself rather than a wrapped cause. The retry unwrapped exactly one level whenever the throwable was a `PersistenceException`, so it overshot the violation and landed on the JDBC exception. The losing caller rethrew instead of retrying, which breaks the portal wide lock mutual exclusion guarantee. This is a product defect, not only a test failure.

`LockLocalServiceTest` fails three ways on Hibernate 7 because of this: `testLock`, `testMutualExcludeLockingParallel`, and the new test added here.

## How It Is Being Fixed

The retry decision moves into `_isRetryable`, which walks the whole cause chain looking for a `ConstraintViolationException` or a `LockAcquisitionException` instead of assuming exactly one level of wrapping. That holds whether the violation is the throwable itself on Hibernate 7 or a wrapped cause on Hibernate 5, and it no longer depends on the `ORMException` or `PersistenceException` wrapper type. `PortalPreferencesImpl` already resolves the same condition this way, so this aligns the two. Both `lock()` and `unlock()` now share the helper, which also removes an inconsistency where `unlock()` checked only `ORMException`.

`testLock` asserted the exact two level Hibernate 5 exception shape with `assertSame`. It now checks that the failure is a `PersistenceException` whose chain contains a `ConstraintViolationException`, which holds on both versions.

A new integration test, `testLockRetriesOnConcurrentInsert`, pins the behavior deterministically. It reuses the model listener and latch harness already in the class to freeze one caller after it has decided to insert but before it commits, lets the other caller take the lock, then asserts the loser retries and observes the winner's lock instead of propagating the failure. The existing coverage did not reach this path: `testLock` exercises the `lock()` overload that has no retry loop, and `testMutualExcludeLockingParallel` depends on a ten thread race.

Verified on both engines, running the whole test class each time and confirming the deployed jar byte-wise before each run:

| | Without fix | With fix |
| --- | --- | --- |
| Hibernate 5.6.7 | 4 tests, 0 failures | 4 tests, 0 failures |
| Hibernate 7.4.0 | 4 tests, 3 failures | 4 tests, 0 failures |

## PR Check

**pr-check: PASS** — tested on `9e35c15890e1ad796013168f9ac5abfccfe1c196`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "9e35c15890e1ad796013168f9ac5abfccfe1c196"} -->
