### PR TITLE
LPD-100132 Test Hibernate session flush across partition scope changes

### DIFF
--- a/modules/apps/portal/portal-db-partition-test/source-formatter-suppressions.xml
+++ b/modules/apps/portal/portal-db-partition-test/source-formatter-suppressions.xml
@@ -5,6 +5,7 @@
 		<suppress checks="CompanyIterationCheck" files="src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest\.java" />
 		<suppress checks="CompanyIterationCheck" files="src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest\.java" />
 		<suppress checks="JavaUpgradeIndexCheck" files="src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest\.java" />
+		<suppress checks="PersistenceCallCheck" files="src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest\.java" />
 	</checkstyle>
 	<source-check>
 		<suppress checks="JavaUpgradeIndexCheck" files="src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest\.java" />

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
@@ -10,14 +10,13 @@ import com.liferay.counter.kernel.service.CounterLocalService;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
-import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.RoleConstants;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.persistence.RolePersistence;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.transaction.Propagation;
@@ -29,9 +28,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
-import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -41,20 +38,11 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 
-	@BeforeClass
-	public static void setUpClass() throws Exception {
-		_company = CompanyTestUtil.addCompany();
-	}
-
-	@AfterClass
-	public static void tearDownClass() throws Exception {
-		companyLocalService.deleteCompany(_company.getCompanyId());
-	}
-
 	@Test
 	public void testSetCompanyIdWithSafeCloseableFlushesSessionOnClose()
 		throws Throwable {
 
+		long defaultCompanyId = PortalInstancePool.getDefaultCompanyId();
 		String name = RandomTestUtil.randomString();
 
 		TransactionInvokerUtil.invoke(
@@ -62,9 +50,9 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 			() -> {
 				try (SafeCloseable safeCloseable =
 						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-							_company.getCompanyId())) {
+							defaultCompanyId)) {
 
-					_addRole(_company.getCompanyId(), name);
+					_addRole(defaultCompanyId, name);
 				}
 
 				return null;
@@ -72,10 +60,11 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 
 		try {
 			Assert.assertFalse(_hasRole(TestPropsValues.getCompanyId(), name));
-			Assert.assertTrue(_hasRole(_company.getCompanyId(), name));
+			Assert.assertTrue(_hasRole(defaultCompanyId, name));
 		}
 		finally {
 			_deleteRole(TestPropsValues.getCompanyId(), name);
+			_deleteRole(defaultCompanyId, name);
 		}
 	}
 
@@ -83,6 +72,7 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 	public void testSetCompanyIdWithSafeCloseableFlushesSessionOnEntry()
 		throws Throwable {
 
+		long defaultCompanyId = PortalInstancePool.getDefaultCompanyId();
 		String name = RandomTestUtil.randomString();
 
 		TransactionInvokerUtil.invoke(
@@ -92,7 +82,7 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 
 				try (SafeCloseable safeCloseable =
 						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-							_company.getCompanyId())) {
+							defaultCompanyId)) {
 
 					_roleLocalService.dynamicQuery(
 						_roleLocalService.dynamicQuery());
@@ -102,11 +92,12 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 			});
 
 		try {
-			Assert.assertFalse(_hasRole(_company.getCompanyId(), name));
+			Assert.assertFalse(_hasRole(defaultCompanyId, name));
 			Assert.assertTrue(_hasRole(TestPropsValues.getCompanyId(), name));
 		}
 		finally {
 			_deleteRole(TestPropsValues.getCompanyId(), name);
+			_deleteRole(defaultCompanyId, name);
 		}
 	}
 
@@ -156,7 +147,6 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 		}
 	}
 
