### PR TITLE
LPD-101130 Clean up license integration test coverage after LPKG change

### DIFF
--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/AppModuleLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/AppModuleLicenseTest.java
@@ -9,25 +9,17 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.license.util.App;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
-import com.liferay.portal.kernel.module.util.SystemBundleUtil;
-import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
 
 import java.io.File;
 
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 
 /**
  * @author Kevin Lee
@@ -48,140 +40,40 @@ public class AppModuleLicenseTest extends BaseLicenseTestCase {
 	}
 
 	@Test
-	public void testEnterpriseLicense() throws Exception {
+	public void testAppLicenses() throws Exception {
 		for (App app : App.values()) {
-			_testEnterpriseLicense(app);
-		}
-	}
+			try (SafeCloseable safeCloseable =
+					resetLicenseDataWithSafeCloseble()) {
 
-	@Test
-	public void testFreeTierLicense() throws Exception {
-		for (App app : App.values()) {
-			_testFreeTierLicense(app);
-		}
-	}
+				assertLicensePropertiesNotExisted(getProductId(app));
 
-	private String[] _getAppSymbolicNames(App app) {
-		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+				Assert.assertFalse(LicenseManagerUtil.isAppEnabled(app));
 
-		List<String> symbolicNames = new ArrayList<>();
+				Assert.assertNull(LicenseManagerUtil.getAppExpirationDate(app));
 
-		for (Bundle bundle : bundleContext.getBundles()) {
-			String symbolicName = bundle.getSymbolicName();
+				long startTime = System.currentTimeMillis();
 
-			if (symbolicName.contains(
-					"." + StringUtil.toLowerCase(app.toString()) + ".")) {
+				File binaryFile = deployAppLicense(app, startTime, Time.HOUR);
 
-				symbolicNames.add(symbolicName);
+				assertLicensePropertiesExisted(getProductId(app));
+
+				Assert.assertTrue(LicenseManagerUtil.isAppEnabled(app));
+
+				Assert.assertEquals(
+					getDateString(new Date(startTime + Time.HOUR)),
+					getDateString(
+						LicenseManagerUtil.getAppExpirationDate(app)));
+
+				binaryFile.delete();
+
+				checkLicense(getProductId(app));
+
+				assertLicensePropertiesNotExisted(getProductId(app));
+
+				Assert.assertFalse(LicenseManagerUtil.isAppEnabled(app));
+
+				Assert.assertNull(LicenseManagerUtil.getAppExpirationDate(app));
 			}
-		}
-
-		return ArrayUtil.toStringArray(symbolicNames);
-	}
-
-	private void _testEnterpriseLicense(App app) throws Exception {
-		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
-			String[] appSymbolicNames = _getAppSymbolicNames(app);
-
-			Assert.assertFalse(
-				appSymbolicNames.toString(),
-				ArrayUtil.isEmpty(appSymbolicNames));
-
-			assertLicensePropertiesNotExisted(getProductId(app));
-
-			assertBundlesExisted(appSymbolicNames);
-
-			assertPortalLicenseNotRegistered();
-
-			assertBundlesExisted(appSymbolicNames);
-
-			Assert.assertNull(LicenseManagerUtil.getAppExpirationDate(app));
-
-			deployEnterprisePortalLicense(Time.HOUR);
-
-			assertLicensePropertiesNotExisted(getProductId(app));
-
-			assertPortalLicenseRegistered();
-
-			assertBundlesNotExisted(appSymbolicNames);
-
-			Assert.assertNull(LicenseManagerUtil.getAppExpirationDate(app));
-
-			long startTime = System.currentTimeMillis();
-
-			File binaryFile = deployAppLicense(app, startTime, Time.HOUR);
-
-			assertLicensePropertiesExisted(getProductId(app));
-
-			assertPortalLicenseRegistered();
-
-			assertBundlesExisted(appSymbolicNames);
-
-			Date expirationDate = LicenseManagerUtil.getAppExpirationDate(app);
-
-			Assert.assertEquals(
-				getDateString(new Date(startTime + Time.HOUR)),
-				getDateString(expirationDate));
-
-			binaryFile.delete();
-
-			checkLicense(getProductId(app));
-
-			assertLicensePropertiesNotExisted(getProductId(app));
-
-			resetLifecycleAction();
-
-			assertPortalLicenseRegistered();
-
-			assertBundlesNotExisted(appSymbolicNames);
-
-			Assert.assertNull(LicenseManagerUtil.getAppExpirationDate(app));
-		}
-	}
-
-	private void _testFreeTierLicense(App app) throws Exception {
-		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
-			String[] appSymbolicNames = _getAppSymbolicNames(app);
-
-			Assert.assertFalse(
-				appSymbolicNames.toString(),
-				ArrayUtil.isEmpty(appSymbolicNames));
-
-			assertLicensePropertiesNotExisted(getProductId(app));
-
-			assertBundlesExisted(appSymbolicNames);
-
-			assertPortalLicenseNotRegistered();
-
-			assertBundlesExisted(appSymbolicNames);
-
-			deployFreeTierPortalLicense(Time.HOUR);
-
-			assertLicensePropertiesNotExisted(getProductId(app));
-
-			assertPortalLicenseRegistered();
-
-			assertBundlesNotExisted(appSymbolicNames);
-
-			File binaryFile = deployAppLicense(app, Time.HOUR);
-
-			assertLicensePropertiesExisted(getProductId(app));
-
-			assertPortalLicenseRegistered();
-
-			assertBundlesNotExisted(appSymbolicNames);
-
-			binaryFile.delete();
-
-			checkLicense(getProductId(app));
-
-			assertLicensePropertiesNotExisted(getProductId(app));
-
-			resetLifecycleAction();
-
-			assertPortalLicenseRegistered();
-
-			assertBundlesNotExisted(appSymbolicNames);
 		}
 	}
 

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
@@ -286,17 +286,6 @@ public abstract class BaseLicenseTestCase implements Serializable {
 
 				field.set(_lifecycleAction, 0L);
 			}
-			else if (Objects.equals(field.getType(), Map.class)) {
-				Map<?, ?> map = (Map<?, ?>)field.get(_lifecycleAction);
-
-				for (Object object : map.values()) {
-					if (Long.class.isAssignableFrom(object.getClass())) {
-						map.clear();
-
-						break;
-					}
-				}
-			}
 		}
 	}
 

--- a/release.properties
+++ b/release.properties
@@ -152,7 +152,7 @@
 ##
 
     release.tool.dir=ext/7.4.x
-    release.tool.sha=9a4499ba1a8691989d608b98827ecccf66f7b9a1
+    release.tool.sha=2f6afe29ad50721264078bcc2489ab1850bcc373
 
 ##
 ## Sonatype


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101130

## What Is Being Fixed

The AppModuleLicenseTest integration tests carried redundant coverage. testEnterpriseLicense and testFreeTierLicense each inspected bundle symbolic names to assert which app bundles were enabled or disabled, duplicating setup and asserting internal bundle state the underlying feature no longer tracks. BaseLicenseTestCase.resetLifecycleAction also cleared a Map field via reflection that the LifecycleAction no longer maintains.

## How It Is Being Fixed

The two tests are consolidated into a single testAppLicenses test that iterates over every App value and asserts license behavior through the public LicenseManagerUtil API — isAppEnabled and getAppExpirationDate — rather than reaching into bundle symbolic names. This drops the bundle-name helper and the enterprise/free-tier split, which no longer change the assertions. In BaseLicenseTestCase, the reflective Map-clearing branch in resetLifecycleAction is removed because the LifecycleAction no longer keeps last-check times for app bundles, so there is nothing to reset.

## Why Are There No Tests?

This is a pure test-code refactor. It simplifies existing integration test coverage without changing any production behavior, so no new tests are warranted.

## PR Check

**pr-check: PASS** — tested on `a97f65726b72dae03e33d25526915e24e49717be`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "a97f65726b72dae03e33d25526915e24e49717be"} -->
