### PR TITLE
LPD-99810 Add a text-extraction performance integration test

### DIFF
--- a/modules/apps/portal/portal-tika-test/bnd.bnd
+++ b/modules/apps/portal/portal-tika-test/bnd.bnd
@@ -1,3 +1,14 @@
 Bundle-Name: Liferay Portal Tika Test
 Bundle-SymbolicName: com.liferay.portal.tika.test
 Bundle-Version: 1.0.0
+Import-Package:\
+	!org.apache.fontbox.*,\
+	!org.apache.pdfbox.*,\
+	\
+	!org.bouncycastle.*,\
+	\
+	*
+-includeresource:\
+	@fontbox-[0-9.]*.jar,\
+	@pdfbox-[0-9.]*.jar,\
+	@pdfbox-io-[0-9.]*.jar

--- a/modules/apps/portal/portal-tika-test/build.gradle
+++ b/modules/apps/portal/portal-tika-test/build.gradle
@@ -1,5 +1,9 @@
 dependencies {
 	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	testIntegrationImplementation group: "org.apache.pdfbox", name: "fontbox", version: "3.0.7"
+	testIntegrationImplementation group: "org.apache.pdfbox", name: "pdfbox", version: "3.0.7"
+	testIntegrationImplementation group: "org.apache.pdfbox", name: "pdfbox-io", version: "3.0.7"
+	testIntegrationImplementation group: "org.apache.poi", name: "poi-ooxml", version: "5.4.1"
 	testIntegrationImplementation group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/portal/portal-tika-test/src/testIntegration/java/com/liferay/portal/tika/test/TextExtractorPerformanceTest.java
+++ b/modules/apps/portal/portal-tika-test/src/testIntegration/java/com/liferay/portal/tika/test/TextExtractorPerformanceTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/portal/portal-tika-test/src/testIntegration/java/com/liferay/portal/tika/test/TextExtractorPerformanceTest.java
+++ b/modules/apps/portal/portal-tika-test/src/testIntegration/java/com/liferay/portal/tika/test/TextExtractorPerformanceTest.java
@@ -33,6 +33,20 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
+import org.apache.poi.ss.SpreadsheetVersion;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.apache.poi.xwpf.usermodel.XWPFParagraph;
+import org.apache.poi.xwpf.usermodel.XWPFRun;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -98,6 +112,32 @@ public class TextExtractorPerformanceTest {
 	}
 
 	@Test
+	public void testDocx() throws Exception {
+		_test(
+			"docx",
+			outputStream -> {
+				try (XWPFDocument xwpfDocument = new XWPFDocument()) {
+					int fileSize = 0;
+
+					while (fileSize < _maxFileSize) {
+						XWPFParagraph xwpfParagraph =
+							xwpfDocument.createParagraph();
+
+						XWPFRun xwpfRun = xwpfParagraph.createRun();
+
+						String text = _generateRandomString();
+
+						xwpfRun.setText(text);
+
+						fileSize += text.length();
+					}
+
+					xwpfDocument.write(outputStream);
+				}
+			});
+	}
+
+	@Test
 	public void testHtml() throws Exception {
 		String[] tags = {
 			"p", "h1", "h2", "h3", "h4", "blockquote", "pre", "code", "div",
@@ -148,6 +188,51 @@ public class TextExtractorPerformanceTest {
 	}
 
 	@Test
+	public void testPdf() throws Exception {
+		_test(
+			"pdf",
+			outputStream -> {
+				try (PDDocument pdDocument = new PDDocument()) {
+					PDType1Font pdType1Font = new PDType1Font(
+						Standard14Fonts.FontName.TIMES_ROMAN);
+
+					int fileSize = 0;
+
+					while (fileSize < _maxFileSize) {
+						PDPage pdPage = new PDPage();
+
+						pdDocument.addPage(pdPage);
+
+						try (PDPageContentStream pdPageContentStream =
+								new PDPageContentStream(pdDocument, pdPage)) {
+
+							pdPageContentStream.beginText();
+							pdPageContentStream.setFont(pdType1Font, 10);
+							pdPageContentStream.setLeading(12);
+							pdPageContentStream.newLineAtOffset(50, 760);
+
+							for (int i = 0;
+								 (i < 60) && (fileSize < _maxFileSize); i++) {
+
+								String text = _generateRandomString();
+
+								pdPageContentStream.showText(text);
+
+								fileSize += text.length();
+
+								pdPageContentStream.newLine();
+							}
+
+							pdPageContentStream.endText();
+						}
+					}
+
+					pdDocument.save(outputStream);
+				}
+			});
+	}
+
+	@Test
 	public void testRtf() throws Exception {
 		_test(
 			"rtf",
@@ -176,6 +261,42 @@ public class TextExtractorPerformanceTest {
 					fileSize += _writeStrings(
 						outputStream, _generateRandomString(),
 						StringPool.NEW_LINE);
+				}
+			});
+	}
+
+	@Test
+	public void testXlsx() throws Exception {
+		_test(
+			"xlsx",
+			outputStream -> {
+				try (SXSSFWorkbook sxssfWorkbook = new SXSSFWorkbook(1)) {
+					int fileSize = 0;
+
+					Sheet sheet = sxssfWorkbook.createSheet("test");
+
+					for (int i = 0;
+						 (fileSize < _maxFileSize) &&
+						 (i < SpreadsheetVersion.EXCEL2007.getMaxRows()); i++) {
+
+						Row row = sheet.createRow(i);
+
+						for (int j = 0;
+							 (fileSize < _maxFileSize) &&
+							 (j < SpreadsheetVersion.EXCEL2007.getMaxColumns());
+							 j++) {
+
+							String text = _generateRandomString();
+
+							Cell cell = row.createCell(j);
+
+							cell.setCellValue(text);
+
+							fileSize += text.length();
+						}
+					}
+
+					sxssfWorkbook.write(outputStream);
 				}
 			});
 	}

--- a/modules/apps/portal/portal-tika-test/src/testIntegration/java/com/liferay/portal/tika/test/TextExtractorPerformanceTest.java
+++ b/modules/apps/portal/portal-tika-test/src/testIntegration/java/com/liferay/portal/tika/test/TextExtractorPerformanceTest.java
@@ -1,0 +1,308 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.tika.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.test.performance.PerformanceTimer;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropertiesUtil;
+import com.liferay.portal.kernel.util.TextExtractor;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.io.BufferedOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Kevin Lee
+ */
+@RunWith(Arquillian.class)
+public class TextExtractorPerformanceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		Class<?> clazz = TextExtractorPerformanceTest.class;
+
+		Properties properties = PropertiesUtil.load(
+			clazz.getResourceAsStream(
+				"dependencies/text-extractor-performance.properties"),
+			"UTF-8");
+
+		_executorService = Executors.newFixedThreadPool(
+			GetterUtil.getInteger(
+				properties.getProperty("text.extractor.max.threads")));
+		_iterations = GetterUtil.getInteger(
+			properties.getProperty("text.extractor.iterations"));
+		_maxFileCount = GetterUtil.getInteger(
+			properties.getProperty("text.extractor.max.file.count"));
+		_maxFileSize = GetterUtil.getInteger(
+			properties.getProperty("text.extractor.max.file.size"));
+		_random = new Random(
+			GetterUtil.getLong(
+				properties.getProperty("text.extractor.random.seed")));
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_executorService.shutdown();
+	}
+
+	@Test
+	public void testCsv() throws Exception {
+		_test(
+			"csv",
+			outputStream -> {
+				int fileSize = _writeStrings(
+					outputStream, "id,name,value,description\n");
+
+				while (fileSize < _maxFileSize) {
+					fileSize += _writeStrings(
+						outputStream, _generateRandomString(), StringPool.COMMA,
+						_generateRandomString(), StringPool.COMMA,
+						_generateRandomString(), StringPool.COMMA,
+						_generateRandomString(), StringPool.NEW_LINE);
+				}
+			});
+	}
+
+	@Test
+	public void testHtml() throws Exception {
+		String[] tags = {
+			"p", "h1", "h2", "h3", "h4", "blockquote", "pre", "code", "div",
+			"span", "em", "strong", "b", "i"
+		};
+
+		_test(
+			"html",
+			outputStream -> {
+				int fileSize = _writeStrings(
+					outputStream,
+					"<!DOCTYPE html>\n<html><head><title>Test</title>",
+					"</head>\n<body>\n");
+
+				while (fileSize < _maxFileSize) {
+					String tag = tags[_random.nextInt(tags.length)];
+
+					fileSize += _writeStrings(
+						outputStream, "<", tag, ">", _generateRandomString(),
+						"</", tag, ">\n");
+				}
+
+				_writeStrings(outputStream, "</body></html>\n");
+			});
+	}
+
+	@Test
+	public void testJson() throws Exception {
+		_test(
+			"json",
+			outputStream -> {
+				int fileSize = _writeStrings(outputStream, "{\n");
+
+				for (int i = 0; fileSize < _maxFileSize; i++) {
+					if (i > 0) {
+						fileSize += _writeStrings(outputStream, ",\n");
+					}
+
+					fileSize += _writeStrings(
+						outputStream,
+						StringBundler.concat(
+							"{\"id\": ", i, ", \"text\": \"",
+							_generateRandomString(), "\"}"));
+				}
+
+				_writeStrings(outputStream, "\n}\n");
+			});
+	}
+
+	@Test
+	public void testRtf() throws Exception {
+		_test(
+			"rtf",
+			outputStream -> {
+				int fileSize = _writeStrings(
+					outputStream,
+					"{\\rtf1\\ansi\\deff0{\\fonttbl{\\f0 Arial;}}\n");
+
+				while (fileSize < _maxFileSize) {
+					fileSize += _writeStrings(
+						outputStream, _generateRandomString(), "\\par\n");
+				}
+
+				_writeStrings(outputStream, "}");
+			});
+	}
+
+	@Test
+	public void testTxt() throws Exception {
+		_test(
+			"txt",
+			outputStream -> {
+				int fileSize = 0;
+
+				while (fileSize < _maxFileSize) {
+					fileSize += _writeStrings(
+						outputStream, _generateRandomString(),
+						StringPool.NEW_LINE);
+				}
+			});
+	}
+
+	@Test
+	public void testXml() throws Exception {
+		_test(
+			"xml",
+			outputStream -> {
+				int fileSize = _writeStrings(
+					outputStream,
+					"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<docs>\n");
+
+				while (fileSize < _maxFileSize) {
+					fileSize += _writeStrings(
+						outputStream, "<doc id=\"", _generateRandomString(),
+						"\">", _generateRandomString(), "</doc>\n");
+				}
+
+				_writeStrings(outputStream, "</docs>\n");
+			});
+	}
+
+	private String _generateRandomString() {
+		StringBundler sb = new StringBundler(1024);
+
+		for (int i = 0; i < sb.capacity(); i++) {
+			sb.append(_CHARS[_random.nextInt(_CHARS.length)]);
+		}
+
+		return sb.toString();
+	}
+
+	private void _test(
+			String format,
+			UnsafeConsumer<OutputStream, Exception> unsafeConsumer)
+		throws Exception {
+
+		List<Path> filePaths = new ArrayList<>();
+
+		Path tempPath = Files.createTempDirectory(null);
+
+		try {
+			for (int i = 0; i < _maxFileCount; i++) {
+				Path filePath = tempPath.resolve(
+					StringBundler.concat(i, StringPool.PERIOD, format));
+
+				try (OutputStream outputStream = new BufferedOutputStream(
+						Files.newOutputStream(filePath))) {
+
+					unsafeConsumer.accept(outputStream);
+
+					filePaths.add(filePath);
+				}
+			}
+
+			for (int i = 1; i <= _iterations; i++) {
+				try (PerformanceTimer performanceTimer = new PerformanceTimer(
+						Long.MAX_VALUE,
+						StringBundler.concat(
+							format, " (Iteration ", i, ", ", _maxFileCount,
+							" files x ", _maxFileSize, " bytes)"))) {
+
+					List<Future<Void>> futures = new ArrayList<>(
+						filePaths.size());
+
+					for (Path filePath : filePaths) {
+						Future<Void> future = _executorService.submit(
+							() -> {
+								try (InputStream inputStream =
+										Files.newInputStream(filePath)) {
+
+									_textExtractor.extractText(inputStream, -1);
+								}
+
+								return null;
+							});
+
+						futures.add(future);
+					}
+
+					for (Future<Void> future : futures) {
+						future.get();
+					}
+				}
+			}
+		}
+		finally {
+			for (Path filePath : filePaths) {
+				Files.deleteIfExists(filePath);
+			}
+
+			Files.deleteIfExists(tempPath);
+		}
+	}
+
+	private int _writeStrings(OutputStream outputStream, String... strings)
+		throws Exception {
+
+		int size = 0;
+
+		for (String string : strings) {
+			byte[] bytes = string.getBytes(StandardCharsets.UTF_8);
+
+			outputStream.write(bytes);
+
+			size += bytes.length;
+		}
+
+		return size;
+	}
+
+	private static final char[] _CHARS = {
+		'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D',
+		'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
+		'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
+		'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't',
+		'u', 'v', 'w', 'x', 'y', 'z', '_', '-', ' '
+	};
+
+	private static ExecutorService _executorService;
+	private static int _iterations;
+	private static int _maxFileCount;
+	private static int _maxFileSize;
+	private static Random _random;
+
+	@Inject
+	private TextExtractor _textExtractor;
+
+}

