### PR TITLE
LPD-101861 Never match when an empty array reaches an IN clause

### DIFF
--- a/modules/apps/asset/asset-taglib-test/src/testIntegration/java/com/liferay/asset/taglib/servlet/taglib/test/AssetCategoriesSelectorTagTest.java
+++ b/modules/apps/asset/asset-taglib-test/src/testIntegration/java/com/liferay/asset/taglib/servlet/taglib/test/AssetCategoriesSelectorTagTest.java
@@ -123,6 +123,7 @@ public class AssetCategoriesSelectorTagTest {
 		ThemeDisplay themeDisplay = new ThemeDisplay();
 
 		themeDisplay.setLocale(LocaleUtil.getDefault());
+		themeDisplay.setScopeGroupId(_group.getGroupId());
 
 		ReflectionTestUtil.setFieldValue(
 			assetCategoriesSelectorTag, "_httpServletRequest",
@@ -139,11 +140,6 @@ public class AssetCategoriesSelectorTagTest {
 
 		String[] categoryIdsTitle = categoryIdsTitles.get(0);
 
-		Assert.assertEquals(StringPool.BLANK, categoryIdsTitle[0]);
-		Assert.assertEquals(StringPool.BLANK, categoryIdsTitle[1]);
-
-		categoryIdsTitle = categoryIdsTitles.get(1);
-
 		Assert.assertEquals(
 			StringBundler.concat(
 				assetCategory1.getCategoryId(), StringPool.COMMA,
@@ -156,6 +152,11 @@ public class AssetCategoriesSelectorTagTest {
 				assetCategory2.getName(), AssetCategoryUtil.CATEGORY_SEPARATOR,
 				assetCategory3.getName()),
 			categoryIdsTitle[1]);
+
+		categoryIdsTitle = categoryIdsTitles.get(1);
+
+		Assert.assertEquals(StringPool.BLANK, categoryIdsTitle[0]);
+		Assert.assertEquals(StringPool.BLANK, categoryIdsTitle[1]);
 	}
 
 	@Test

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/persistence/impl/CommerceOrderFinderImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/persistence/impl/CommerceOrderFinderImpl.java
@@ -168,6 +168,10 @@ public class CommerceOrderFinderImpl
 	}
 
 	protected String replaceOrderStatus(String sql, int[] orderStatuses) {
+		if (orderStatuses.length == 0) {
+			return StringUtil.replace(sql, "[$ORDER_STATUS$]", "NULL");
+		}
+
 		StringBundler sb = new StringBundler(orderStatuses.length);
 
 		for (int i = 0; i < orderStatuses.length; i++) {

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/persistence/impl/CommerceOrderItemFinderImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/persistence/impl/CommerceOrderItemFinderImpl.java
@@ -204,6 +204,10 @@ public class CommerceOrderItemFinderImpl
 	}
 
 	protected String replaceOrderStatus(String sql, int[] orderStatuses) {
+		if (orderStatuses.length == 0) {
+			return StringUtil.replace(sql, "[$ORDER_STATUS$]", "NULL");
+		}
+
 		StringBundler sb = new StringBundler(orderStatuses.length);
 
 		for (int i = 0; i < orderStatuses.length; i++) {

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderFinderTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderFinderTest.java
@@ -1,0 +1,52 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.commerce.service.persistence.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.commerce.service.persistence.CommerceOrderFinder;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.TransactionalTestRule;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jiefeng Wu
+ */
+@RunWith(Arquillian.class)
+public class CommerceOrderFinderTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			new TransactionalTestRule(
+				Propagation.REQUIRED, "com.liferay.commerce.service"));
+
+	@Test
+	public void testFindByG_OWithEmptyOrderStatuses() throws Exception {
+		Assert.assertEquals(
+			Collections.emptyList(),
+			_commerceOrderFinder.findByG_O(
+				TestPropsValues.getGroupId(), new int[0], QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS));
+	}
+
+	@Inject
+	private CommerceOrderFinder _commerceOrderFinder;
+
+}

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderItemFinderTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/service/persistence/test/CommerceOrderItemFinderTest.java
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.commerce.service.persistence.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.commerce.service.persistence.CommerceOrderItemFinder;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.TransactionalTestRule;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jiefeng Wu
+ */
+@RunWith(Arquillian.class)
+public class CommerceOrderItemFinderTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			new TransactionalTestRule(
+				Propagation.REQUIRED, "com.liferay.commerce.service"));
+
+	@Test
+	public void testCountByG_A_OWithEmptyOrderStatuses() throws Exception {
+		Assert.assertEquals(
+			0,
+			_commerceOrderItemFinder.countByG_A_O(
+				TestPropsValues.getGroupId(), RandomTestUtil.randomLong(),
+				new int[0]));
+	}
+
+	@Test
+	public void testFindByG_A_OWithEmptyOrderStatuses() throws Exception {
+		Assert.assertEquals(
+			Collections.emptyList(),
+			_commerceOrderItemFinder.findByG_A_O(
+				TestPropsValues.getGroupId(), RandomTestUtil.randomLong(),
+				new int[0], QueryUtil.ALL_POS, QueryUtil.ALL_POS));
+	}
+
+	@Inject
+	private CommerceOrderItemFinder _commerceOrderItemFinder;
+
+}

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBArticleFinderImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBArticleFinderImpl.java
@@ -187,6 +187,10 @@ public class KBArticleFinderImpl
 	}
 
 	protected String replaceWorkflowStatus(String sql, int[] status) {
+		if (status.length == 0) {
+			return StringUtil.replace(sql, "[$WORKFLOW_STATUS$]", "NULL");
+		}
+
 		StringBundler sb = new StringBundler(status.length);
 
 		for (int i = 0; i < status.length; i++) {

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBArticleFinderTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/service/persistence/test/KBArticleFinderTest.java
@@ -1,0 +1,63 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.knowledge.base.service.persistence.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.knowledge.base.service.persistence.KBArticleFinder;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.TransactionalTestRule;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jiefeng Wu
+ */
+@RunWith(Arquillian.class)
+public class KBArticleFinderTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			new TransactionalTestRule(
+				Propagation.REQUIRED, "com.liferay.knowledge.base.service"));
+
+	@Test
+	public void testCountByUrlTitleWithEmptyStatus() throws Exception {
+		Assert.assertEquals(
+			0,
+			_kbArticleFinder.countByUrlTitle(
+				TestPropsValues.getGroupId(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), new int[0]));
+	}
+
+	@Test
+	public void testFindByUrlTitleWithEmptyStatus() throws Exception {
+		Assert.assertEquals(
+			Collections.emptyList(),
+			_kbArticleFinder.findByUrlTitle(
+				TestPropsValues.getGroupId(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), new int[0], QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS));
+	}
+
+	@Inject
+	private KBArticleFinder _kbArticleFinder;
+
+}

