### PR TITLE
LPD-101861 Never match when an arrayable IN finder value is empty

### DIFF
--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/PermissionCheckFinderEntryTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/PermissionCheckFinderEntryTest.java
@@ -30,11 +30,14 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.TransactionalTestRule;
 import com.liferay.portal.tools.service.builder.test.model.PermissionCheckFinderEntry;
 import com.liferay.portal.tools.service.builder.test.service.PermissionCheckFinderEntryLocalService;
+import com.liferay.portal.tools.service.builder.test.service.persistence.PermissionCheckFinderEntryPersistence;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -57,7 +60,11 @@ public class PermissionCheckFinderEntryTest {
 	@ClassRule
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			new TransactionalTestRule(
+				Propagation.REQUIRED,
+				"com.liferay.portal.tools.service.builder.test.service"));
 
 	@Before
 	public void setUp() throws Exception {
@@ -78,6 +85,14 @@ public class PermissionCheckFinderEntryTest {
 			_group1.getGroupId(), _user.getUserId());
 		_permissionCheckFinderEntry3 = _addPermissionCheckFinderEntry(
 			_group2.getGroupId(), _user.getUserId());
+	}
+
+	@Test
+	public void testFilterFindByEmptyGroupIds() {
+		Assert.assertEquals(
+			Collections.emptyList(),
+			_permissionCheckFinderEntryLocalService.filterFindByGroupId(
+				new long[0]));
 	}
 
 	@Test
@@ -170,6 +185,22 @@ public class PermissionCheckFinderEntryTest {
 			Arrays.asList(
 				_permissionCheckFinderEntry2, _permissionCheckFinderEntry3),
 			Collections.singletonList(_permissionCheckFinderEntry2));
+	}
+
+	@Test
+	public void testFindByEmptyGroupIds() {
+		PermissionCheckFinderEntryPersistence
+			permissionCheckFinderEntryPersistence =
+				(PermissionCheckFinderEntryPersistence)
+					_permissionCheckFinderEntryLocalService.
+						getBasePersistence();
+
+		Assert.assertEquals(
+			Collections.emptyList(),
+			permissionCheckFinderEntryPersistence.findByGroupId(new long[0]));
+		Assert.assertEquals(
+			0,
+			permissionCheckFinderEntryPersistence.countByGroupId(new long[0]));
 	}
 
 	private PermissionCheckFinderEntry _addPermissionCheckFinderEntry(

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/ArrayableFinderColumn.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/ArrayableFinderColumn.java
@@ -34,12 +34,18 @@ public class ArrayableFinderColumn<T extends BaseModel<T>>
 		_hqlInPrefix = StringBundler.concat(
 			"(", entityAlias, columnName, andOperator ? " NOT IN (" : " IN (");
 
+		_hqlNeverMatches = StringBundler.concat(
+			"(", entityAlias, columnName, " IN (NULL))");
+
 		if (Objects.equals(columnName, dbColumnName)) {
 			_sqlInPrefix = _hqlInPrefix;
+			_sqlNeverMatches = _hqlNeverMatches;
 		}
 		else {
 			_sqlInPrefix = StringUtil.replace(
 				_hqlInPrefix, columnName, dbColumnName);
+			_sqlNeverMatches = StringUtil.replace(
+				_hqlNeverMatches, columnName, dbColumnName);
 		}
 	}
 
