### PR TITLE
LPD-102338 Escape user email and screen name in Monitoring JSPs

### DIFF
--- a/modules/apps/monitoring/monitoring-web/src/main/resources/META-INF/resources/edit_session.jsp
+++ b/modules/apps/monitoring/monitoring-web/src/main/resources/META-INF/resources/edit_session.jsp
@@ -84,7 +84,7 @@ renderResponse.setTitle(LanguageUtil.format(request, "session-id-x", sessionId, 
 									<liferay-ui:message key="email-address" />
 								</dt>
 								<dd>
-									<%= (user2 != null) ? user2.getEmailAddress() : LanguageUtil.get(request, "not-available") %>
+									<%= (user2 != null) ? HtmlUtil.escape(user2.getEmailAddress()) : LanguageUtil.get(request, "not-available") %>
 								</dd>
 								<dt class="h4">
 									<liferay-ui:message key="last-request" />

--- a/modules/apps/monitoring/monitoring-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/monitoring/monitoring-web/src/main/resources/META-INF/resources/view.jsp
@@ -98,7 +98,7 @@ PortletURL portletURL = PortletURLBuilder.createRenderURL(
 					<liferay-ui:search-container-column-text
 						href="<%= rowURL %>"
 						name="screen-name"
-						value='<%= (user2 != null) ? user2.getScreenName() : LanguageUtil.get(request, "not-available") %>'
+						value='<%= (user2 != null) ? HtmlUtil.escape(user2.getScreenName()) : LanguageUtil.get(request, "not-available") %>'
 					/>
 
 					<liferay-ui:search-container-column-date


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102338

## What Is Being Fixed

A FindSecBugs and AI-assisted review of the 2025.q1.20 branch (LPD-97914) found values rendered into the Monitoring portlet's JSPs without HTML escaping, so stored user data could be interpreted as markup. In monitoring-web, the user email address in the session detail view and the user screen name in the live-sessions list column were emitted directly from the raw, non-escaped user model.

## How It Is Being Fixed

Both values are read from UserLocalServiceUtil.getUserById(...), which returns a non-escaped model, so each is now wrapped in HtmlUtil.escape(...) at the point of output — matching the already-escaped full-name outputs on the adjacent lines. edit_session.jsp escapes the email address and view.jsp escapes the screen-name column value. No other outputs change; the nearby userTracker fields are already safe via toEscapedModel(). These are topolik's two original monitoring-web commits from LPD-97914, cherry-picked onto master and re-prefixed to this ticket.

## Why Are There No Tests?

This is a one-line output-escaping change in a JSP fragment. There is no unit or integration test layer for JSP rendering in this admin portlet, and a Playwright test asserting a single escaped label would cost more to maintain than it catches. Escaping is verified by the JSP compile in pr-check and by review of the one-line diff.

## PR Check

**pr-check: PASS** — tested on `df82dbb6219006c4c5f651adc68ba22d2defea56`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |

<!-- pr-check {"result": "success", "sha": "df82dbb6219006c4c5f651adc68ba22d2defea56"} -->
