### PR TITLE
LPD-102291 Add per-database CI test suites for Service Builder

### DIFF
--- a/ci.properties
+++ b/ci.properties
@@ -134,6 +134,13 @@ ci.test.available.suites=\
     security,\
     security-playwright,\
     service-builder,\
+    service-builder-db2,\
+    service-builder-hypersonic,\
+    service-builder-mariadb,\
+    service-builder-mysql,\
+    service-builder-oracle,\
+    service-builder-postgresql,\
+    service-builder-sqlserver,\
     service-builder-tester,\
     setup-wizard,\
     sf,\
@@ -273,6 +280,13 @@ ci.test.suite.description[search-remote-minimum]=Test search tests with the mini
 ci.test.suite.description[security]=Test all Application Security team tests.
 ci.test.suite.description[security-playwright]=Test all Application Security team Playwright tests.
 ci.test.suite.description[service-builder]=Test Service Builder tests.
+ci.test.suite.description[service-builder-db2]=Test Service Builder tests on DB2.
+ci.test.suite.description[service-builder-hypersonic]=Test Service Builder tests on Hypersonic.
+ci.test.suite.description[service-builder-mariadb]=Test Service Builder tests on MariaDB.
+ci.test.suite.description[service-builder-mysql]=Test Service Builder tests on MySQL.
+ci.test.suite.description[service-builder-oracle]=Test Service Builder tests on Oracle.
+ci.test.suite.description[service-builder-postgresql]=Test Service Builder tests on PostgreSQL.
+ci.test.suite.description[service-builder-sqlserver]=Test Service Builder tests on SQL Server.
 ci.test.suite.description[service-builder-tester]=Tests Service Builder changes against legacy branches.
 ci.test.suite.description[setup-wizard]=Test Setup Wizard tests.
 ci.test.suite.description[sf]=Test source formatter.

--- a/test.properties
+++ b/test.properties
@@ -6613,6 +6613,142 @@
         testray.main.component.name == "Service Builder"
 
     #