--- a/modules/apps/portal/portal-tika-test/src/testIntegration/java/com/liferay/portal/tika/test/TextExtractorPerformanceTest.java
+++ b/modules/apps/portal/portal-tika-test/src/testIntegration/java/com/liferay/portal/tika/test/TextExtractorPerformanceTest.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropertiesUtil;
 import com.liferay.portal.kernel.util.TextExtractor;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -24,6 +25,7 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -86,6 +88,13 @@ public class TextExtractorPerformanceTest {
 		_random = new Random(
 			GetterUtil.getLong(
 				properties.getProperty("text.extractor.random.seed")));
+
+		String logFilePath = properties.getProperty(
+			"text.extractor.log.file.path");
+
+		if (Validator.isNotNull(logFilePath)) {
+			_logFilePath = Paths.get(logFilePath);
+		}
 	}
 
 	@AfterClass
@@ -355,7 +364,7 @@ public class TextExtractorPerformanceTest {
 
 			for (int i = 1; i <= _iterations; i++) {
 				try (PerformanceTimer performanceTimer = new PerformanceTimer(
-						Long.MAX_VALUE,
+						_logFilePath, Long.MAX_VALUE,
 						StringBundler.concat(
 							format, " (Iteration ", i, ", ", _maxFileCount,
 							" files x ", _maxFileSize, " bytes)"))) {
@@ -419,6 +428,7 @@ public class TextExtractorPerformanceTest {
 
 	private static ExecutorService _executorService;
 	private static int _iterations;
+	private static Path _logFilePath;
 	private static int _maxFileCount;
 	private static int _maxFileSize;
 	private static Random _random;

--- a/modules/apps/portal/portal-tika-test/src/testIntegration/resources/com/liferay/portal/tika/test/dependencies/text-extractor-performance.properties
+++ b/modules/apps/portal/portal-tika-test/src/testIntegration/resources/com/liferay/portal/tika/test/dependencies/text-extractor-performance.properties
@@ -1,4 +1,5 @@
 text.extractor.iterations=1
+text.extractor.log.file.path=
 text.extractor.max.file.count=1
 text.extractor.max.file.size=65536
 text.extractor.max.threads=1

--- a/modules/apps/portal/portal-tika-test/src/testIntegration/resources/com/liferay/portal/tika/test/dependencies/text-extractor-performance.properties
+++ b/modules/apps/portal/portal-tika-test/src/testIntegration/resources/com/liferay/portal/tika/test/dependencies/text-extractor-performance.properties
@@ -1,0 +1,5 @@
+text.extractor.iterations=1
+text.extractor.max.file.count=1
+text.extractor.max.file.size=65536
+text.extractor.max.threads=1
+text.extractor.random.seed=42


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99810

## What Is Being Fixed

Validating the Apache Tika 1.28.5 → 3.3.1 upgrade (LPD-97689) required
measuring `TextExtractor` extraction performance across file formats and under
concurrent load, but the repository had no such test.

## How It Is Being Fixed

Adds `TextExtractorPerformanceTest`, a property-driven integration test that
generates a seeded corpus per format (csv, docx, html, json, pdf, rtf, txt,
xlsx, xml) and times `TextExtractor.extractText` across a configurable file
count, file size, and thread pool — so the same class runs either a single
large-file benchmark or a concurrent folder benchmark. The binary formats are
generated with PDFBox and Apache POI, embedded into the test bundle so the test
also runs against the older Tika 1.x bundle. `PerformanceTimer` is extended to
append its timings to a file for offline analysis. The committed properties use
tiny, single-threaded defaults so the test stays cheap on CI.

## PR Check

**pr-check: PASS** — tested on `34c71c89c19e254e90b38a7236065f0755b8f853`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "34c71c89c19e254e90b38a7236065f0755b8f853"} -->