--- a/modules/apps/social/social-activity-test/src/testIntegration/java/com/liferay/social/activity/service/test/SocialActivityCounterFinderTest.java
+++ b/modules/apps/social/social-activity-test/src/testIntegration/java/com/liferay/social/activity/service/test/SocialActivityCounterFinderTest.java
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.social.activity.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.social.kernel.service.SocialActivityCounterLocalServiceUtil;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jiefeng Wu
+ */
+@RunWith(Arquillian.class)
+public class SocialActivityCounterFinderTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testGetUserActivityCountersCountWithEmptyRankingNames()
+		throws Exception {
+
+		Assert.assertEquals(
+			0,
+			SocialActivityCounterLocalServiceUtil.getUserActivityCountersCount(
+				TestPropsValues.getGroupId(), new String[0]));
+	}
+
+}

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/PermissionCheckFinderEntryTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/PermissionCheckFinderEntryTest.java
@@ -30,11 +30,14 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.TransactionalTestRule;
 import com.liferay.portal.tools.service.builder.test.model.PermissionCheckFinderEntry;
 import com.liferay.portal.tools.service.builder.test.service.PermissionCheckFinderEntryLocalService;
+import com.liferay.portal.tools.service.builder.test.service.persistence.PermissionCheckFinderEntryPersistence;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -57,7 +60,11 @@ public class PermissionCheckFinderEntryTest {
 	@ClassRule
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			new TransactionalTestRule(
+				Propagation.REQUIRED,
+				"com.liferay.portal.tools.service.builder.test.service"));
 
 	@Before
 	public void setUp() throws Exception {
@@ -78,6 +85,21 @@ public class PermissionCheckFinderEntryTest {
 			_group1.getGroupId(), _user.getUserId());
 		_permissionCheckFinderEntry3 = _addPermissionCheckFinderEntry(
 			_group2.getGroupId(), _user.getUserId());
+	}
+
+	@Test
+	public void testEmptyGroupIds() {
+		Assert.assertEquals(
+			Collections.emptyList(),
+			_permissionCheckFinderEntryPersistence.findByGroupId(new long[0]));
+		Assert.assertEquals(
+			0,
+			_permissionCheckFinderEntryPersistence.countByGroupId(new long[0]));
+
+		Assert.assertEquals(
+			Collections.emptyList(),
+			_permissionCheckFinderEntryLocalService.filterFindByGroupId(
+				new long[0]));
 	}
 
 	@Test