+    # Service Builder DB2
+    #
+
+    test.batch.class.names.includes[service-builder-db2]=\
+        **/portal-tools-service-builder-test-sequence-service/**/*Test.java,\
+        **/portal-tools-service-builder-test-sequence-test/**/*Test.java,\
+        **/portal-tools-service-builder-test-service/**/*Test.java,\
+        **/portal-tools-service-builder-test-test/**/*Test.java
+
+    test.batch.dist.app.servers[service-builder-db2]=tomcat
+
+    test.batch.names[service-builder-db2]=\
+        functional-tomcat101-db2111,\
+        modules-integration-db2111
+
+    test.batch.run.property.query[functional-tomcat*][service-builder-db2]=\
+        testray.main.component.name == "Service Builder"
+
+    #
+    # Service Builder Hypersonic
+    #
+
+    test.batch.class.names.includes[service-builder-hypersonic]=\
+        **/portal-tools-service-builder-test-sequence-service/**/*Test.java,\
+        **/portal-tools-service-builder-test-sequence-test/**/*Test.java,\
+        **/portal-tools-service-builder-test-service/**/*Test.java,\
+        **/portal-tools-service-builder-test-test/**/*Test.java
+
+    test.batch.dist.app.servers[service-builder-hypersonic]=tomcat
+
+    test.batch.names[service-builder-hypersonic]=\
+        functional-tomcat101-hypersonic20,\
+        modules-integration-hypersonic20
+
+    test.batch.run.property.query[functional-tomcat*][service-builder-hypersonic]=\
+        testray.main.component.name == "Service Builder"
+
+    #
+    # Service Builder MariaDB
+    #
+
+    test.batch.class.names.includes[service-builder-mariadb]=\
+        **/portal-tools-service-builder-test-sequence-service/**/*Test.java,\
+        **/portal-tools-service-builder-test-sequence-test/**/*Test.java,\
+        **/portal-tools-service-builder-test-service/**/*Test.java,\
+        **/portal-tools-service-builder-test-test/**/*Test.java
+
+    test.batch.dist.app.servers[service-builder-mariadb]=tomcat
+
+    test.batch.names[service-builder-mariadb]=\
+        functional-tomcat101-mariadb104,\
+        modules-integration-mariadb104
+
+    test.batch.run.property.query[functional-tomcat*][service-builder-mariadb]=\
+        testray.main.component.name == "Service Builder"
+
+    #
+    # Service Builder MySQL
+    #
+
+    test.batch.class.names.excludes[modules-integration-mysql84][service-builder-mysql]=\
+        **/portal-tools-service-builder-test-sequence-test/**/SequenceEntryLocalServiceTest.java
+
+    test.batch.class.names.includes[service-builder-mysql]=\
+        **/portal-tools-service-builder-test-sequence-service/**/*Test.java,\
+        **/portal-tools-service-builder-test-sequence-test/**/*Test.java,\
+        **/portal-tools-service-builder-test-service/**/*Test.java,\
+        **/portal-tools-service-builder-test-test/**/*Test.java
+
+    test.batch.dist.app.servers[service-builder-mysql]=tomcat
+
+    test.batch.names[service-builder-mysql]=\
+        functional-tomcat101-mysql84,\
+        modules-integration-mysql84
+
+    test.batch.run.property.query[functional-tomcat*][service-builder-mysql]=\
+        testray.main.component.name == "Service Builder"
+
+    #
+    # Service Builder Oracle
+    #
+
+    test.batch.class.names.includes[service-builder-oracle]=\
+        **/portal-tools-service-builder-test-sequence-service/**/*Test.java,\
+        **/portal-tools-service-builder-test-sequence-test/**/*Test.java,\
+        **/portal-tools-service-builder-test-service/**/*Test.java,\
+        **/portal-tools-service-builder-test-test/**/*Test.java
+
+    test.batch.dist.app.servers[service-builder-oracle]=tomcat
+
+    test.batch.names[service-builder-oracle]=\
+        functional-tomcat101-oracle193,\
+        modules-integration-oracle193
+
+    test.batch.run.property.query[functional-tomcat*][service-builder-oracle]=\
+        testray.main.component.name == "Service Builder"
+
+    #
+    # Service Builder PostgreSQL
+    #
+
+    test.batch.class.names.includes[service-builder-postgresql]=\
+        **/portal-tools-service-builder-test-sequence-service/**/*Test.java,\
+        **/portal-tools-service-builder-test-sequence-test/**/*Test.java,\
+        **/portal-tools-service-builder-test-service/**/*Test.java,\
+        **/portal-tools-service-builder-test-test/**/*Test.java
+
+    test.batch.dist.app.servers[service-builder-postgresql]=tomcat
+
+    test.batch.names[service-builder-postgresql]=\
+        functional-tomcat101-postgresql121,\
+        modules-integration-postgresql121
+
+    test.batch.run.property.query[functional-tomcat*][service-builder-postgresql]=\
+        testray.main.component.name == "Service Builder"
+
+    #
+    # Service Builder SQLServer
+    #
+
+    test.batch.class.names.includes[service-builder-sqlserver]=\
+        **/portal-tools-service-builder-test-sequence-service/**/*Test.java,\
+        **/portal-tools-service-builder-test-sequence-test/**/*Test.java,\
+        **/portal-tools-service-builder-test-service/**/*Test.java,\
+        **/portal-tools-service-builder-test-test/**/*Test.java
+
+    test.batch.dist.app.servers[service-builder-sqlserver]=tomcat
+
+    test.batch.names[service-builder-sqlserver]=\
+        functional-tomcat101-sqlserver2019,\
+        modules-integration-sqlserver2019
+
+    test.batch.run.property.query[functional-tomcat*][service-builder-sqlserver]=\
+        testray.main.component.name == "Service Builder"
+
+    #
     # Setup Wizard
     #
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102291

## What Is Being Fixed

CI had only a single `ci:test:service-builder` suite, which runs the Service Builder test modules across all seven supported databases at once. There was no way to run the Service Builder tests against one database in isolation — which is what you want when reproducing or triaging a database-specific failure without paying for the full seven-database fan-out.

## How It Is Being Fixed

Added seven per-database CI suites (`service-builder-db2`, `service-builder-hypersonic`, `service-builder-mariadb`, `service-builder-mysql`, `service-builder-oracle`, `service-builder-postgresql`, `service-builder-sqlserver`), each a single-database slice of the existing suite. In `test.properties`, each new suite reuses the base suite's scoping — the `test.batch.class.names.includes` restricting execution to the four `portal-tools-service-builder-test-*` modules, and the functional `test.batch.run.property.query` filtering to the "Service Builder" Testray component — and lists only that database's `functional-tomcat101-<db>` and `modules-integration-<db>` batches at the same versions the base suite already uses. The MySQL variant also carries the base suite's `SequenceEntryLocalServiceTest` exclude. In `ci.properties`, each suite is registered in `ci.test.available.suites` with a description so it becomes a valid `ci:test:` command. The existing `service-builder` suite is left unchanged and remains the all-databases run.

## Why Are There No Tests?

This change is CI batch configuration in `test.properties` and `ci.properties` — it groups existing Service Builder tests into per-database CI suites. It adds no product code and no new test code, so there is nothing to unit-test. The suite definitions are validated by the pr-check PQL validation (which checks the added `test.batch.run.property.query` expressions) and by CI dry-runs.

## PR Check

**pr-check: PASS** — tested on `3387137b63a700cbf93633a9efd4d1bd6227c71b`

| Validation | Result |
| --- | --- |
| PQL Validation | PASS |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "3387137b63a700cbf93633a9efd4d1bd6227c71b"} -->