@@ -75,7 +81,15 @@ public class ArrayableFinderColumn<T extends BaseModel<T>>
 		Object[] array = (Object[])normalizedValue;
 
 		if (array.length == 0) {
-			return "";
+			if (_andOperator) {
+				return "";
+			}
+
+			if (sqlQuery) {
+				return _sqlNeverMatches;
+			}
+
+			return _hqlNeverMatches;
 		}
 
 		if (type == Type.STRING) {
@@ -233,6 +247,8 @@ public class ArrayableFinderColumn<T extends BaseModel<T>>
 
 	private final boolean _andOperator;
 	private final String _hqlInPrefix;
+	private final String _hqlNeverMatches;
 	private final String _sqlInPrefix;
+	private final String _sqlNeverMatches;
 
 }

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/service/persistence/impl/ArrayableFinderColumnTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/service/persistence/impl/ArrayableFinderColumnTest.java
@@ -20,16 +20,48 @@ import org.junit.Test;
 public class ArrayableFinderColumnTest {
 
 	@Test
-	public void testEmptyArrayDropsConstraint() {
+	public void testEmptyArrayAndOperatorDropsConstraint() {
+		ArrayableFinderColumn<TestModel> arrayableFinderColumn = _newLongColumn(
+			true, entity -> 0L);
+
+		Object normalizedValue = arrayableFinderColumn.normalizeValue(null);
+
+		Assert.assertEquals(
+			"", arrayableFinderColumn.getSqlFragment(normalizedValue, false));
+	}
+
+	@Test
+	public void testEmptyArrayNeverMatches() {
 		ArrayableFinderColumn<TestModel> arrayableFinderColumn = _newLongColumn(
 			false, entity -> 0L);
 
 		Object normalizedValue = arrayableFinderColumn.normalizeValue(null);
 
 		Assert.assertEquals(
-			"", arrayableFinderColumn.getSqlFragment(normalizedValue, false));
+			"(t.col IN (NULL))",
+			arrayableFinderColumn.getSqlFragment(normalizedValue, false));
+		Assert.assertEquals(
+			"(t.col IN (NULL))",
+			arrayableFinderColumn.getSqlFragment(normalizedValue, true));
 		Assert.assertEquals(
 			"", arrayableFinderColumn.toFinderArg(normalizedValue));
+	}
+
+	@Test
+	public void testEmptyArrayNeverMatchesNative() {
+		ArrayableFinderColumn<TestModel> arrayableFinderColumn =
+			new ArrayableFinderColumn<>(
+				"t.", "active", "active_", FinderColumn.Type.BOOLEAN, "=",
+				false, true, true, entity -> true);
+
+		Object normalizedValue = arrayableFinderColumn.normalizeValue(null);
+
+		Assert.assertEquals(
+			"(t.active IN (NULL))",
+			arrayableFinderColumn.getSqlFragment(normalizedValue, false));
+		Assert.assertEquals(
+			"(t.active_ IN (NULL))",
+			arrayableFinderColumn.getSqlFragment(normalizedValue, true));
 	}
 
 	@Test
@@ -129,14 +161,15 @@ public class ArrayableFinderColumnTest {
 	}
 
 	@Test
-	public void testStringEmptyArrayDropsConstraint() {
+	public void testStringEmptyArrayNeverMatches() {
 		ArrayableFinderColumn<TestModel> arrayableFinderColumn =
 			_newStringColumn(false, true, false, entity -> "anything");
 
 		Object normalizedValue = arrayableFinderColumn.normalizeValue(null);
 
 		Assert.assertEquals(
-			"", arrayableFinderColumn.getSqlFragment(normalizedValue, false));
+			"(t.col IN (NULL))",
+			arrayableFinderColumn.getSqlFragment(normalizedValue, false));
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101861

## What Is Being Fixed

`ArrayableFinderColumn.getSqlFragment` returned an empty fragment for a zero length array, and every SQL builder skips an empty fragment with `continue`. The constraint was therefore dropped from the `WHERE` clause, with two symptoms. A finder whose columns are all arrayable produced `... WHERE  ORDER BY ...`, which does not parse (`antlr.NoViableAltException: unexpected token: ORDER`). With other conditions present the arrayable filter silently disappeared instead, so a `groupId` array leaked rows across sites — the quieter and more dangerous half.

LPD-98241 surfaced the first symptom through `AssetVocabularyLocalServiceImpl.getGroupsVocabularies`, where `getCurrentAndAncestorSiteAndDepotGroupIds(0)` returns `long[0]`.

## How It Is Being Fixed

An empty `IN` list can never match anything, so the fragment now says exactly that instead of saying nothing at all. An empty `NOT IN` list excludes nothing, which genuinely is the absence of a constraint, so it keeps returning nothing. That also leaves the SQL of the three existing `NOT IN` arrayable finders (`MBCategory` twice, `JournalArticle` once) untouched.

The never matching condition is `IN (NULL)` rather than a literal such as `1 = 0`. Comparing against `NULL` yields unknown rather than true for every column type on every database, and deriving it from the column follows the same shape as `hqlBind`, `hqlNull` and `hqlIsNull`: built in the constructor and stored as an HQL and SQL pair so the native form uses the database column name. It also names the column in the query log, which says which filter was emptied.

Deciding this in the column needs no new emptiness check, since the zero length test is already there, and one place covers every path: `count`, `find`, `filterCount` and `filterFind` all reach the same method, as does the builder in `UniquePersistenceFinder` that no caller guards. It also avoids a downcast, because only the column knows whether it is `IN` or `NOT IN`.

`PermissionCheckFinderEntryTest` gains a `TransactionalTestRule`, matching the generated `PermissionCheckFinderEntryPersistenceTest` in the same module. Without a transaction the persistence call fails in `VerifySessionFactoryWrapper` before it reaches SQL, so the test could not have validated the generated query.

The same change is on jeffwu0724#1414 for Hibernate 7.

## PR Check

**pr-check: PASS** — tested on `473664877fa90a2c986220b523056cb831118f90`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "473664877fa90a2c986220b523056cb831118f90"} -->
