### PR TITLE
LPD-102989 Index the address region instead of the country name

### DIFF
--- a/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/search/spi/model/index/contributor/OrganizationModelDocumentContributor.java
+++ b/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/search/spi/model/index/contributor/OrganizationModelDocumentContributor.java
@@ -121,8 +121,9 @@ public class OrganizationModelDocumentContributor
 								DSLQueryFactoryUtil.select(
 									AddressTable.INSTANCE.classPK,
 									AddressTable.INSTANCE.city,
-									CountryTable.INSTANCE.name,
-									RegionTable.INSTANCE.name,
+									CountryTable.INSTANCE.name.as(
+										"countryName"),
+									RegionTable.INSTANCE.name.as("regionName"),
 									AddressTable.INSTANCE.street1,
 									AddressTable.INSTANCE.street2,
 									AddressTable.INSTANCE.street3,

--- a/modules/apps/organizations/organizations-test/build.gradle
+++ b/modules/apps/organizations/organizations-test/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:object:object-test-util")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-api")
+	testIntegrationImplementation project(":apps:portal-search:portal-search-spi")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationImplementation project(":apps:portal:portal-local-service-tree-test-util")

--- a/modules/apps/organizations/organizations-test/src/testIntegration/java/com/liferay/organizations/internal/search/spi/model/index/contributor/test/OrganizationModelDocumentContributorTest.java
+++ b/modules/apps/organizations/organizations-test/src/testIntegration/java/com/liferay/organizations/internal/search/spi/model/index/contributor/test/OrganizationModelDocumentContributorTest.java
@@ -1,0 +1,128 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.organizations.internal.search.spi.model.index.contributor.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.model.Country;
+import com.liferay.portal.kernel.model.ListType;
+import com.liferay.portal.kernel.model.ListTypeConstants;
+import com.liferay.portal.kernel.model.Organization;
+import com.liferay.portal.kernel.model.Region;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.DocumentImpl;
+import com.liferay.portal.kernel.search.ReindexCacheThreadLocal;
+import com.liferay.portal.kernel.service.AddressLocalService;
+import com.liferay.portal.kernel.service.CountryService;
+import com.liferay.portal.kernel.service.ListTypeService;
+import com.liferay.portal.kernel.service.RegionService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jiefeng Wu
+ */
+@RunWith(Arquillian.class)
+public class OrganizationModelDocumentContributorTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testContributeAddressInReindexMode() throws Exception {
+		_organization = OrganizationTestUtil.addOrganization();
+
+		Country country = _countryService.getCountryByName(
+			_organization.getCompanyId(), "canada");
+
+		Region region = _regionService.getRegion(country.getCountryId(), "AB");
+
+		List<ListType> listTypes = _listTypeService.getListTypes(
+			_organization.getCompanyId(),
+			ListTypeConstants.ORGANIZATION_ADDRESS);
+
+		ListType listType = listTypes.get(0);
+
+		_addressLocalService.addAddress(
+			null, TestPropsValues.getUserId(), Organization.class.getName(),
+			_organization.getOrganizationId(), country.getCountryId(),
+			listType.getListTypeId(), region.getRegionId(),
+			RandomTestUtil.randomString(), null, false, null, false,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), null, RandomTestUtil.randomString(),
+			null, new ServiceContext());
+
+		Document document = new DocumentImpl();
+
+		_organizationModelDocumentContributor.contribute(
+			document, _organization);
+
+		_assertAddressFields(document, region);
+
+		Document reindexModeDocument = new DocumentImpl();
+
+		try (SafeCloseable safeCloseable =
+				ReindexCacheThreadLocal.openReindexMode()) {
+
+			_organizationModelDocumentContributor.contribute(
+				reindexModeDocument, _organization);
+		}
+
+		_assertAddressFields(reindexModeDocument, region);
+	}
+
+	private void _assertAddressFields(Document document, Region region) {
+		Assert.assertTrue(
+			ArrayUtil.contains(document.getValues("country"), "canada"));
+		Assert.assertArrayEquals(
+			new String[] {StringUtil.toLowerCase(region.getName())},
+			document.getValues("region"));
+	}
+
+	@Inject
+	private AddressLocalService _addressLocalService;
+
+	@Inject
+	private CountryService _countryService;
+
+	@Inject
+	private ListTypeService _listTypeService;
+
+	@DeleteAfterTestRun
+	private Organization _organization;
+
+	@Inject(
+		filter = "component.name=com.liferay.organizations.internal.search.spi.model.index.contributor.OrganizationModelDocumentContributor"
+	)
+	private ModelDocumentContributor<Organization>
+		_organizationModelDocumentContributor;
+
+	@Inject
+	private RegionService _regionService;
+
+}

