### PR TITLE
LPD-102637 Upgrade jakarta.mail to 2.0.2

### DIFF
--- a/modules/test/jenkins-results-parser/build.gradle
+++ b/modules/test/jenkins-results-parser/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 	api group: "com.google.cloud", name: "google-cloud-storage", version: "2.48.0"
 	api group: "com.google.guava", name: "guava", version: "32.0.1-jre"
 	api group: "com.liferay", name: "com.liferay.poshi.core", version: "1.0.159"
-	api group: "com.sun.mail", name: "jakarta.mail", version: "2.0.1"
+	api group: "com.sun.mail", name: "jakarta.mail", version: "2.0.2"
 	api group: "commons-codec", name: "commons-codec", version: "1.15"
 	api group: "commons-io", name: "commons-io", version: "2.19.0"
 	api group: "io.prometheus", name: "prometheus-metrics-exposition-textformats", version: "1.8.0"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102637

## What Is Being Fixed

Security scanners report CVE-2025-7962 against Liferay Portal and Liferay DXP because the CI build-tooling module `modules/test/jenkins-results-parser` depends on `com.sun.mail:jakarta.mail:2.0.1`, which has a known vulnerability. The library is build tooling only and is not present in any released artifact.

## How It Is Being Fixed

Bump `com.sun.mail:jakarta.mail` from 2.0.1 to 2.0.2 in `modules/test/jenkins-results-parser/build.gradle`. 2.0.2 is the fix on the 2.x line and the final release of this coordinate on Maven Central. Earlier attempts (LRCI-7404, LRCI-7425) targeted 2.1.3 and were discarded because that version does not exist for this coordinate — the 2.1.x line was renamed to `org.eclipse.angus:jakarta.mail`. The bump was verified to resolve from the Nexus mirror and the module compiles against it.

## Why Are There No Tests?

This is a build-tooling-only dependency version bump with no released-artifact surface and no behavioral change, so there is nothing meaningful to unit- or integration-test. Dependency resolution from the mirror and a clean module compile were verified by pr-check's build validations.

## PR Check

**pr-check: PASS** — tested on `989a0f2bb438e695bc496359ea4f1f391cb1ec10`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "989a0f2bb438e695bc496359ea4f1f391cb1ec10"} -->
