### PR TITLE
LPD-100291 Avoid Tomcat fingerprinting by removing all content

### DIFF
--- a/build-dist.xml
+++ b/build-dist.xml
@@ -1012,9 +1012,15 @@ org.apache.level=WARNING]]>
 			file="${app.server.tomcat.dir}/conf/server.xml"
 		>
 			<replacetoken><![CDATA[pattern="%h %l %u %t &quot;%r&quot; %s %b" />]]></replacetoken>
-			<replacevalue><![CDATA[pattern="%h %l %u %t &quot;%r&quot; %s %b" />-->
-				<Valve className="org.apache.catalina.valves.ErrorReportValve" showReport="false" showServerInfo="false" />]]>
-			</replacevalue>
+			<replacevalue><![CDATA[pattern="%h %l %u %t &quot;%r&quot; %s %b" />-->]]></replacevalue>
+		</replace>
+
+		<replace
+			failOnNoReplacements="true"
+			file="${app.server.tomcat.dir}/conf/server.xml"
+		>
+			<replacetoken><![CDATA[unpackWARs="true" autoDeploy="true">]]></replacetoken>
+			<replacevalue><![CDATA[unpackWARs="true" autoDeploy="true" errorReportValveClass="">]]></replacevalue>
 		</replace>
 
 		<replace


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100291

## What Is Being Fixed

A request with a malformed percent-encoded URI (for example `curl -i http://localhost:8080/%2xc`) is rejected by Tomcat's HTTP connector before it reaches the Liferay web application, and Tomcat's ErrorReportValve renders its built-in HTML error page for the 400 response. Even with showReport="false" and showServerInfo="false", the valve still emits a minimal HTML skeleton — a doctype, an inline style block, and the status heading — whose markup and CSS are recognizably Tomcat, allowing the server to be fingerprinted.

## How It Is Being Fixed

The bundled Tomcat's conf/server.xml is patched at dist-assembly time. Instead of adding a muted ErrorReportValve, the Host element is given errorReportValveClass="". An empty value makes StandardHost install no ErrorReportValve at all, so nothing writes an error body for responses the application never handled. The malformed-URI request now returns 400 with an empty body and no fingerprintable content. Requests that reach the Liferay web application are unaffected, because portal-web's web.xml declares a catch-all error page (/errors/code.jsp) that renders those responses inside the application.

## Notes

Removing the ErrorReportValve applies to the whole Host, so the bundled Tomcat manager webapp also loses its fallback error page for any error it does not handle through its own web.xml — the body is empty rather than the default Tomcat page. The impact is cosmetic and admin-only (the manager webapp is normally locked down and not exposed), so it is flagged for awareness rather than as a blocker.

## Why Are There No Tests?

The change is a build-time edit to build-dist.xml that patches the bundled Tomcat server.xml. The behavior it corrects is a connector-level rejection that occurs below the servlet layer, so it cannot be exercised by a unit or integration test, and no existing test asserts on Tomcat's error-page content. It was verified manually against the ticket's reproduction (400 with an empty body). This matches the precedent of the original valve configuration, which was introduced in build-dist.xml without a test.

## PR Check

**pr-check: PASS** — tested on `e60395e5a5a89c8ecf84112c09b5d29be433277a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "e60395e5a5a89c8ecf84112c09b5d29be433277a"} -->