--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/spi/model/index/contributor/UserModelDocumentContributor.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/spi/model/index/contributor/UserModelDocumentContributor.java
@@ -246,8 +246,9 @@ public class UserModelDocumentContributor
 								DSLQueryFactoryUtil.select(
 									AddressTable.INSTANCE.classPK,
 									AddressTable.INSTANCE.city,
-									CountryTable.INSTANCE.name,
-									RegionTable.INSTANCE.name,
+									CountryTable.INSTANCE.name.as(
+										"countryName"),
+									RegionTable.INSTANCE.name.as("regionName"),
 									AddressTable.INSTANCE.street1,
 									AddressTable.INSTANCE.street2,
 									AddressTable.INSTANCE.street3,

--- a/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/internal/search/spi/model/index/contributor/test/UserModelDocumentContributorTest.java
+++ b/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/internal/search/spi/model/index/contributor/test/UserModelDocumentContributorTest.java
@@ -1,0 +1,125 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.users.admin.internal.search.spi.model.index.contributor.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.model.Contact;
+import com.liferay.portal.kernel.model.Country;
+import com.liferay.portal.kernel.model.ListType;
+import com.liferay.portal.kernel.model.ListTypeConstants;
+import com.liferay.portal.kernel.model.Region;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.DocumentImpl;
+import com.liferay.portal.kernel.search.ReindexCacheThreadLocal;
+import com.liferay.portal.kernel.service.AddressLocalService;
+import com.liferay.portal.kernel.service.CountryService;
+import com.liferay.portal.kernel.service.ListTypeService;
+import com.liferay.portal.kernel.service.RegionService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jiefeng Wu
+ */
+@RunWith(Arquillian.class)
+public class UserModelDocumentContributorTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testContributeAddressInReindexMode() throws Exception {
+		_user = UserTestUtil.addUser();
+
+		Country country = _countryService.getCountryByName(
+			_user.getCompanyId(), "canada");
+
+		Region region = _regionService.getRegion(country.getCountryId(), "AB");
+
+		List<ListType> listTypes = _listTypeService.getListTypes(
+			_user.getCompanyId(), ListTypeConstants.CONTACT_ADDRESS);
+
+		ListType listType = listTypes.get(0);
+
+		_addressLocalService.addAddress(
+			null, _user.getUserId(), Contact.class.getName(),
+			_user.getContactId(), country.getCountryId(),
+			listType.getListTypeId(), region.getRegionId(),
+			RandomTestUtil.randomString(), null, false, null, false,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), null, RandomTestUtil.randomString(),
+			null, new ServiceContext());
+
+		Document document = new DocumentImpl();
+
+		_userModelDocumentContributor.contribute(document, _user);
+
+		_assertAddressFields(document, region);
+
+		Document reindexModeDocument = new DocumentImpl();
+
+		try (SafeCloseable safeCloseable =
+				ReindexCacheThreadLocal.openReindexMode()) {
+
+			_userModelDocumentContributor.contribute(
+				reindexModeDocument, _user);
+		}
+
+		_assertAddressFields(reindexModeDocument, region);
+	}
+
+	private void _assertAddressFields(Document document, Region region) {
+		Assert.assertTrue(
+			ArrayUtil.contains(document.getValues("country"), "canada"));
+		Assert.assertArrayEquals(
+			new String[] {StringUtil.toLowerCase(region.getName())},
+			document.getValues("region"));
+	}
+
+	@Inject
+	private AddressLocalService _addressLocalService;
+
+	@Inject
+	private CountryService _countryService;
+
+	@Inject
+	private ListTypeService _listTypeService;
+
+	@Inject
+	private RegionService _regionService;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+	@Inject(
+		filter = "component.name=com.liferay.users.admin.internal.search.spi.model.index.contributor.UserModelDocumentContributor"
+	)
+	private ModelDocumentContributor<User> _userModelDocumentContributor;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102989

## What Is Being Fixed

The bulk address query that `UserModelDocumentContributor` and `OrganizationModelDocumentContributor` issue when `ReindexCacheThreadLocal.openReindexMode()` is open selects a column named `name` from both `Country` and `Region`, so both result columns reach Hibernate under the same label and nothing tells them apart.

Hibernate 5 resolves both to the first matching column and indexes the address's country name as its region, corrupting the `region` field on every bulk reindex without raising anything. Hibernate 7 rejects the mapping in `ResultSetMappingImpl.checkDuplicateAliases` with `NonUniqueDiscoveredSqlAliasException`, which the user contributor swallows in a `catch` of `Exception` so the document silently loses every field the contributor writes, while the organization contributor lets it propagate and fails the reindex.

## How It Is Being Fixed

Each of the two `name` columns gets its own label, so Hibernate can tell the result columns apart. Both callers read the row positionally, so no call site changes shape; what changes is the indexed value, in that after a bulk reindex the `region` field stops carrying the address's country name and starts carrying its region name.

The tests call each contributor directly, contributing one document outside reindex mode and another inside it and asserting the same country and region values on both. The path outside reindex mode reads each `Address` entity, so it never touches the bulk query and serves as the control. Each pass gets its own document because a failed contribution writes nothing, and a reused document would keep the control's values and hide it.

Verified live on both Hibernate versions. With the fix both tests pass on Hibernate 5.6.7 and on Hibernate 7.4.0. Without it, on Hibernate 5 both fail with `expected:<[albert]a> but was:<[canad]a>`; on Hibernate 7 the user test fails on the missing `country` field and the organization test errors with `NonUniqueDiscoveredSqlAliasException`. The deployed jar's constant pool was checked with `javap` before every run.

## PR Check

**pr-check: PASS** — tested on `66f35b9530c5f47c09a3dfeb536cee65107384a9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "66f35b9530c5f47c09a3dfeb536cee65107384a9"} -->
