### PR TITLE
LPD-92565 Defer WAR deployment until its feature flag is enabled

### DIFF
--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabFactory.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabFactory.java
@@ -16,7 +16,6 @@ import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.osgi.web.servlet.JSPServletFactory;
 import com.liferay.portal.osgi.web.servlet.context.helper.ServletContextHelperFactory;
 import com.liferay.portal.osgi.web.wab.extender.internal.configuration.WabExtenderConfiguration;
-import com.liferay.portal.profile.PortalProfile;
 
 import java.util.Dictionary;
 import java.util.concurrent.CountDownLatch;
@@ -141,7 +140,7 @@ public class WabFactory
 		}
 
 		private final Bundle _bundle;
-		private ServiceRegistration<PortalProfile> _serviceRegistration;
+		private ServiceRegistration<?> _serviceRegistration;
 		private final CountDownLatch _started = new CountDownLatch(1);
 
 	}

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WebBundleDeployer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WebBundleDeployer.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.osgi.web.wab.extender.internal;
 
+import com.liferay.portal.kernel.feature.flag.FeatureFlagListener;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.PropertiesUtil;
@@ -50,7 +51,7 @@ public class WebBundleDeployer {
 		}
 	}
 
-	public ServiceRegistration<PortalProfile> doStart(Bundle bundle) {
+	public ServiceRegistration<?> doStart(Bundle bundle) {
 		Enumeration<URL> enumeration = bundle.findEntries(
 			"/WEB-INF", "liferay-plugin-package.properties", false);
 
@@ -63,6 +64,16 @@ public class WebBundleDeployer {
 		try {
 			Properties properties = PropertiesUtil.load(
 				enumeration.nextElement());
+
+			Set<String> featureFlagKeys = SetUtil.fromArray(
+				StringUtil.split(
+					properties.getProperty("liferay-feature-flag-keys")));
+
+			if (!featureFlagKeys.isEmpty()) {
+				return _bundleContext.registerService(
+					FeatureFlagListener.class,
+					new WarFeatureFlagListener(bundle, featureFlagKeys), null);
+			}
 
 			Set<String> portalProfileNames = SetUtil.fromArray(
 				StringUtil.split(
@@ -141,6 +152,31 @@ public class WebBundleDeployer {
 	private final Dictionary<String, Object> _properties;
 	private final ConcurrentMap<Bundle, WabBundleProcessor>
 		_wabBundleProcessors = new ConcurrentHashMap<>();
+
+	private class WarFeatureFlagListener implements FeatureFlagListener {
+
+		@Override
+		public void onValue(
+			long companyId, String featureFlagKey, boolean enabled) {
+
+			if (enabled && _featureFlagKeys.contains(featureFlagKey) &&
+				!_wabBundleProcessors.containsKey(_bundle)) {
+
+				_initWabBundle(_bundle);
+			}
+		}
+
+		private WarFeatureFlagListener(
+			Bundle bundle, Set<String> featureFlagKeys) {
+
+			_bundle = bundle;
+			_featureFlagKeys = featureFlagKeys;
+		}
+
+		private final Bundle _bundle;
+		private final Set<String> _featureFlagKeys;
+
+	}
 
 	private class WarModuleProfile implements PortalProfile {
 


### PR DESCRIPTION
A WAR can now declare liferay-feature-flag-keys in its liferay-plugin-package.properties. When the property is present, the WAB extender registers a FeatureFlagListener rather than initializing the bundle right away, and holds off until one of the declared flags is enabled. This mirrors the existing liferay-portal-profile-names gate, which already defers initialization until the matching portal profile activates.