### PR TITLE
LPD-96888 Let Hibernate reconcile a sequence increment size mismatch

### DIFF
--- a/modules/util/portal-tools-service-builder-test-sequence-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/sequence/service/test/SequenceEntryLocalServiceTest.java
+++ b/modules/util/portal-tools-service-builder-test-sequence-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/sequence/service/test/SequenceEntryLocalServiceTest.java
@@ -6,15 +6,23 @@
 package com.liferay.portal.tools.service.builder.test.sequence.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Release;
+import com.liferay.portal.kernel.service.ReleaseLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.tools.service.builder.test.sequence.service.SequenceEntryLocalService;
 
+import java.io.IOException;
 import java.io.InputStream;
+
+import java.sql.SQLException;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -51,6 +59,8 @@ public class SequenceEntryLocalServiceTest {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
+		_deleteSequenceEntrySchema();
+
 		Bundle bundle = FrameworkUtil.getBundle(
 			SequenceEntryLocalServiceTest.class);
 
@@ -73,6 +83,8 @@ public class SequenceEntryLocalServiceTest {
 	@AfterClass
 	public static void tearDownClass() throws Exception {
 		_bundle.uninstall();
+
+		_deleteSequenceEntrySchema();
 	}
 
 	@Test
@@ -81,6 +93,34 @@ public class SequenceEntryLocalServiceTest {
 			_sequenceEntryLocalService.addSequenceEntry(
 				_sequenceEntryLocalService.createSequenceEntry(0)));
 	}
+
+	private static void _deleteSequenceEntrySchema() {
+		_runSQL("drop table SequenceEntry");
+		_runSQL("drop sequence id_sequence");
+
+		Release release = ReleaseLocalServiceUtil.fetchRelease(
+			"com.liferay.portal.tools.service.builder.test.sequence.service");
+
+		if (release != null) {
+			ReleaseLocalServiceUtil.deleteRelease(release);
+		}
+	}
+
+	private static void _runSQL(String sql) {
+		try {
+			DB db = DBManagerUtil.getDB();
+
+			db.runSQL(sql);
+		}
+		catch (IOException | SQLException exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SequenceEntryLocalServiceTest.class);
 
 	private static Bundle _bundle;
 

--- a/modules/util/portal-tools-service-builder-test-sequence-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/sequence/service/test/SequenceEntryLocalServiceTest.java
+++ b/modules/util/portal-tools-service-builder-test-sequence-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/sequence/service/test/SequenceEntryLocalServiceTest.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.tools.service.builder.test.sequence.model.SequenceEntry;
 import com.liferay.portal.tools.service.builder.test.sequence.service.SequenceEntryLocalService;
 
 import java.io.IOException;
@@ -89,9 +90,21 @@ public class SequenceEntryLocalServiceTest {
 
 	@Test
 	public void testAddSequenceEntry() {
-		Assert.assertNotNull(
-			_sequenceEntryLocalService.addSequenceEntry(
-				_sequenceEntryLocalService.createSequenceEntry(0)));
+		Assert.assertNotNull(_addSequenceEntry());
+	}
+
+	@Test
+	public void testAddSequenceEntryIncrementsPrimaryKeyByOne() {
+		SequenceEntry sequenceEntry1 = _addSequenceEntry();
+		SequenceEntry sequenceEntry2 = _addSequenceEntry();
+		SequenceEntry sequenceEntry3 = _addSequenceEntry();
+
+		Assert.assertEquals(
+			sequenceEntry1.getSequenceEntryId() + 1,
+			sequenceEntry2.getSequenceEntryId());
+		Assert.assertEquals(
+			sequenceEntry2.getSequenceEntryId() + 1,
+			sequenceEntry3.getSequenceEntryId());
 	}
 
 	private static void _deleteSequenceEntrySchema() {
@@ -117,6 +130,11 @@ public class SequenceEntryLocalServiceTest {
 				_log.debug(exception);
 			}
 		}
+	}
+
+	private SequenceEntry _addSequenceEntry() {
+		return _sequenceEntryLocalService.addSequenceEntry(
+			_sequenceEntryLocalService.createSequenceEntry(0));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/portal-impl/src/com/liferay/portal/spring/hibernate/PortalHibernateConfiguration.java
+++ b/portal-impl/src/com/liferay/portal/spring/hibernate/PortalHibernateConfiguration.java
@@ -109,6 +109,8 @@ public class PortalHibernateConfiguration
 		properties.setProperty(
 			"hibernate.current_session_context_class",
 			PortalCurrentSessionContext.class.getName());
+		properties.setProperty(
+			"hibernate.id.sequence.increment_size_mismatch_strategy", "FIX");
 
 		if (Validator.isNull(PropsValues.HIBERNATE_DIALECT)) {
 			Class<?> clazz = dialect.getClass();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96888

## What Is Being Fixed

The database defaults a sequence to an increment of 1, and Hibernate 5 defaults a sequence generator's increment size to 1 as well, so the mapping and the database agree. Hibernate 7 changed that default to 50, so they no longer agree, and the default mismatch strategy of EXCEPTION stops the session factory from building, which means the module never starts: "The increment size of the [id_sequence] sequence is set to [50] in the entity mapping but the mapped database sequence increment size is [1]".

## How It Is Being Fixed

Hibernate provides a setting for exactly this case, so ask it to take the increment size from the database rather than from the mapping. See https://docs.hibernate.org/orm/7.0/javadocs/org/hibernate/id/SequenceMismatchStrategy.html. PortletHibernateConfiguration extends PortalHibernateConfiguration, so every module session factory inherits the setting and no mapping has to be edited, including one that is hand written or was generated by an older Service Builder. An integration test pins the behavior by asserting that consecutive primary keys increment by one, and a schema cleanup lets that test rerun.

## PR Check

**pr-check: PASS** — tested on `46f6d27d14025461fccb9aac69929b48081204db`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "46f6d27d14025461fccb9aac69929b48081204db"} -->
