### PR TITLE
LPD-101612 Bump Apache Neethi to 3.2.3

### DIFF
--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -952,7 +952,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.document.library.repository.cmis.impl.jar!neethi.jar</file-name>
-				<version>3.2.2</version>
+				<version>3.2.3</version>
 				<project-name>Apache Neethi</project-name>
 				<project-url>https://www.apache.org/</project-url>
 				<licenses>
@@ -7000,7 +7000,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.sharepoint.soap.repository.jar!neethi.jar</file-name>
-				<version>3.2.2</version>
+				<version>3.2.3</version>
 				<project-name>Apache Neethi</project-name>
 				<project-url>https://www.apache.org/</project-url>
 				<licenses>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -531,7 +531,7 @@
                 </tr>
                 			
                 <tr>
-                    <td nowrap="nowrap">com.liferay.document.library.repository.cmis.impl.jar!neethi.jar</td><td nowrap="nowrap">3.2.2</td><td nowrap="nowrap"><a href="https://www.apache.org/">Apache Neethi</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache-2.0</a>
+                    <td nowrap="nowrap">com.liferay.document.library.repository.cmis.impl.jar!neethi.jar</td><td nowrap="nowrap">3.2.3</td><td nowrap="nowrap"><a href="https://www.apache.org/">Apache Neethi</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache-2.0</a>
                         <br>
                     </td><td></td>
                 </tr>
@@ -3621,7 +3621,7 @@
                 </tr>
                 			
                 <tr>
-                    <td nowrap="nowrap">com.liferay.sharepoint.soap.repository.jar!neethi.jar</td><td nowrap="nowrap">3.2.2</td><td nowrap="nowrap"><a href="https://www.apache.org/">Apache Neethi</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache-2.0</a>
+                    <td nowrap="nowrap">com.liferay.sharepoint.soap.repository.jar!neethi.jar</td><td nowrap="nowrap">3.2.3</td><td nowrap="nowrap"><a href="https://www.apache.org/">Apache Neethi</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache-2.0</a>
                         <br>
                     </td><td></td>
                 </tr>

--- a/modules/apps/document-library/document-library-repository-cmis-impl/build.gradle
+++ b/modules/apps/document-library/document-library-repository-cmis-impl/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 	compileInclude group: "com.liferay", name: "org.apache.cxf.rt.wsdl", version: "3.6.11.JAKARTA-LIFERAY-PATCHED-1"
 	compileInclude group: "org.apache.chemistry.opencmis", name: "chemistry-opencmis-client-api", version: "0.14.0"
 	compileInclude group: "org.apache.chemistry.opencmis", name: "chemistry-opencmis-client-impl", version: "0.14.0"
-	compileInclude group: "org.apache.neethi", name: "neethi", version: "3.2.2"
+	compileInclude group: "org.apache.neethi", name: "neethi", version: "3.2.3"
 	compileOnly group: "com.fasterxml.woodstox", name: "woodstox-core", version: "6.4.0"
 	compileOnly group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"

--- a/modules/apps/portal-remote/portal-remote-soap-extender-impl/build.gradle
+++ b/modules/apps/portal-remote/portal-remote-soap-extender-impl/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "jakarta.xml.ws", name: "jakarta.xml.ws-api", version: "3.0.1"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.dependencymanager", version: "4.6.0"
-	compileOnly group: "org.apache.neethi", name: "neethi", version: "3.2.2"
+	compileOnly group: "org.apache.neethi", name: "neethi", version: "3.2.3"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:portal-remote:portal-remote-soap-extender-api")

--- a/modules/dxp/apps/sharepoint-soap/sharepoint-soap-repository/build.gradle
+++ b/modules/dxp/apps/sharepoint-soap/sharepoint-soap-repository/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 	compileInclude group: "org.apache.axis2", name: "axis2-xmlbeans", version: "1.8.0"
 	compileInclude group: "org.apache.httpcomponents", name: "httpclient", version: "4.5.13"
 	compileInclude group: "org.apache.httpcomponents", name: "httpcore", version: "4.4.14"
-	compileInclude group: "org.apache.neethi", name: "neethi", version: "3.2.2"
+	compileInclude group: "org.apache.neethi", name: "neethi", version: "3.2.3"
 	compileInclude group: "org.apache.woden", name: "woden-api", version: "1.0M9"
 	compileInclude group: "org.apache.ws.xmlschema", name: "xmlschema-core", version: "2.2.1"
 	compileInclude group: "org.apache.xmlbeans", name: "xmlbeans", version: "3.1.0"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101612

## What Is Being Fixed

Three modules pin Apache Neethi 3.2.2: `document-library-repository-cmis-impl`, `sharepoint-soap-repository` and `portal-remote-soap-extender-impl`. The current upstream release is 3.2.3, published to Maven Central on 2026-07-24, and the ticket asks for 3.2.3 or above.

## How It Is Being Fixed

The version literal moves to 3.2.3 in the three `build.gradle` files. There is no central pin for this library, so the version is duplicated per module and all three have to move together. The `neethi-*.jar` glob in the `deployDependencies` block of `portal-remote-soap-extender-impl` and the `!org.apache.neethi.*` import negations in the two embedding modules are version-agnostic and need no edit. A second commit carries the regenerated `lib/versions-complete.xml` and `lib/versions.html` from `ant build-lib-versions`, matching how the previous bump of this library landed.

The upgrade is a drop-in. The 3.2.3 OSGi manifest keeps the same `Bundle-SymbolicName`, the same five exported packages, the same `Import-Package` set with `org.apache.axiom.om` optional, and the same JavaSE 1.8 requirement, so both consumption paths still work: the jar embedded through `compileInclude` in the two repository modules, and the standalone bundle that `portal-remote-soap-extender-impl` imports. A class-list and signature diff of 3.2.2 against 3.2.3 shows nothing removed and no signature changed, so CXF 3.6.11 and Axis2 1.8.0 link against it unchanged.

## Why Are There No Tests?

The change is a third-party dependency version literal, which has no testable surface of its own, and the previous bump of this library landed the same way. It was verified by rebuilding with `ant all` and booting the portal: bundle `147 Apache Neethi (3.2.3)` is Active, and the three consuming bundles are Active too — `1288` Portal Remote SOAP Extender Implementation, `1017` Document Library Repository CMIS Implementation and `861` Sharepoint SOAP Repository — with no unresolved requirements in the log.

## PR Check

**pr-check: PASS** — tested on `735da9d69790e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Structural Smoke | PASS |

Structural Smoke note: `ModulesStructureTest` passed 8/8. `LibraryReferenceTest` reports one failure, `testIntelliJLibPreModules`, which reproduces identically on clean `master` at `9bc377c568ae2` and is unrelated to this change.

<!-- pr-check {"result": "success", "sha": "735da9d69790ec3b63e8fd3916aec87438ca6fea"} -->