-	private static Company _company;
 	private static final TransactionConfig _transactionConfig =
 		TransactionConfig.Factory.create(
 			Propagation.REQUIRED, new Class<?>[] {Exception.class});

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
@@ -71,8 +71,8 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 			});
 
 		try {
-			Assert.assertTrue(_hasRole(_company.getCompanyId(), name));
 			Assert.assertFalse(_hasRole(TestPropsValues.getCompanyId(), name));
+			Assert.assertTrue(_hasRole(_company.getCompanyId(), name));
 		}
 		finally {
 			_deleteRole(TestPropsValues.getCompanyId(), name);
@@ -102,8 +102,8 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 			});
 
 		try {
-			Assert.assertTrue(_hasRole(TestPropsValues.getCompanyId(), name));
 			Assert.assertFalse(_hasRole(_company.getCompanyId(), name));
+			Assert.assertTrue(_hasRole(TestPropsValues.getCompanyId(), name));
 		}
 		finally {
 			_deleteRole(TestPropsValues.getCompanyId(), name);
@@ -121,7 +121,7 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 		role.setName(name);
 		role.setType(RoleConstants.TYPE_REGULAR);
 
-		_roleLocalService.updateRole(role);
+		_rolePersistence.update(role);
 	}
 
 	private void _deleteRole(long companyId, String name) throws Exception {

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
@@ -1,0 +1,176 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.db.partition.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.counter.kernel.service.CounterLocalService;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.RoleConstants;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.persistence.RolePersistence;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
+import com.liferay.portal.test.rule.Inject;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jorge Avalos
+ */
+@RunWith(Arquillian.class)
+public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_company = CompanyTestUtil.addCompany();
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		companyLocalService.deleteCompany(_company.getCompanyId());
+	}
+
+	@Test
+	public void testSetCompanyIdWithSafeCloseableFlushesSessionOnClose()
+		throws Throwable {
+
+		String name = RandomTestUtil.randomString();
+
+		TransactionInvokerUtil.invoke(
+			_transactionConfig,
+			() -> {
+				try (SafeCloseable safeCloseable =
+						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+							_company.getCompanyId())) {
+
+					_addRole(_company.getCompanyId(), name);
+				}
+
+				return null;
+			});
+
+		try {
+			Assert.assertTrue(_hasRole(_company.getCompanyId(), name));
+			Assert.assertFalse(_hasRole(TestPropsValues.getCompanyId(), name));
+		}
+		finally {
+			_deleteRole(TestPropsValues.getCompanyId(), name);
+		}
+	}
+
+	@Test
+	public void testSetCompanyIdWithSafeCloseableFlushesSessionOnEntry()
+		throws Throwable {
+
+		String name = RandomTestUtil.randomString();
+
+		TransactionInvokerUtil.invoke(
+			_transactionConfig,
+			() -> {
+				_addRole(TestPropsValues.getCompanyId(), name);
+
+				try (SafeCloseable safeCloseable =
+						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+							_company.getCompanyId())) {
+
+					_roleLocalService.dynamicQuery(
+						_roleLocalService.dynamicQuery());
+				}
+
+				return null;
+			});
+
+		try {
+			Assert.assertTrue(_hasRole(TestPropsValues.getCompanyId(), name));
+			Assert.assertFalse(_hasRole(_company.getCompanyId(), name));
+		}
+		finally {
+			_deleteRole(TestPropsValues.getCompanyId(), name);
+		}
+	}
+
+	private void _addRole(long companyId, String name) {
+		long roleId = _counterLocalService.increment();
+
+		Role role = _rolePersistence.create(roleId);
+
+		role.setCompanyId(companyId);
+		role.setClassNameId(_classNameLocalService.getClassNameId(Role.class));
+		role.setClassPK(roleId);
+		role.setName(name);
+		role.setType(RoleConstants.TYPE_REGULAR);
+
+		_roleLocalService.updateRole(role);
+	}
+
+	private void _deleteRole(long companyId, String name) throws Exception {
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setRawCompanyIdWithSafeCloseable(companyId);
+
+			Connection connection = DataAccess.getConnection();
+
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"delete from Role_ where name = ?")) {
+
+			preparedStatement.setString(1, name);
+
+			preparedStatement.execute();
+		}
+	}
+
+	private boolean _hasRole(long companyId, String name) throws Exception {
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setRawCompanyIdWithSafeCloseable(companyId);
+
+			Connection connection = DataAccess.getConnection();
+
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select roleId from Role_ where name = ?")) {
+
+			preparedStatement.setString(1, name);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				return resultSet.next();
+			}
+		}
+	}
+
+	private static Company _company;
+	private static final TransactionConfig _transactionConfig =
+		TransactionConfig.Factory.create(
+			Propagation.REQUIRED, new Class<?>[] {Exception.class});
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@Inject
+	private CounterLocalService _counterLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@Inject
+	private RolePersistence _rolePersistence;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100132

