### PR TITLE
LPD-84842 [IndexOnStartupExecutor] Use an eager service tracker map

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/osgi/util/tracker/IndexOnStartupExecutor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/osgi/util/tracker/IndexOnStartupExecutor.java
@@ -5,10 +5,11 @@
 
 package com.liferay.portal.search.internal.osgi.util.tracker;
 
+import com.liferay.osgi.service.tracker.collections.EagerServiceTrackerCustomizer;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.BaseSearcher;
 import com.liferay.portal.kernel.search.IndexWriterHelper;
 import com.liferay.portal.kernel.search.Indexer;
@@ -22,10 +23,7 @@ import com.liferay.portal.search.internal.instance.lifecycle.IndexOnStartupPorta
 
 import java.io.Serializable;
 
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -37,8 +35,6 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.util.tracker.ServiceTracker;
-import org.osgi.util.tracker.ServiceTrackerCustomizer;
 
 /**
  * @author Michael C. Han
@@ -48,72 +44,44 @@ import org.osgi.util.tracker.ServiceTrackerCustomizer;
 	service = {}
 )
 public class IndexOnStartupExecutor
-	implements ServiceTrackerCustomizer<Indexer<?>, Indexer<?>> {
+	implements EagerServiceTrackerCustomizer
+		<Indexer<?>, ServiceRegistration<PortalInstanceLifecycleListener>> {
 
 	@Override
-	public Indexer<?> addingService(
+	public ServiceRegistration<PortalInstanceLifecycleListener> addingService(
 		ServiceReference<Indexer<?>> serviceReference) {
 
 		Indexer<?> indexer = _bundleContext.getService(serviceReference);
 
-		boolean indexerIndexOnStartup = GetterUtil.getBoolean(
-			serviceReference.getProperty(PropsKeys.INDEX_ON_STARTUP), true);
-
 		String className = indexer.getClassName();
 
-		if (!indexerIndexOnStartup || Validator.isNull(className) ||
-			_isBaseSearcher(indexer.getClass())) {
+		_bundleContext.ungetService(serviceReference);
 
-			return indexer;
-		}
-
-		synchronized (_serviceRegistrations) {
-			if (_serviceRegistrations.containsKey(className)) {
-				if (_log.isInfoEnabled()) {
-					_log.info(
-						"Skip duplicate service registration for " + className);
-				}
-
-				return indexer;
-			}
-
-			PortalInstanceLifecycleListener portalInstanceLifecycleListener =
-				new IndexOnStartupPortalInstanceLifecycleListener(
-					_indexWriterHelper, className,
-					HashMapBuilder.<String, Serializable>put(
-						"executionMode",
-						_reindexConfiguration.defaultReindexExecutionMode()
-					).build());
-
-			ServiceRegistration<PortalInstanceLifecycleListener>
-				serviceRegistration = _bundleContext.registerService(
-					PortalInstanceLifecycleListener.class,
-					portalInstanceLifecycleListener, null);
-
-			_serviceRegistrations.put(className, serviceRegistration);
-		}
-
-		return indexer;
+		return _bundleContext.registerService(
+			PortalInstanceLifecycleListener.class,
+			new IndexOnStartupPortalInstanceLifecycleListener(
+				_indexWriterHelper, className,
+				HashMapBuilder.<String, Serializable>put(
+					"executionMode",
+					_reindexConfiguration.defaultReindexExecutionMode()
+				).build()),
+			null);
 	}
 
 	@Override
 	public void modifiedService(
-		ServiceReference<Indexer<?>> serviceReference, Indexer<?> indexer) {
+		ServiceReference<Indexer<?>> serviceReference,
+		ServiceRegistration<PortalInstanceLifecycleListener>
+			serviceRegistration) {
 	}
 
 	@Override
 	public void removedService(
-		ServiceReference<Indexer<?>> serviceReference, Indexer<?> indexer) {
+		ServiceReference<Indexer<?>> serviceReference,
+		ServiceRegistration<PortalInstanceLifecycleListener>
+			serviceRegistration) {
 
-		synchronized (_serviceRegistrations) {
-			ServiceRegistration<PortalInstanceLifecycleListener>
-				serviceRegistration = _serviceRegistrations.remove(
-					indexer.getClassName());
-
-			if (serviceRegistration != null) {
-				serviceRegistration.unregister();
-			}
-		}
+		serviceRegistration.unregister();
 	}
 
 	@Activate
@@ -131,12 +99,43 @@ public class IndexOnStartupExecutor
 
 			scheduledExecutorService.schedule(
 				() -> {
-					if (_bundleContext != null) {
-						_serviceTracker = new ServiceTracker<>(
-							_bundleContext,
-							(Class<Indexer<?>>)(Class<?>)Indexer.class, this);
+					BundleContext currentBundleContext = _bundleContext;
 
-						_serviceTracker.open();
+					if (currentBundleContext == null) {
+						return;
+					}
+
+					_serviceTrackerMap =
+						ServiceTrackerMapFactory.openSingleValueMap(
+							currentBundleContext,
+							(Class<Indexer<?>>)(Class<?>)Indexer.class, null,
+							(serviceReference, emitter) -> {
+								Indexer<?> indexer =
+									currentBundleContext.getService(
+										serviceReference);
+
+								boolean indexerIndexOnStartup =
+									GetterUtil.getBoolean(
+										serviceReference.getProperty(
+											PropsKeys.INDEX_ON_STARTUP),
+										true);
+
+								String className = indexer.getClassName();
+
+								if (indexerIndexOnStartup &&
+									Validator.isNotNull(className) &&
+									!_isBaseSearcher(indexer.getClass())) {
+
+									emitter.emit(className);
+								}
+
+								currentBundleContext.ungetService(
+									serviceReference);
+							},
+							this);
+
+					if (_bundleContext == null) {
+						_serviceTrackerMap.close();
 					}
 				},
 				PropsValues.INDEX_ON_STARTUP_DELAY, TimeUnit.SECONDS);
@@ -149,28 +148,8 @@ public class IndexOnStartupExecutor
 	protected void deactivate() {
 		_bundleContext = null;
 
-		Set<String> removedIndexerClassNames = new HashSet<>();
-
-		synchronized (_serviceRegistrations) {
-			for (Map.Entry
-					<String,
-					 ServiceRegistration<PortalInstanceLifecycleListener>>
-						entry : _serviceRegistrations.entrySet()) {
-
-				ServiceRegistration<?> serviceRegistration = entry.getValue();
-
-				serviceRegistration.unregister();
-
-				removedIndexerClassNames.add(entry.getKey());
-			}
-
-			for (String removedIndexerClassName : removedIndexerClassNames) {
-				_serviceRegistrations.remove(removedIndexerClassName);
-			}
-		}
-
-		if (_serviceTracker != null) {
-			_serviceTracker.close();
+		if (_serviceTrackerMap != null) {
+			_serviceTrackerMap.close();
 		}
 	}
 
@@ -186,18 +165,14 @@ public class IndexOnStartupExecutor
 		return false;
 	}
 
-	private static final Log _log = LogFactoryUtil.getLog(
-		IndexOnStartupExecutor.class);
-
-	private BundleContext _bundleContext;
+	private volatile BundleContext _bundleContext;
 
 	@Reference
 	private IndexWriterHelper _indexWriterHelper;
 
 	private volatile ReindexConfiguration _reindexConfiguration;
-	private final Map
+	private ServiceTrackerMap
 		<String, ServiceRegistration<PortalInstanceLifecycleListener>>
-			_serviceRegistrations = new HashMap<>();
-	private ServiceTracker<Indexer<?>, Indexer<?>> _serviceTracker;
+			_serviceTrackerMap;
 
 }


### PR DESCRIPTION
The class only ever used the service tracker to react to indexers coming and going, never to look anything up, so a lazily opened service tracker map would never open. Implementing EagerServiceTrackerCustomizer makes the map open as soon as it is created, which the scheduled task still defers by INDEX_ON_STARTUP_DELAY. The eligibility checks move into the service reference mapper so that only indexers that qualify for an index on startup are keyed by their class name, and the map itself now holds the portal instance lifecycle listener registrations, which removes the hand-maintained registration map along with the duplicate class name guard that only existed to keep it consistent.