@@ -329,6 +351,10 @@ public class PermissionCheckFinderEntryTest {
 	@Inject
 	private PermissionCheckFinderEntryLocalService
 		_permissionCheckFinderEntryLocalService;
+
+	@Inject
+	private PermissionCheckFinderEntryPersistence
+		_permissionCheckFinderEntryPersistence;
 
 	@DeleteAfterTestRun
 	private User _permissionedUser;

--- a/portal-impl/src/com/liferay/portlet/social/service/persistence/impl/SocialActivityCounterFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/service/persistence/impl/SocialActivityCounterFinderImpl.java
@@ -57,6 +57,10 @@ public class SocialActivityCounterFinderImpl
 
 	@Override
 	public int countU_ByG_N(long groupId, String[] names) {
+		if (names.length == 0) {
+			return 0;
+		}
+
 		Session session = null;
 
 		try {

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/ArrayableFinderColumn.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/ArrayableFinderColumn.java
@@ -34,12 +34,18 @@ public class ArrayableFinderColumn<T extends BaseModel<T>>
 		_hqlInPrefix = StringBundler.concat(
 			"(", entityAlias, columnName, andOperator ? " NOT IN (" : " IN (");
 
+		_hqlNeverMatches = StringBundler.concat(
+			"(", entityAlias, columnName, " IN (NULL))");
+
 		if (Objects.equals(columnName, dbColumnName)) {
 			_sqlInPrefix = _hqlInPrefix;
+			_sqlNeverMatches = _hqlNeverMatches;
 		}
 		else {
 			_sqlInPrefix = StringUtil.replace(
 				_hqlInPrefix, columnName, dbColumnName);
+			_sqlNeverMatches = StringUtil.replace(
+				_hqlNeverMatches, columnName, dbColumnName);
 		}
 	}
 
@@ -75,7 +81,15 @@ public class ArrayableFinderColumn<T extends BaseModel<T>>
 		Object[] array = (Object[])normalizedValue;
 
 		if (array.length == 0) {
-			return "";
+			if (_andOperator) {
+				return "";
+			}
+
+			if (sqlQuery) {
+				return _sqlNeverMatches;
+			}
+
+			return _hqlNeverMatches;
 		}
 
 		if (type == Type.STRING) {
@@ -233,6 +247,8 @@ public class ArrayableFinderColumn<T extends BaseModel<T>>
 
 	private final boolean _andOperator;
 	private final String _hqlInPrefix;
+	private final String _hqlNeverMatches;
 	private final String _sqlInPrefix;
+	private final String _sqlNeverMatches;
 
 }

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/service/persistence/impl/ArrayableFinderColumnTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/service/persistence/impl/ArrayableFinderColumnTest.java
@@ -20,14 +20,15 @@ import org.junit.Test;
 public class ArrayableFinderColumnTest {
 
 	@Test
-	public void testEmptyArrayDropsConstraint() {
+	public void testEmptyArrayNeverMatches() {
 		ArrayableFinderColumn<TestModel> arrayableFinderColumn = _newLongColumn(
 			false, entity -> 0L);
 
 		Object normalizedValue = arrayableFinderColumn.normalizeValue(null);
 
 		Assert.assertEquals(
-			"", arrayableFinderColumn.getSqlFragment(normalizedValue, false));
+			"(t.col IN (NULL))",
+			arrayableFinderColumn.getSqlFragment(normalizedValue, false));
 		Assert.assertEquals(
 			"", arrayableFinderColumn.toFinderArg(normalizedValue));
 	}
@@ -129,14 +130,15 @@ public class ArrayableFinderColumnTest {
 	}
 
 	@Test
-	public void testStringEmptyArrayDropsConstraint() {
+	public void testStringEmptyArrayNeverMatches() {
 		ArrayableFinderColumn<TestModel> arrayableFinderColumn =
 			_newStringColumn(false, true, false, entity -> "anything");
 
 		Object normalizedValue = arrayableFinderColumn.normalizeValue(null);
 
 		Assert.assertEquals(
-			"", arrayableFinderColumn.getSqlFragment(normalizedValue, false));
+			"(t.col IN (NULL))",
+			arrayableFinderColumn.getSqlFragment(normalizedValue, false));
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101861

## What Is Being Fixed

An empty array reaching a SQL `IN` clause either crashed the query or silently removed the filter.

Service Builder finders take arrays through `ArrayableFinderColumn`, whose `getSqlFragment` returned an empty string for a zero length array. Every SQL builder skips an empty fragment, so the condition left the query entirely. When the arrayable column was the only condition, the query ended with a dangling `WHERE` followed by `ORDER BY`, which Hibernate refuses to parse — what LPD-98241 hit through `AssetVocabularyPersistence.findByGroupId`. When other conditions remained the query still ran, but the filter was gone and rows carrying every value of that column came back. On a `groupId` array that means cross-site rows, with no error anywhere.

Four hand-written custom SQL finders had the same defect in a louder form. Their `[$PLACEHOLDER$]` sits inside the `IN ( … )` parentheses, so an empty substitution leaves `IN ()` and the database rejects the statement outright.

## How It Is Being Fixed

An empty `IN` list can never match anything, so it now says exactly that instead of saying nothing at all. `ArrayableFinderColumn` builds `(alias.column IN (NULL))`, derived from the column and stored as an HQL and SQL pair so the native form carries the database column name. Comparing anything with `NULL` yields unknown rather than true for every column type on every database, so no dialect needs a special case. An empty `NOT IN` list is left alone, because excluding nothing genuinely is the absence of a constraint.

Deciding this in the column rather than in each caller covers `count`, `find`, `filterCount` and `filterFind` through one method, needs no new emptiness check since the zero length test was already there, and avoids a downcast, because only the column knows whether it is `IN` or `NOT IN`.

The three status finders substitute `NULL` for their placeholder. The `0` sentinel used elsewhere in the repo is safe for ID columns but would be wrong here, since `WorkflowConstants.STATUS_APPROVED` is `0` and it would silently narrow the query rather than fail. `SocialActivityCounterFinderImpl.countU_ByG_N` returns early instead, matching the guard its sibling `findU_ByG_N` already had.

One existing test asserted the old behavior. `AssetCategoriesSelectorTagTest` built a `ThemeDisplay` with no scope group, so `getGroupIds` caught a `NullPointerException` and fell back to an empty array, and the dropped filter returned every public vocabulary in the database rather than the site's. Setting the scope group ID sends the tag down the path an application actually takes.

## Verification

Each fix was run with and without the production change on a live portal:

| Test | Without fix | With fix |
| --- | --- | --- |
| `ArrayableFinderColumnTest` (14) | 2 FAILED | 14 PASSED |
| `PermissionCheckFinderEntryTest.testEmptyGroupIds` | FAILED | PASSED |
| `KBArticleFinderTest` (2) | FAILED | PASSED |
| `CommerceOrderFinderTest` | FAILED | PASSED |
| `CommerceOrderItemFinderTest` (2) | FAILED | PASSED |
| `SocialActivityCounterFinderTest` | FAILED | PASSED |

`AssetCategoriesSelectorTagTest` passes either way after the scope group fix, which is the point of that change — it no longer depends on the empty-array path.

## PR Check

**pr-check: PASS** — tested on `a64e88df534a267d5e4ab04cdf3a7799d3c4ddba`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "a64e88df534a267d5e4ab04cdf3a7799d3c4ddba"} -->