Sent directly to Core Infrastructure. `pr-check`'s Transaction Usage validation passes only for @shuyangzhou, and the test being added is his: the two `TransactionInvokerUtil.invoke(...)` calls wrapping the scenario bodies come from his own description on the ticket. There is no production transaction code here, no `REQUIRES_NEW`, and no commit callbacks — the transaction usage is confined to the test harness.

The ticket is old. Victor Ware filed it on 2023-08-15 to cover a gap LPS-185647 left behind, and it has been open since. The gap is still open on master today.

Supersedes liferay-database-infra/liferay-portal#3811, and #3774 before it — that one was opened while the ticket still carried its `LPS-193587` key. The tree has not changed across any of them: both files are byte-identical to the revision @marianoalvarosaiz approved on #3774 and @jorgediaz-lr approved on #3811. This branch is only rebased onto current master.

## What Is Being Fixed

LPS-185647 made `CompanyThreadLocal` flush and clear the pending Hibernate session when the active company changes under `DATABASE_PARTITION_ENABLED`, so writes land in the correct DB partition. It shipped with no test coverage. Two scenarios misroute a write without it:

1. A transaction writes for the current company, enters another company's scope, and runs an overlapping query — auto-flush fires against the wrong partition.
1. A transaction enters another company's scope, writes there, returns to the outer scope, and commits — the pending write flushes to the outer partition.

## How It Is Being Fixed

`TransactionFlushDBPartitionTest` extends `BaseDBPartitionTestCase`, so it runs only when partitioning is enabled and the vendor supports it, and inherits the base class's rules and `assume()` guard order verbatim. Each test opens a real transaction around `CompanyThreadLocal.setCompanyIdWithSafeCloseable`, forces one flush trigger (a query on entry, or the `SafeCloseable` close), and asserts the row landed in the right partition and not the other.

Three details exist to stop the test passing for the wrong reason:

- **Writes go through `RolePersistence` directly**, as the ticket requires. `RoleLocalService.addRole` reaches a finder through `addResources`, which auto-flushes regardless of the fix — both tests would pass with LPS-185647 reverted. `Checkstyle:PersistenceCallCheck` (LPS-68923) forbids the cross-package `update()`, so this needs one suppression in the module's existing `source-formatter-suppressions.xml`; four sibling integration tests already carry one for the same check, two of them under `modules/apps/portal`.
- **Reads use raw JDBC** scoped by `setRawCompanyIdWithSafeCloseable`. `RoleLocalService.fetchRole` is served from a finder cache keyed at write time and never reflects the actual partition.
- **Neither company is provisioned.** A partition-enabled run already has two: `TestPropsValues.getCompanyId()` resolves through `database.partition.company.web.id`, not `company.default.web.id`, so it never collides with `PortalInstancePool.getDefaultCompanyId()`. Both outlive the test, so each scenario cleans its role from both partitions.

Confirmed against a partition-enabled bundle on PostgreSQL 16.3: both tests pass with the flush intact, both fail with a bare `AssertionError` once `CompanyThreadLocal._syncLastDBPartitionSessionState` is disabled, and both pass again when it is restored.
