### PR TITLE
LPD-102507 Do not create a configuration while reading or deleting one

### DIFF
--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/configuration/LDAPConfigurationListener.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/configuration/LDAPConfigurationListener.java
@@ -19,6 +19,7 @@ import com.liferay.portal.security.ldap.configuration.ConfigurationProvider;
 import java.io.IOException;
 
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -37,10 +38,12 @@ public class LDAPConfigurationListener implements ConfigurationListener {
 
 	@Override
 	public void configurationEvent(ConfigurationEvent configurationEvent) {
+		String pid = configurationEvent.getPid();
+
 		String factoryPid = configurationEvent.getFactoryPid();
 
 		if (Validator.isNull(factoryPid)) {
-			factoryPid = configurationEvent.getPid();
+			factoryPid = pid;
 		}
 
 		if (factoryPid.endsWith(".scoped")) {
@@ -57,19 +60,24 @@ public class LDAPConfigurationListener implements ConfigurationListener {
 
 		try {
 			if (configurationEvent.getType() == ConfigurationEvent.CM_DELETED) {
-				configurationProvider.unregisterConfiguration(
-					configurationEvent.getPid());
+				configurationProvider.unregisterConfiguration(pid);
+
+				return;
 			}
-			else {
-				configurationProvider.registerConfiguration(
-					_configurationAdmin.getConfiguration(
-						configurationEvent.getPid(), StringPool.QUESTION));
+
+			Configuration[] configurations =
+				_configurationAdmin.listConfigurations(
+					"(service.pid=" + pid + ")");
+
+			if (configurations == null) {
+				return;
 			}
+
+			configurationProvider.registerConfiguration(configurations[0]);
 		}
-		catch (IOException ioException) {
+		catch (InvalidSyntaxException | IOException exception) {
 			throw new SystemException(
-				"Unable to load configuration " + configurationEvent.getPid(),
-				ioException);
+				"Unable to load configuration " + pid, exception);
 		}
 	}
 

--- a/modules/apps/portal-security/portal-security-ldap-test/src/testIntegration/java/com/liferay/portal/security/ldap/internal/configuration/test/LDAPConfigurationListenerTest.java
+++ b/modules/apps/portal-security/portal-security-ldap-test/src/testIntegration/java/com/liferay/portal/security/ldap/internal/configuration/test/LDAPConfigurationListenerTest.java
@@ -1,0 +1,85 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.ldap.internal.configuration.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.InfrastructureUtil;
+import com.liferay.portal.security.ldap.configuration.LDAPServerConfiguration;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import javax.sql.DataSource;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.cm.ConfigurationEvent;
+import org.osgi.service.cm.ConfigurationListener;
+
+/**
+ * @author Mariano Álvaro Sáiz
+ */
+@RunWith(Arquillian.class)
+public class LDAPConfigurationListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testStaleConfigurationUpdatedEvent() throws Exception {
+		String factoryPid = LDAPServerConfiguration.class.getName();
+
+		String pid = StringBundler.concat(
+			factoryPid, "~", RandomTestUtil.randomString());
+
+		Bundle bundle = FrameworkUtil.getBundle(
+			LDAPConfigurationListenerTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		_configurationListener.configurationEvent(
+			new ConfigurationEvent(
+				bundleContext.getServiceReference(ConfigurationAdmin.class),
+				ConfigurationEvent.CM_UPDATED, factoryPid, pid));
+
+		DataSource dataSource = InfrastructureUtil.getDataSource();
+
+		try (Connection connection = dataSource.getConnection();
+
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select configurationId from Configuration_ where " +
+					"configurationId = ?")) {
+
+			preparedStatement.setString(1, pid);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				Assert.assertFalse(resultSet.next());
+			}
+		}
+	}
+
+	@Inject(
+		filter = "component.name=com.liferay.portal.security.ldap.internal.configuration.LDAPConfigurationListener"
+	)
+	private ConfigurationListener _configurationListener;
+
+}

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/file/install/deploy/test/DBPartitionFileInstallDeployTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/file/install/deploy/test/DBPartitionFileInstallDeployTest.java
@@ -46,7 +46,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.cm.ConfigurationEvent;
+import org.osgi.service.cm.ConfigurationListener;
 
 /**
  * @author Luis Ortiz
@@ -162,6 +166,37 @@ public class DBPartitionFileInstallDeployTest extends BaseDBPartitionTestCase {
 	}
 
 	@Test
+	public void testStaleConfigurationUpdatedEvent() throws Exception {
+		Bundle bundle = FrameworkUtil.getBundle(
+			DBPartitionFileInstallDeployTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		ConfigurationEvent configurationEvent = new ConfigurationEvent(
+			bundleContext.getServiceReference(ConfigurationAdmin.class),
+			ConfigurationEvent.CM_UPDATED, null, _CONFIGURATION_FACTORY_PID);
+
+		try {
+			try (ServiceTrackerList<ConfigurationListener> serviceTrackerList =
+					ServiceTrackerListFactory.open(
+						bundleContext, ConfigurationListener.class)) {
+
+				for (ConfigurationListener configurationListener :
+						serviceTrackerList.toList()) {
+
+					configurationListener.configurationEvent(
+						configurationEvent);
+				}
+			}
+
+			_checkConfigurationNotExists();
+		}
+		finally {
+			_deleteConfigurations();
+		}
+	}
+
+	@Test
 	public void testSystemScopedConfiguration() throws Exception {
 		_testScopedConfiguration(
 			() -> _checkConfigurationExists(
@@ -228,6 +263,22 @@ public class DBPartitionFileInstallDeployTest extends BaseDBPartitionTestCase {
 		}
 
 		return StringBundler.concat(StringPool.QUOTE, value, StringPool.QUOTE);
+	}
+
+	private void _deleteConfigurations() throws Exception {
+		DBPartitionUtil.forEachCompanyId(
+			companyId -> {
+				try (Connection connection = _dataSource.getConnection();
+
+					PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							"delete from Configuration_ where " +
+								"configurationId = ?")) {
+
+					preparedStatement.setString(1, _CONFIGURATION_FACTORY_PID);
+					preparedStatement.executeUpdate();
+				}
+			});
 	}
 
 	private String _getContent(
@@ -366,20 +417,7 @@ public class DBPartitionFileInstallDeployTest extends BaseDBPartitionTestCase {
 		finally {
 			Files.deleteIfExists(path);
 
-			DBPartitionUtil.forEachCompanyId(
-				companyId -> {
-					try (Connection connection = _dataSource.getConnection();
-
-						PreparedStatement preparedStatement =
-							connection.prepareStatement(
-								"delete from Configuration_ where " +
-									"configurationId = ?")) {
-
-						preparedStatement.setString(
-							1, _CONFIGURATION_FACTORY_PID);
-						preparedStatement.executeUpdate();
-					}
-				});
+			_deleteConfigurations();
 
 			_fileInstaller.uninstall(path.toFile());
 		}

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/configuration/ConfigurationFileInstaller.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/configuration/ConfigurationFileInstaller.java
@@ -204,21 +204,29 @@ public class ConfigurationFileInstaller implements FileInstaller {
 	public void uninstall(File file) throws Exception {
 		String[] pid = _parsePid(file.getName());
 
-		String logString = StringPool.BLANK;
+		String servicePid = pid[0];
 
 		if (pid[1] != null) {
-			logString = StringPool.TILDE + pid[1];
+			servicePid = StringBundler.concat(pid[0], StringPool.TILDE, pid[1]);
 		}
 
 		if (_log.isInfoEnabled()) {
 			_log.info(
 				StringBundler.concat(
-					"Deleting configuration from ", pid[0], logString,
-					".config"));
+					"Deleting configuration from ", servicePid, ".config"));
 		}
 
-		Configuration configuration = _getConfiguration(
-			file.getName(), pid[0], pid[1]);
+		Configuration configuration = _findExistingConfiguration(
+			FileInstallConstants.FELIX_FILE_INSTALL_FILENAME, file.getName());
+
+		if (configuration == null) {
+			configuration = _findExistingConfiguration(
+				Constants.SERVICE_PID, servicePid);
+		}
+
+		if (configuration == null) {
+			return;
+		}
 
 		try (SafeCloseable safeCloseable =
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
@@ -263,15 +271,13 @@ public class ConfigurationFileInstaller implements FileInstaller {
 		return StringUtil.replace(string, "[\\*]", "\\\\*");
 	}
 
-	private Configuration _findExistingConfiguration(String fileName)
+	private Configuration _findExistingConfiguration(String key, String value)
 		throws Exception {
 
 		Configuration[] configurations = _configurationAdmin.listConfigurations(
 			StringBundler.concat(
-				StringPool.OPEN_PARENTHESIS,
-				FileInstallConstants.FELIX_FILE_INSTALL_FILENAME,
-				StringPool.EQUAL, _escapeFilterValue(fileName),
-				StringPool.CLOSE_PARENTHESIS));
+				StringPool.OPEN_PARENTHESIS, key, StringPool.EQUAL,
+				_escapeFilterValue(value), StringPool.CLOSE_PARENTHESIS));
 
 		if ((configurations != null) && (configurations.length > 0)) {
 			return configurations[0];
@@ -363,7 +369,8 @@ public class ConfigurationFileInstaller implements FileInstaller {
 			String fileName, String pid, String name)
 		throws Exception {
 
-		Configuration configuration = _findExistingConfiguration(fileName);
+		Configuration configuration = _findExistingConfiguration(
+			FileInstallConstants.FELIX_FILE_INSTALL_FILENAME, fileName);
 
 		if (configuration != null) {
 			return configuration;

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/configuration/FileSyncConfigurationListener.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/configuration/FileSyncConfigurationListener.java
@@ -85,9 +85,18 @@ public class FileSyncConfigurationListener implements ConfigurationListener {
 
 		if (type == ConfigurationEvent.CM_UPDATED) {
 			try {
-				Configuration configuration =
-					_configurationAdmin.getConfiguration(
-						configurationEvent.getPid(), StringPool.QUESTION);
+				Configuration[] configurations =
+					_configurationAdmin.listConfigurations(
+						StringBundler.concat(
+							StringPool.OPEN_PARENTHESIS, Constants.SERVICE_PID,
+							StringPool.EQUAL, configurationEvent.getPid(),
+							StringPool.CLOSE_PARENTHESIS));
+
+				if (configurations == null) {
+					return;
+				}
+
+				Configuration configuration = configurations[0];
 
 				Dictionary<String, Object> dictionary =
 					configuration.getProperties();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102507

Forwarded from liferay-database-infra#3867 at the Database Infra reviewer's request, since `ConfigurationFileInstaller` and `FileSyncConfigurationListener` belong to Core Infra.

## What Is Being Fixed

`DBPartitionFileInstallDeployTest.testGroupScopedPortableKeyConfiguration` failed on a single dialect of a single build with a bare `AssertionError`: a `Configuration_` row was visible in a database partition that must not hold it.

Reading a configuration through Configuration Admin can write to the database. `ConfigurationAdmin#getConfiguration(pid, location)` creates the configuration when the PID does not exist, and a singleton configuration is persisted as soon as it is created. `FileSyncConfigurationListener` used that method to read the properties of the configuration named by a configuration event, and configuration events are delivered asynchronously on a thread whose `CompanyThreadLocal` is unset, which `DBPartitionUtil` maps to the default partition. An event that arrives after its configuration was deleted therefore resurrects it as a row nothing ever deletes. `LDAPConfigurationListener` did the same, and also registered the resulting properties free configuration in the LDAP configuration provider. `ConfigurationFileInstaller#uninstall` resolved the configuration before opening the company scope, so it wrote the row to one partition and deleted it from another.

## How It Is Being Fixed

None of the three callers creates a configuration any more. Each resolves the PID through `ConfigurationAdmin#listConfigurations`, which never creates, and returns early when nothing matches. For the listeners the observable behavior is unchanged, since a configuration with no properties gave them no file name and no provider work anyway. `uninstall` keeps its lookup by file install file name and only falls back to a lookup by service PID, so it still deletes a configuration created outside file install, while a file whose configuration is already gone becomes a no-op. `LDAPConfigurationListener` gains no new idiom, as that class already used `listConfigurations` in its service tracker customizer.

Each fix ships with an integration test that fires a synthetic `CM_UPDATED` event for a PID Configuration Admin does not hold and asserts that no `Configuration_` row appears. The first fires it at every registered `ConfigurationListener`, so the invariant covers any listener rather than one implementation. Both fail against the unfixed bundles and pass with the fix, while the eight pre existing methods of `DBPartitionFileInstallDeployTest` and the seventeen LDAP configuration provider tests pass either way, which is what shows the stricter lookup does not break the paths that legitimately register and delete configurations.

## PR Check

**pr-check: PASS** — tested on `9a57ffca5d6d2ce77dd83a2aa4bb502a1d5a5675`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

Baseline repaired three `packageinfo` files, all lowered versions in modules this branch does not touch, so they are pre existing drift on `master` rather than findings of this branch. They were reverted rather than committed, per the rule that only minor and micro bumps are autocommitted.

<!-- pr-check {"result": "success", "sha": "9a57ffca5d6d2ce77dd83a2aa4bb502a1d5a5675"} -->
