### PR TITLE
LPD-101861 Never query when an arrayable finder value is empty

### DIFF
--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/PermissionCheckFinderEntryTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/PermissionCheckFinderEntryTest.java
@@ -35,6 +35,7 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.tools.service.builder.test.model.PermissionCheckFinderEntry;
 import com.liferay.portal.tools.service.builder.test.service.PermissionCheckFinderEntryLocalService;
+import com.liferay.portal.tools.service.builder.test.service.persistence.PermissionCheckFinderEntryPersistence;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -78,6 +79,14 @@ public class PermissionCheckFinderEntryTest {
 			_group1.getGroupId(), _user.getUserId());
 		_permissionCheckFinderEntry3 = _addPermissionCheckFinderEntry(
 			_group2.getGroupId(), _user.getUserId());
+	}
+
+	@Test
+	public void testFilterFindByEmptyGroupIds() {
+		Assert.assertEquals(
+			Collections.emptyList(),
+			_permissionCheckFinderEntryLocalService.filterFindByGroupId(
+				new long[0]));
 	}
 
 	@Test
@@ -170,6 +179,22 @@ public class PermissionCheckFinderEntryTest {
 			Arrays.asList(
 				_permissionCheckFinderEntry2, _permissionCheckFinderEntry3),
 			Collections.singletonList(_permissionCheckFinderEntry2));
+	}
+
+	@Test
+	public void testFindByEmptyGroupIds() {
+		PermissionCheckFinderEntryPersistence
+			permissionCheckFinderEntryPersistence =
+				(PermissionCheckFinderEntryPersistence)
+					_permissionCheckFinderEntryLocalService.
+						getBasePersistence();
+
+		Assert.assertEquals(
+			Collections.emptyList(),
+			permissionCheckFinderEntryPersistence.findByGroupId(new long[0]));
+		Assert.assertEquals(
+			0,
+			permissionCheckFinderEntryPersistence.countByGroupId(new long[0]));
 	}
 
 	private PermissionCheckFinderEntry _addPermissionCheckFinderEntry(

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/CollectionPersistenceFinder.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/CollectionPersistenceFinder.java
@@ -80,6 +80,10 @@ public class CollectionPersistenceFinder
 
 			normalizeValues(values);
 
+			if (isEmptyArrayable(values)) {
+				return 0;
+			}
+
 			Object[] finderArgs = buildFinderArgs(values);
 
 			Long count = (Long)finderCache.getResult(
@@ -138,6 +142,10 @@ public class CollectionPersistenceFinder
 			}
 
 			normalizeValues(values);
+
+			if (isEmptyArrayable(values)) {
+				return Collections.emptyList();
+			}
 
 			FinderPath finderPath = null;
 			Object[] finderArgs = null;
@@ -221,6 +229,25 @@ public class CollectionPersistenceFinder
 
 			basePersistenceImpl.remove(entity);
 		}
+	}
+
+	protected boolean isEmptyArrayable(Object[] values) {
+		if (_arrayableIndexes == null) {
+			return false;
+		}
+
+		for (int index : _arrayableIndexes) {
+			ArrayableFinderColumn<?> arrayableFinderColumn =
+				(ArrayableFinderColumn<?>)finderColumns[index];
+
+			if (!arrayableFinderColumn.isAndOperator() &&
+				(Array.getLength(values[index]) == 0)) {
+
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private String _buildFindSql(

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/FilterCollectionPersistenceFinder.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/FilterCollectionPersistenceFinder.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.security.permission.InlineSQLHelperUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -241,6 +242,10 @@ public class FilterCollectionPersistenceFinder
 
 		normalizeValues(values);
 
+		if (isEmptyArrayable(values)) {
+			return 0;
+		}
+
 		String sql = _replacePermissionCheck(
 			buildSQLWhere(_filterSqlCountWhere, values, true), groupIds);
 
@@ -286,6 +291,10 @@ public class FilterCollectionPersistenceFinder
 		}
 
 		normalizeValues(values);
+
+		if (isEmptyArrayable(values)) {
+			return Collections.emptyList();
+		}
 
 		boolean inlineDistinct = basePersistenceImpl.getDB(
 		).isSupportsInlineDistinct();

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/packageinfo
@@ -1,1 +1,1 @@
-version 8.0.0
+version 8.1.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101861

## What Is Being Fixed

Service Builder's arrayable finders treat a zero length value array as "no condition at all" instead of "matches nothing". ArrayableFinderColumn.getSqlFragment returns an empty string for an empty array, and every SQL builder skips an empty fragment.

That produces two symptoms. When the arrayable column is the only condition and the finder declares no extra where clause, the generated JPQL ends with a dangling WHERE followed directly by ORDER BY, and Hibernate rejects it with antlr.NoViableAltException, aborting whatever was rendering the page. When the finder carries other conditions the query still parses, but the arrayable condition is silently dropped and rows matching every value of that column come back — on a groupId column that leaks content across sites. MBCategoryPersistence.findByNotC_G_P is affected by the silent variant today, since an empty parentCategoryIds array returns categories under every parent.

The defect is not new and it is not a regression from LPD-98241. The pre-refactor generated code had the identical flaw: removeConjunction only ever stripped a trailing " AND ", so it never guarded an empty array, and that template is still in use for pre-7.4 Service Builder targets. LPD-98241 is simply the first caller to reach it, through AssetVocabularyPersistence.findByGroupId when the resolved site and depot group array came back empty.

## How It Is Being Fixed

An empty IN set matches nothing, so the finder answers without touching the database. An empty NOT IN set excludes nothing, so isEmptyArrayable ignores columns whose arrayable operator is AND and leaves their condition to be dropped exactly as before — inverting that half would turn "matches every row" into "returns nothing", which is worse than the original bug.

The guard sits in find, count, filterFind, and filterCount because each of those builds and runs its own query, and the shared code further down only returns a SQL string, so it cannot express "skip the query". Returning before the finder cache lookup also keeps the cache clean, and it mirrors the length one short circuit already present a few lines above in find and count.

The check lives in CollectionPersistenceFinder so it can reuse the arrayable column indexes and isAndOperator that _isMultiElementArrayable and _paginate already rely on. It is protected rather than package private because the source formatter requires an explicit modifier on every method, and that one protected method is the whole addition to the exported API, hence the separate minor package version bump.

Dropping the WHERE keyword when no condition survives is deliberately left alone. Only a finder whose sole column is an arrayable NOT IN can reach that state, and no such finder exists — every arrayable-operator="AND" column in the repository sits alongside another column.

Verified against a Hibernate 5.6.7 bundle. Before the fix testFilterFindByEmptyGroupIds failed with the same antlr.NoViableAltException, the same HqlBaseParser frames, and the same ErrorTracker pair reported on the ticket. After the fix all six tests in PermissionCheckFinderEntryTest pass and the portal log contains no parse error at all, which the module's LogAssertionAppender would otherwise catch.

## PR Check

**pr-check: PASS** — tested on `bc0e8603440cb75db6d0e34d60caa80495e4b377`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "bc0e8603440cb75db6d0e34d60caa80495e4b377"} -->
