### PR TITLE
[FIPS] LPD-101281 Refuse noncompliant JGroups intra-cluster encryption profiles- #3188

### DIFF
--- a/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/jgroups/JGroupsClusterChannelFactory.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/jgroups/JGroupsClusterChannelFactory.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.SocketUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -64,6 +65,15 @@ public class JGroupsClusterChannelFactory implements ClusterChannelFactory {
 		ExecutorService executorService, String channleLogicName,
 		String channelPropertiesLocation, String clusterName,
 		ClusterReceiver clusterReceiver) {
+
+		if (PropsValues.FIPS_ENABLED &&
+			!channelPropertiesLocation.startsWith("jgroups/secure/x509/")) {
+
+			throw new SecurityException(
+				"The clustering authentication profile \"" +
+					channelPropertiesLocation +
+						"\" is not allowed in FIPS mode");
+		}
 
 		try {
 			return new JGroupsClusterChannel(

--- a/modules/apps/portal/portal-cluster-multiple/src/main/resources/jgroups/secure/md5/udp_control.xml
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/resources/jgroups/secure/md5/udp_control.xml
@@ -32,7 +32,7 @@
 	<!--<BARRIER />-->
 	<ASYM_ENCRYPT
 		asym_algorithm="RSA"
-		asym_keylength="512"
+		asym_keylength="2048"
 		change_key_on_coord_leave="false"
 		change_key_on_leave="false"
 		sym_algorithm="AES/CBC/PKCS5Padding"

--- a/modules/apps/portal/portal-cluster-multiple/src/main/resources/jgroups/secure/md5/udp_transport.xml
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/resources/jgroups/secure/md5/udp_transport.xml
@@ -32,7 +32,7 @@
 	<!--<BARRIER />-->
 	<ASYM_ENCRYPT
 		asym_algorithm="RSA"
-		asym_keylength="512"
+		asym_keylength="2048"
 		change_key_on_coord_leave="false"
 		change_key_on_leave="false"
 		sym_algorithm="AES/CBC/PKCS5Padding"

--- a/modules/apps/portal/portal-cluster-multiple/src/main/resources/jgroups/secure/x509/udp_control.xml
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/resources/jgroups/secure/x509/udp_control.xml
@@ -32,7 +32,7 @@
 	<!--<BARRIER />-->
 	<ASYM_ENCRYPT
 		asym_algorithm="RSA"
-		asym_keylength="512"
+		asym_keylength="2048"
 		change_key_on_coord_leave="false"
 		change_key_on_leave="false"
 		sym_algorithm="AES/CBC/PKCS5Padding"

--- a/modules/apps/portal/portal-cluster-multiple/src/main/resources/jgroups/secure/x509/udp_transport.xml
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/resources/jgroups/secure/x509/udp_transport.xml
@@ -32,7 +32,7 @@
 	<!--<BARRIER />-->
 	<ASYM_ENCRYPT
 		asym_algorithm="RSA"
-		asym_keylength="512"
+		asym_keylength="2048"
 		change_key_on_coord_leave="false"
 		change_key_on_leave="false"
 		sym_algorithm="AES/CBC/PKCS5Padding"

--- a/modules/apps/portal/portal-cluster-multiple/src/test/java/com/liferay/portal/cluster/multiple/internal/jgroups/JGroupsClusterChannelFactoryTest.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/test/java/com/liferay/portal/cluster/multiple/internal/jgroups/JGroupsClusterChannelFactoryTest.java
@@ -1,0 +1,73 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.cluster.multiple.internal.jgroups;
+
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.cluster.multiple.configuration.ClusterExecutorConfiguration;
+import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Caio Farias
+ */
+public class JGroupsClusterChannelFactoryTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testCreateClusterChannel() {
+		JGroupsClusterChannelFactory jGroupsClusterChannelFactory =
+			new JGroupsClusterChannelFactory(
+				ConfigurableUtil.createConfigurable(
+					ClusterExecutorConfiguration.class,
+					Collections.emptyMap()));
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			_testCreateClusterChannel(
+				"jgroups/secure/md5/udp_control.xml",
+				jGroupsClusterChannelFactory);
+			_testCreateClusterChannel(
+				"jgroups/secure/md5/udp_transport.xml",
+				jGroupsClusterChannelFactory);
+			_testCreateClusterChannel(
+				"jgroups/unsecure/udp_control.xml",
+				jGroupsClusterChannelFactory);
+			_testCreateClusterChannel(
+				"jgroups/unsecure/udp_transport.xml",
+				jGroupsClusterChannelFactory);
+		}
+	}
+
+	private void _testCreateClusterChannel(
+		String channelPropertiesLocation,
+		JGroupsClusterChannelFactory jGroupsClusterChannelFactory) {
+
+		SecurityException securityException = Assert.assertThrows(
+			SecurityException.class,
+			() -> jGroupsClusterChannelFactory.createClusterChannel(
+				null, null, channelPropertiesLocation, null, null));
+
+		Assert.assertEquals(
+			"The clustering authentication profile \"" +
+				channelPropertiesLocation + "\" is not allowed in FIPS mode",
+			securityException.getMessage());
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101281

## Why

 [FIPS](https://csrc.nist.gov/pubs/fips/140-3/final) forbids RSA keys below 2048 bits for key establishment and forbids MD5 entirely. Both were in use for intra-cluster traffic: every secure JGroups profile wrapped the shared group key with a 512 bit RSA key, and the default md5 profile authenticates joining members with MD5. IN  [FIPS](https://csrc.nist.gov/pubs/fips/140-3/final)  mode, a forbidden profile cannot be warned about and used anyway, so createClusterChannel refuses it with a SecurityException.

## Key changes

- Raise asym_keylength to 2048 in every secure profile — 512 is below the FIPS minimum.
- Refuse any profile outside jgroups/secure/x509/ when FIPS is enabled — md5 authenticates with a nonapproved token.
- Guard in createClusterChannel, not while parsing — a SecurityException reaches the operator instead of being buried as a cause inside the SystemException that channel creation failures carry.