### PR TITLE
LPD-102989 Index the address region instead of the country name

### DIFF
--- a/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/search/spi/model/index/contributor/OrganizationModelDocumentContributor.java
+++ b/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/search/spi/model/index/contributor/OrganizationModelDocumentContributor.java
@@ -121,8 +121,9 @@ public class OrganizationModelDocumentContributor
 								DSLQueryFactoryUtil.select(
 									AddressTable.INSTANCE.classPK,
 									AddressTable.INSTANCE.city,
-									CountryTable.INSTANCE.name,
-									RegionTable.INSTANCE.name,
+									CountryTable.INSTANCE.name.as(
+										"countryName"),
+									RegionTable.INSTANCE.name.as("regionName"),
 									AddressTable.INSTANCE.street1,
 									AddressTable.INSTANCE.street2,
 									AddressTable.INSTANCE.street3,

--- a/modules/apps/organizations/organizations-test/src/testIntegration/java/com/liferay/organizations/search/test/OrganizationIndexerIndexedFieldsTest.java
+++ b/modules/apps/organizations/organizations-test/src/testIntegration/java/com/liferay/organizations/search/test/OrganizationIndexerIndexedFieldsTest.java
@@ -11,28 +11,38 @@ import com.liferay.expando.kernel.model.ExpandoColumnConstants;
 import com.liferay.expando.kernel.model.ExpandoTable;
 import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
 import com.liferay.expando.kernel.service.ExpandoTableLocalService;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.model.Country;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ListType;
+import com.liferay.portal.kernel.model.ListTypeConstants;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.Region;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.ReindexCacheThreadLocal;
 import com.liferay.portal.kernel.search.SearchEngineHelper;
+import com.liferay.portal.kernel.service.AddressLocalService;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CountryService;
 import com.liferay.portal.kernel.service.ListTypeService;
 import com.liferay.portal.kernel.service.OrganizationService;
 import com.liferay.portal.kernel.service.RegionService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.document.Document;
 import com.liferay.portal.search.model.uid.UIDFactory;
 import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.Searcher;
@@ -48,10 +58,12 @@ import com.liferay.users.admin.test.util.search.GroupSearchFixture;
 
 import java.io.Serializable;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -104,6 +116,44 @@ public class OrganizationIndexerIndexedFieldsTest {
 
 		_organizationFixture = organizationFixture;
 		_organizations = organizationFixture.getOrganizations();
+	}
+
+	@Test
+	public void testAddress() throws Exception {
+		Organization organization = _organizationFixture.createOrganization(
+			RandomTestUtil.randomString());
+
+		Country country = countryService.getCountryByName(
+			organization.getCompanyId(), "canada");
+
+		List<ListType> listTypes = listTypeService.getListTypes(
+			organization.getCompanyId(),
+			ListTypeConstants.ORGANIZATION_ADDRESS);
+
+		ListType listType = listTypes.get(0);
+
+		Region region = regionService.getRegion(country.getCountryId(), "AB");
+
+		addressLocalService.addAddress(
+			null, TestPropsValues.getUserId(), Organization.class.getName(),
+			organization.getOrganizationId(), country.getCountryId(),
+			listType.getListTypeId(), region.getRegionId(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), false,
+			RandomTestUtil.randomString(), false, RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			RandomTestUtil.randomString(), null, new ServiceContext());
+
+		indexer.reindexCompany(organization.getCompanyId());
+
+		_assertRegionNames(organization);
+
+		try (SafeCloseable safeCloseable =
+				ReindexCacheThreadLocal.openReindexMode()) {
+
+			indexer.reindexCompany(organization.getCompanyId());
+		}
+
+		_assertRegionNames(organization);
 	}
 
 	@Test
@@ -162,6 +212,9 @@ public class OrganizationIndexerIndexedFieldsTest {
 	}
 
 	@Inject
+	protected AddressLocalService addressLocalService;
+
+	@Inject
 	protected ClassNameLocalService classNameLocalService;
 
 	@Inject
@@ -207,6 +260,27 @@ public class OrganizationIndexerIndexedFieldsTest {
 
 	@Inject
 	protected UserLocalService userLocalService;
+
+	private void _assertRegionNames(Organization organization) {
+		List<Document> documents = searcher.search(
+			searchRequestBuilderFactory.builder(
+			).companyId(
+				organization.getCompanyId()
+			).fields(
+				StringPool.STAR
+			).modelIndexerClasses(
+				Organization.class
+			).queryString(
+				organization.getName()
+			).build()
+		).getDocuments();
+
+		Document document = documents.get(0);
+
+		Assert.assertEquals(
+			Arrays.asList("alabama", "alberta"),
+			ListUtil.sort(document.getStrings("region")));
+	}
 
 	private Map<String, Object> _expectedFieldValues(Organization organization)
 		throws Exception {

--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/spi/model/index/contributor/UserModelDocumentContributor.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/spi/model/index/contributor/UserModelDocumentContributor.java
@@ -246,8 +246,9 @@ public class UserModelDocumentContributor
 								DSLQueryFactoryUtil.select(
 									AddressTable.INSTANCE.classPK,
 									AddressTable.INSTANCE.city,
-									CountryTable.INSTANCE.name,
-									RegionTable.INSTANCE.name,
+									CountryTable.INSTANCE.name.as(
+										"countryName"),
+									RegionTable.INSTANCE.name.as("regionName"),
 									AddressTable.INSTANCE.street1,
 									AddressTable.INSTANCE.street2,
 									AddressTable.INSTANCE.street3,

--- a/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/search/test/UserIndexerIndexedFieldsTest.java
+++ b/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/search/test/UserIndexerIndexedFieldsTest.java
@@ -60,6 +60,7 @@ import com.liferay.users.admin.test.util.search.UserSearchFixture;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -119,6 +120,23 @@ public class UserIndexerIndexedFieldsTest {
 			name ->
 				!name.contains(StringPool.PERIOD) && !name.equals("timestamp"),
 			searchTerm);
+
+		try (SafeCloseable safeCloseable =
+				ReindexCacheThreadLocal.openReindexMode()) {
+
+			_indexerFixture.reindexCompany(user2.getCompanyId());
+		}
+
+		document = _indexerFixture.searchOnlyOne(searchTerm);
+
+		_indexedFieldsFixture.postProcessDocument(document);
+
+		Map<String, String> addressMap = new HashMap<>();
+
+		_populateAddressFieldValues(user2, addressMap);
+
+		FieldValuesAssert.assertFieldValues(
+			document, addressMap, addressMap::containsKey, searchTerm);
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102989

## What Is Being Fixed

UserModelDocumentContributor and OrganizationModelDocumentContributor issue one bulk address query when ReindexCacheThreadLocal.openReindexMode() is open. That query selects a column named name from both Country and Region, so both result columns reach Hibernate under the same label and nothing tells them apart.

Hibernate 5 resolves both to the first matching column, so a bulk reindex indexes an address's country name as its region. Searching or faceting users and organizations by region silently returns the wrong thing, and nothing is reported: the user contributor catches Exception and reports through a warn log that portal-log4j.xml leaves off by default, and the value written is a plausible country name rather than a null. Hibernate 7 rejects the duplicate label outright with NonUniqueDiscoveredSqlAliasException.

Both call sites have been on master since 26150d2 and 8649766 in January 2026 and are present in release-7.4.13.149 and .150.

## How It Is Being Fixed

The first commit adds one integration test per contributor. Each asserts the address region twice, once through the per-model path and once with the reindex cache open, so a failure lands on the bulk query rather than on the expected values. The organization test has to give its organization an address of its own, because OrganizationFixture only sets regionId and countryId on the organization row and the bulk query would return no row for it.

The second commit gives each name column its own alias. Both callers read the row positionally, so no call site changes shape; what changes is the indexed value.

Verified live on both Hibernate versions, with and without the fix:

| Test | H5 without | H5 with | H7 without | H7 with |
| --- | --- | --- | --- | --- |
| UserIndexerIndexedFieldsTest#testAddress | FAIL | PASS | FAIL | PASS |
| OrganizationIndexerIndexedFieldsTest#testAddress | FAIL | PASS | FAIL | PASS |

## PR Check

**pr-check: PASS** — tested on `85c9434ee838d0603cfa201116ba9f2762415944`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

Baseline flags a semantic versioning bump owed by com.liferay.portal.dao.orm.hibernate (portal-impl/bnd.bnd 131.0.2 to 131.1.0, its packageinfo 13.0.0 to 13.1.0). This branch changes no file under portal-impl or portal-kernel and baseline reports nothing under modules, so the bump is pre-existing on master and was deliberately left out of this pull request.

<!-- pr-check {"result": "success", "sha": "85c9434ee838d0603cfa201116ba9f2762415944"} -->
